### PR TITLE
Removing Slack notifications for Snyk

### DIFF
--- a/.github/workflows/post-deploy-slack-notification.yml
+++ b/.github/workflows/post-deploy-slack-notification.yml
@@ -8,7 +8,6 @@ on:
       - 'main'
       - 'val'
       - 'production'
-      - 'snyk-**'
 
 jobs:
   notify_on_failure:
@@ -23,20 +22,6 @@ jobs:
           SLACK_MESSAGE: "${{ github.event.workflow_run.html_url }}"
           MSG_MINIMAL: true
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-
-  # Notify the integrations channel only when a Snyk auto merge fails
-  notify_failed_snyk_auto_merge:
-    runs-on: ubuntu-latest
-    #only check branch names that begin with snyk-
-    if: ${{ github.event.workflow_run.conclusion == 'failure' && startsWith(github.event.workflow_run.head_branch, 'snyk-') }}
-    steps:
-      - name: Slack Notification
-        uses: rtCamp/action-slack-notify@v2
-        env:
-          SLACK_TITLE: ":boom: A Synk auto merge has failed in ${{ github.repository }}"
-          SLACK_MESSAGE: "${{ github.event.workflow_run.html_url }}"
-          MSG_MINIMAL: true
-          SLACK_WEBHOOK: ${{ secrets.INTEGRATIONS_SLACK_WEBHOOK }}
 
   # Sends a slack message to the mdct-prod-releases channel in CMS slack
   notify_on_prod_release:


### PR DESCRIPTION
### Description
Now that we've disabled the Snyk Auto Merge workflow the slack alerts for failed Snyk builds are just noisy and unnecessary. The original intent was auto merge was "out of sight out of mind" we want alerts when it doesnt work. Well ... now we're merging them all by hand and getting alerts at 2am for something we need to handle anyhow is no bueno.

This PR simply just removes that notification when a build fails on a snyk branch as well as a failed PR check.

HCBS doesnt have the snyk auto merge workflow, so we don't have to get rid of that 👍 

### Related ticket(s)


---
### How to test
should be no testing needed, if we see alerts still we didnt fix it. I dont think thats the case.


### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
