### PR TITLE
Deploy Runner - handle Serverless Compose errors

### DIFF
--- a/services/ui-src/serverless.yml
+++ b/services/ui-src/serverless.yml
@@ -32,6 +32,7 @@ custom:
       - val
       - production
   api_region: ${param:ApiRegion, ""}
+  test_fail: ${ssm:/not_real}
   api_url: ${param:ApiGatewayRestApiUrl, ""}
   application_endpoint: ${env:APPLICATION_ENDPOINT, ssm:/${self:custom.stage}/ui/application_endpoint, ssm:/default/ui/application_endpoint}
   cognito_region: ${param:CognitoRegion, ""}

--- a/services/ui-src/serverless.yml
+++ b/services/ui-src/serverless.yml
@@ -32,7 +32,6 @@ custom:
       - val
       - production
   api_region: ${param:ApiRegion, ""}
-  test_fail: ${ssm:/not_real}
   api_url: ${param:ApiGatewayRestApiUrl, ""}
   application_endpoint: ${env:APPLICATION_ENDPOINT, ssm:/${self:custom.stage}/ui/application_endpoint, ssm:/default/ui/application_endpoint}
   cognito_region: ${param:CognitoRegion, ""}

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -102,13 +102,11 @@ export default class LabeledProcessRunner {
 
       proc.on("close", (code) => {
         const paddedPrefix = this.formattedPrefix(prefix);
+        process.stdout.write(`${paddedPrefix} Exit: ${code}\n`);
         if (code == 1) {
-          const errorMessage = `Exit Code Error: ${code}`;
-          process.stdout.write(`${paddedPrefix} ${errorMessage}\n`);
-          reject(errorMessage);
+          reject(code);
           return;
         }
-        process.stdout.write(`${paddedPrefix} Exit: ${code}\n`);
         resolve();
       });
     });

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -103,7 +103,7 @@ export default class LabeledProcessRunner {
       proc.on("close", (code) => {
         const paddedPrefix = this.formattedPrefix(prefix);
         process.stdout.write(`${paddedPrefix} Exit: ${code}\n`);
-        if (code == 1) {
+        if (code != 0) {
           reject(code);
           return;
         }

--- a/src/runner.ts
+++ b/src/runner.ts
@@ -102,6 +102,12 @@ export default class LabeledProcessRunner {
 
       proc.on("close", (code) => {
         const paddedPrefix = this.formattedPrefix(prefix);
+        if (code == 1) {
+          const errorMessage = `Exit Code Error: ${code}`;
+          process.stdout.write(`${paddedPrefix} ${errorMessage}\n`);
+          reject(errorMessage);
+          return;
+        }
         process.stdout.write(`${paddedPrefix} Exit: ${code}\n`);
         resolve();
       });


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Serverless compose gracefully exits with code 1 on error, thus not tripping the .error() catch in the runner. Add an extra catch for all non-success codes.

This was causing false successes in the deploy step, while logs of errors existed.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
N/A

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
This action should have failed with an invalid ssm param: https://github.com/Enterprise-CMCS/macpro-mdct-hcbs/actions/runs/9859930365
This action should succeed normally: https://github.com/Enterprise-CMCS/macpro-mdct-hcbs/actions/runs/9860132356

The logging has been adjusted slightly since the first test.

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
