### PR TITLE
CMDCT-3958: Swap to OAC on UI Bucket

### DIFF
--- a/services/ui/serverless.yml
+++ b/services/ui/serverless.yml
@@ -143,6 +143,11 @@ resources:
           ServerSideEncryptionConfiguration:
             - ServerSideEncryptionByDefault:
                 SSEAlgorithm: AES256
+        PublicAccessBlockConfiguration:
+          BlockPublicAcls: true
+          BlockPublicPolicy: true
+          IgnorePublicAcls: true
+          RestrictPublicBuckets: true
       DeletionPolicy: Delete
     BucketPolicy:
       Type: AWS::S3::BucketPolicy
@@ -150,11 +155,16 @@ resources:
         PolicyDocument:
           Version: "2012-10-17"
           Statement:
-            - Effect: Allow
-              Action: "s3:GetObject"
-              Resource: !Sub arn:aws:s3:::${S3Bucket}/*
+            - Sid: AllowCloudFrontServicePrincipalReadOnly
+              Action:
+              - 's3:GetObject'
+              Effect: Allow
               Principal:
-                CanonicalUser: !GetAtt CloudFrontOriginAccessIdentity.S3CanonicalUserId
+                Service: cloudfront.amazonaws.com
+              Resource: !Sub "${S3Bucket.Arn}/*"
+              Condition:
+                StringEquals:
+                  AWS:SourceArn: !Sub "arn:aws:cloudfront::${AWS::AccountId}:distribution/${CloudFrontDistribution.Id}"
             - Sid: "AllowSSLRequestsOnly"
               Effect: Deny
               Action: "s3:*"
@@ -205,11 +215,14 @@ resources:
                 Bool:
                   aws:SecureTransport: false
         Bucket: !Ref LoggingBucket
-    CloudFrontOriginAccessIdentity:
-      Type: AWS::CloudFront::CloudFrontOriginAccessIdentity
-      Properties:
-        CloudFrontOriginAccessIdentityConfig:
-          Comment: OAI to prevent direct public access to the bucket
+    CloudFrontOriginAccessControl:
+    Type: AWS::CloudFront::OriginAccessControl
+    Properties:
+      OriginAccessControlConfig:
+        Name: ${self:service}-${self:custom.stage}-oac-conf
+        OriginAccessControlOriginType: s3
+        SigningBehavior: always
+        SigningProtocol: sigv4
     CloudFrontDistribution:
       Type: AWS::CloudFront::Distribution
       Properties:
@@ -223,8 +236,9 @@ resources:
           Origins:
             - DomainName: !GetAtt S3Bucket.DomainName
               Id: S3Origin
+              OriginAccessControlId: !Ref CloudFrontOriginAccessControl
               S3OriginConfig:
-                OriginAccessIdentity: !Sub origin-access-identity/cloudfront/${CloudFrontOriginAccessIdentity}
+                OriginAccessIdentity: ""
           Enabled: true
           HttpVersion: "http2"
           DefaultRootObject: index.html

--- a/services/ui/serverless.yml
+++ b/services/ui/serverless.yml
@@ -216,13 +216,13 @@ resources:
                   aws:SecureTransport: false
         Bucket: !Ref LoggingBucket
     CloudFrontOriginAccessControl:
-    Type: AWS::CloudFront::OriginAccessControl
-    Properties:
-      OriginAccessControlConfig:
-        Name: ${self:service}-${self:custom.stage}-oac-conf
-        OriginAccessControlOriginType: s3
-        SigningBehavior: always
-        SigningProtocol: sigv4
+      Type: AWS::CloudFront::OriginAccessControl
+      Properties:
+        OriginAccessControlConfig:
+          Name: ${self:service}-${self:custom.stage}-oac-conf
+          OriginAccessControlOriginType: s3
+          SigningBehavior: always
+          SigningProtocol: sigv4
     CloudFrontDistribution:
       Type: AWS::CloudFront::Distribution
       Properties:


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
SecurityHub is mad because we don't use the 2022 new and shiny Origin Access Control rules for our cloudfront distro. Instead we are using Origin Access Identity, which is a slightly more complex pattern to do the same thing.

I am pretty sure the old CMS AWS accounts have this rule disabled, and HCBS is flagged because it is under the new account setup. Regardless, easy enough to clean up and remove a slightly more complicated config in favor of one that just sets up a single rule between two resources.

This just takes the bucket we host our UI in, and says it can only be accessed via the specific cloudfront distribution. No public access by navigating directly to the bucket.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3958

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
https://du8ioa447dep0.cloudfront.net/
Deployed link still works, you wouldn't be able to access the bucket if things went really wrong.
~~I will monitor securityhub for the next scan for this branch~~
Confirmed this resolves the finding.

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
