### PR TITLE
Remove and replace momentjs with date-fns

### DIFF
--- a/services/ui-src/src/components/layout/Timeout.tsx
+++ b/services/ui-src/src/components/layout/Timeout.tsx
@@ -11,13 +11,13 @@ import {
 } from "@chakra-ui/react";
 import { useLocation } from "react-router-dom";
 import {
-  calculateRemainingSeconds,
+  calculateRemainingMilliSeconds,
   refreshCredentials,
   updateTimeout,
   UserContext,
 } from "utils";
 import { PROMPT_AT, IDLE_WINDOW } from "../../constants";
-import moment from "moment";
+import { add } from "date-fns";
 
 export const Timeout = () => {
   const context = useContext(UserContext);
@@ -43,7 +43,9 @@ export const Timeout = () => {
   }, [location]);
 
   const setTimer = () => {
-    const expiration = moment().add(IDLE_WINDOW, "milliseconds");
+    const expiration = add(new Date(), {
+      seconds: IDLE_WINDOW / 1000,
+    });
     if (timeoutPromptId) {
       clearTimers();
     }
@@ -53,14 +55,14 @@ export const Timeout = () => {
     // Set the initial timer for when a prompt appears
     const promptTimer = window.setTimeout(() => {
       // Once the prompt appears, set timers for logging out, and for updating text on screen
-      setTimeLeft(calculateRemainingSeconds(expiration));
+      setTimeLeft(calculateRemainingMilliSeconds(expiration));
       setShowTimeout(true);
       const forceLogoutTimer = window.setTimeout(() => {
         clearTimers();
         logout();
       }, IDLE_WINDOW - PROMPT_AT);
       const updateTextTimer = window.setInterval(() => {
-        setTimeLeft(calculateRemainingSeconds(expiration));
+        setTimeLeft(calculateRemainingMilliSeconds(expiration));
       }, 500);
       setTimeoutForceId(forceLogoutTimer);
       setUpdateTextIntervalId(updateTextTimer);

--- a/services/ui-src/src/components/layout/Timeout.tsx
+++ b/services/ui-src/src/components/layout/Timeout.tsx
@@ -11,7 +11,7 @@ import {
 } from "@chakra-ui/react";
 import { useLocation } from "react-router-dom";
 import {
-  calculateRemainingMilliSeconds,
+  calculateRemainingSeconds,
   refreshCredentials,
   updateTimeout,
   UserContext,
@@ -55,14 +55,14 @@ export const Timeout = () => {
     // Set the initial timer for when a prompt appears
     const promptTimer = window.setTimeout(() => {
       // Once the prompt appears, set timers for logging out, and for updating text on screen
-      setTimeLeft(calculateRemainingMilliSeconds(expiration));
+      setTimeLeft(calculateRemainingSeconds(expiration));
       setShowTimeout(true);
       const forceLogoutTimer = window.setTimeout(() => {
         clearTimers();
         logout();
       }, IDLE_WINDOW - PROMPT_AT);
       const updateTextTimer = window.setInterval(() => {
-        setTimeLeft(calculateRemainingMilliSeconds(expiration));
+        setTimeLeft(calculateRemainingSeconds(expiration));
       }, 500);
       setTimeoutForceId(forceLogoutTimer);
       setUpdateTextIntervalId(updateTextTimer);

--- a/services/ui-src/src/utils/auth/authLifecycle.test.tsx
+++ b/services/ui-src/src/utils/auth/authLifecycle.test.tsx
@@ -1,13 +1,15 @@
 import { initAuthManager, updateTimeout, getExpiration } from "utils";
 import { refreshCredentials } from "./authLifecycle";
-import moment from "moment";
 import { Hub } from "aws-amplify";
+import { sub } from "date-fns";
 
 describe("utils/auth", () => {
   describe("Test AuthManager Init", () => {
-    test("Initiallizing when past expiration will require a new login", async () => {
+    test("Initializing when past expiration will require a new login", async () => {
       // Set an initial time, because jest runs too fast to have different timestamps
-      const expired = moment().subtract(5, "days").format().toString();
+      const expired = sub(new Date(), {
+        days: 5,
+      }).toString();
       localStorage.setItem("mdcthcbs_session_exp", expired);
 
       initAuthManager();
@@ -25,20 +27,19 @@ describe("utils/auth", () => {
     });
 
     test("Test updateTimeout", () => {
-      const currentTime = moment();
+      const currentTime = Date.now();
       updateTimeout();
       jest.runAllTimers(); // Dodge 2 second debounce, get the updated timestamp
 
       const savedTime = localStorage.getItem("mdcthcbs_session_exp");
-      expect(moment(savedTime).isSameOrAfter(currentTime)).toBeTruthy();
+      expect(new Date(savedTime!).valueOf()).toBeGreaterThanOrEqual(
+        new Date(currentTime).valueOf()
+      );
     });
 
     test("Test getExpiration and refreshCredentials", async () => {
       // Set an initial time, because jest runs too fast to have different timestamps
-      const initialExpiration = moment()
-        .subtract(5, "seconds")
-        .format()
-        .toString();
+      const initialExpiration = sub(Date.now(), { seconds: 5 }).toString();
       localStorage.setItem("mdcthcbs_session_exp", initialExpiration);
       await refreshCredentials();
       jest.runAllTimers(); // Dodge 2 second debounce, get the updated timestamp
@@ -46,7 +47,9 @@ describe("utils/auth", () => {
       // Check that the new timestamp is updated
       const storedExpiration = getExpiration();
       expect(storedExpiration).not.toEqual(initialExpiration);
-      expect(moment(storedExpiration).isAfter(initialExpiration)).toBeTruthy();
+      expect(new Date(storedExpiration!).valueOf()).toBeGreaterThan(
+        new Date(initialExpiration).valueOf()
+      );
     });
     test("Test getExpiration returns an empty string if nothing is set", async () => {
       localStorage.removeItem("mdcthcbs_session_exp");
@@ -73,7 +76,7 @@ describe("utils/auth", () => {
     });
 
     test("Ignore unrelated auth events", () => {
-      const currentTime = moment();
+      const currentTime = Date.now();
       Hub.listen = jest
         .fn()
         .mockImplementation((channel: string, callback: any) => {
@@ -81,7 +84,9 @@ describe("utils/auth", () => {
         });
       initAuthManager();
       const savedTime = localStorage.getItem("mdcthcbs_session_exp");
-      expect(moment(savedTime).isSameOrAfter(currentTime)).toBeTruthy();
+      expect(new Date(savedTime!).valueOf()).toBeGreaterThanOrEqual(
+        new Date(currentTime).valueOf()
+      );
       expect(localStorage.setItem).not.toHaveBeenCalled();
     });
   });

--- a/services/ui-src/src/utils/auth/authLifecycle.test.tsx
+++ b/services/ui-src/src/utils/auth/authLifecycle.test.tsx
@@ -7,9 +7,9 @@ describe("utils/auth", () => {
   describe("Test AuthManager Init", () => {
     test("Initializing when past expiration will require a new login", async () => {
       // Set an initial time, because jest runs too fast to have different timestamps
-      const expired = sub(new Date(), {
+      const expired = sub(Date.now(), {
         days: 5,
-      }).toString();
+      }).toDateString();
       localStorage.setItem("mdcthcbs_session_exp", expired);
 
       initAuthManager();

--- a/services/ui-src/src/utils/auth/authLifecycle.tsx
+++ b/services/ui-src/src/utils/auth/authLifecycle.tsx
@@ -1,6 +1,6 @@
 import { Auth, Hub } from "aws-amplify";
-import moment from "moment";
 import { IDLE_WINDOW } from "../../constants";
+import { isBefore, addMilliseconds } from "date-fns";
 
 let authManager: AuthManager;
 
@@ -14,7 +14,7 @@ class AuthManager {
   constructor() {
     // Force users with stale tokens > then the timeout to log in for a fresh session
     const exp = localStorage.getItem("mdcthcbs_session_exp");
-    if (exp && moment(exp).isBefore()) {
+    if (exp && isBefore(Number(exp), new Date())) {
       localStorage.removeItem("mdcthcbs_session_exp");
       Auth.signOut().then(() => {
         window.location.href = "/";
@@ -53,10 +53,7 @@ class AuthManager {
    * Timer function for idle timeout, keeps track of an idle timer that triggers a forced logout timer if not reset.
    */
   setTimer = () => {
-    const expiration = moment()
-      .add(IDLE_WINDOW, "milliseconds")
-      .format()
-      .toString();
+    const expiration = addMilliseconds(new Date(), IDLE_WINDOW).toString();
     localStorage.setItem("mdcthcbs_session_exp", expiration);
   };
 }

--- a/services/ui-src/src/utils/auth/authLifecycle.tsx
+++ b/services/ui-src/src/utils/auth/authLifecycle.tsx
@@ -13,8 +13,11 @@ class AuthManager {
 
   constructor() {
     // Force users with stale tokens > then the timeout to log in for a fresh session
-    const exp = localStorage.getItem("mdcthcbs_session_exp");
-    if (exp && isBefore(Number(exp), new Date())) {
+    const expiration = localStorage.getItem("mdcthcbs_session_exp");
+    const isExpired =
+      expiration &&
+      isBefore(new Date(expiration).valueOf(), Date.now().valueOf());
+    if (isExpired) {
       localStorage.removeItem("mdcthcbs_session_exp");
       Auth.signOut().then(() => {
         window.location.href = "/";

--- a/services/ui-src/src/utils/other/time.ts
+++ b/services/ui-src/src/utils/other/time.ts
@@ -1,6 +1,6 @@
 import { utcToZonedTime, zonedTimeToUtc } from "date-fns-tz";
 import { DateShape, TimeShape } from "types";
-import moment from "moment";
+import { differenceInSeconds } from "date-fns";
 
 export const midnight: TimeShape = { hour: 0, minute: 0, second: 0 };
 export const oneSecondToMidnight: TimeShape = {
@@ -146,7 +146,7 @@ export const checkDateRangeStatus = (
  */
 export const calculateRemainingSeconds = (expiresAt?: any) => {
   if (!expiresAt) return 0;
-  return moment(expiresAt).diff(moment()) / 1000;
+  return differenceInSeconds(expiresAt, new Date());
 };
 
 export const displayLongformPeriod = (


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->

date-fns is a package we already had installed, and is a recommended swap for momentjs.

the moment package is a sub-dependency of serverless-bundle. we cannot remove it from yarn.lock, but hopefully this still resolves the issue.

References:
[Security issue](https://www.invicti.com/web-vulnerability-scanner/vulnerabilities/version-disclosure-momentjs/)
[MomentJS recommends using alternatives](https://momentjs.com/docs/#/-project-status/)

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3911

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->

- Modify the values for IDLE_WINDOW and PROMPT_AT in the src/constants.ts file to be shorter (change leading values to 1 and 0.5 or something)
- Run locally
- Let the app sit until the timeout hits
    - Ensure the prompt shows up as expected
    - Ensure the prompt still does the correct actions when you click on them
    - Ensure if you don't do anything it logs you out
- Tests pass

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
