### PR TITLE
Adding build badges to HCBS README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,13 @@
 [![Maintainability](https://api.codeclimate.com/v1/badges/93cd54dad7df73b09209/maintainability)](https://codeclimate.com/repos/664553bb1a9a4300ce1216ac/maintainability)
 [![Test Coverage](https://api.codeclimate.com/v1/badges/93cd54dad7df73b09209/test_coverage)](https://codeclimate.com/repos/664553bb1a9a4300ce1216ac/test_coverage)
 
+### Integration Environment Deploy Status:
+| Branch  | Build Status |
+| ------------- | ------------- |
+| main  | ![deploy](https://github.com/Enterprise-CMCS/macpro-mdct-hcbs/actions/workflows/deploy.yml/badge.svg)  |
+| val  | ![deploy](https://github.com/Enterprise-CMCS/macpro-mdct-hcbs/actions/workflows/deploy.yml/badge.svg?branch=val)  |
+| production  | ![deploy](https://github.com/Enterprise-CMCS/macpro-mdct-hcbs/actions/workflows/deploy.yml/badge.svg?branch=production)  |
+
 HCBS is the CMCS MDCT application for collecting state data related to Home- and Community-Based Services (HCBS) programs and performance. The collected data assists CMCS in monitoring, managing, and better understanding Medicaid and CHIP programs.
 
 HCBS are types of person-centered care delivered in the home and community which address the needs of people with functional limitations who need assistance with everyday activities. They are often designed to enable people to stay in their homes, rather than moving to a facility for care. The programs generally fall into two categories: health services (which meet medical needs) and human services (which support activities of daily living).


### PR DESCRIPTION
### Description
Adding a single pane of glass to show  deploy status of each of our integration environments for HCBS. This helps more easily identify if one is red without having to go look through the deploy action in github


### Related ticket(s)
n/a
---
### How to test
look at the readme on this bring 


### Important updates
n/a


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
