### PR TITLE
Adding WAF to sit in front of cognito for additional security

### DIFF
--- a/services/ui-auth/serverless.yml
+++ b/services/ui-auth/serverless.yml
@@ -29,6 +29,7 @@ plugins:
   - serverless-bundle
   - serverless-iam-helper
   - serverless-s3-bucket-helper
+  - "@enterprise-cmcs/serverless-waf-plugin"
 
 s3BucketHelper:
   loggingConfiguration:
@@ -39,6 +40,11 @@ custom:
   project: "hcbs"
   stage: ${opt:stage, self:provider.stage}
   region: ${opt:region, self:provider.region}
+  wafPlugin:
+    name: ${self:service}-${self:custom.stage}-webacl-waf
+  wafExcludeRules:
+    awsCommon:
+      - "SizeRestrictions_BODY"
   serverlessTerminationProtection:
     stages:
       - main
@@ -133,6 +139,18 @@ resources:
             StringAttributeConstraints:
               MinLength: 0
               MaxLength: 256
+        UserPoolAddOns:
+          AdvancedSecurityMode: ENFORCED
+        UserPoolTags:
+          Name: ${self:custom.stage}-user-pool
+
+    # Associate the WAF Web ACL with the Cognito User Pool
+    CognitoUserPoolWAFAssociation:
+      Type: 'AWS::WAFv2::WebACLAssociation'
+      Properties:
+        ResourceArn: !GetAtt CognitoUserPool.Arn
+        WebACLArn: !GetAtt WafPluginAcl.Arn
+
     CognitoUserPoolClient:
       Type: AWS::Cognito::UserPoolClient
       Properties:


### PR DESCRIPTION
### Description
AWS Cognito has API endpoints that are public similar to api gateway or cloudfront it is a good practice to protect this resource with a web application firewall (WAF) to restrict traffic and provide additional security measures from the firewall. This PR adds a WAF to cognito following the pattern of the other MDCT apps.

https://docs.aws.amazon.com/cognito/latest/developerguide/user-pool-waf.html


### Related ticket(s)
https://jiraent.cms.gov/browse/CMDCT-3665

---
### How to test
after merge to main log into main env with idm user to verify no issues are seen.


### Important updates
I'm not crazy about adding more severless changes as we're attempting to migrate to the cdk but its a fairly straight approach from our other services so when we do waf changes in any other service for cdk that will just carry over to here.


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
