### PR TITLE
[Cmdct-3998] Save and Load Form

### DIFF
--- a/services/app-api/forms/qm.ts
+++ b/services/app-api/forms/qm.ts
@@ -77,8 +77,6 @@ export const qmReportTemplate: ReportTemplate = {
         {
           type: ElementType.MeasureTable,
           measureDisplay: "required",
-          modalId: "req-measure-result-modal",
-          to: "req-measure-report",
         },
       ],
     },
@@ -124,8 +122,6 @@ export const qmReportTemplate: ReportTemplate = {
         {
           type: ElementType.MeasureTable,
           measureDisplay: "stratified",
-          modalId: "req-measure-result-modal",
-          to: "req-measure-report",
         },
       ],
     },

--- a/services/app-api/handlers/reports/update.test.ts
+++ b/services/app-api/handlers/reports/update.test.ts
@@ -1,0 +1,78 @@
+import { StatusCodes } from "../../libs/response-lib";
+import { proxyEvent } from "../../testing/proxyEvent";
+import { APIGatewayProxyEvent } from "../../types/types";
+import { updateReport } from "./update";
+
+jest.mock("../../utils/authorization", () => ({
+  isAuthenticated: jest.fn().mockResolvedValue(true),
+}));
+
+jest.mock("../../storage/reports", () => ({
+  putReport: () => jest.fn(),
+}));
+
+const reportObj = { type: "QM", state: "PA", id: "QMPA123" };
+const report = JSON.stringify(reportObj);
+
+const testEvent: APIGatewayProxyEvent = {
+  ...proxyEvent,
+  pathParameters: { reportType: "QM", state: "PA", id: "QMPA123" },
+  headers: { "cognito-identity-id": "test" },
+  body: report,
+};
+
+describe("Test update report handler", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("Test missing path params", async () => {
+    const badTestEvent = {
+      ...proxyEvent,
+      pathParameters: {},
+    } as APIGatewayProxyEvent;
+    const res = await updateReport(badTestEvent, null);
+    expect(res.statusCode).toBe(StatusCodes.BadRequest);
+  });
+
+  test("Test missing body", async () => {
+    const emptyBodyEvent = {
+      ...proxyEvent,
+      pathParameters: { reportType: "QM", state: "PA", id: "QMPA123" },
+      body: null,
+    } as APIGatewayProxyEvent;
+    const res = await updateReport(emptyBodyEvent, null);
+    expect(res.statusCode).toBe(StatusCodes.BadRequest);
+  });
+
+  test("Test body + param mismatch", async () => {
+    const badType = {
+      ...proxyEvent,
+      pathParameters: { reportType: "ZZ", state: "PA", id: "QMPA123" },
+      body: report,
+    } as APIGatewayProxyEvent;
+    const badState = {
+      ...proxyEvent,
+      pathParameters: { reportType: "QM", state: "OR", id: "QMPA123" },
+      body: report,
+    } as APIGatewayProxyEvent;
+    const badId = {
+      ...proxyEvent,
+      pathParameters: { reportType: "QM", state: "PA", id: "ZZOR1234" },
+      body: report,
+    } as APIGatewayProxyEvent;
+
+    const resType = await updateReport(badType, null);
+    expect(resType.statusCode).toBe(StatusCodes.BadRequest);
+    const resState = await updateReport(badState, null);
+    expect(resState.statusCode).toBe(StatusCodes.BadRequest);
+    const resId = await updateReport(badId, null);
+    expect(resId.statusCode).toBe(StatusCodes.BadRequest);
+  });
+
+  test("Test Successful update", async () => {
+    const res = await updateReport(testEvent, null);
+
+    expect(res.statusCode).toBe(StatusCodes.Ok);
+  });
+});

--- a/services/app-api/handlers/reports/update.ts
+++ b/services/app-api/handlers/reports/update.ts
@@ -1,0 +1,32 @@
+import handler from "../../libs/handler-lib";
+import { parseReportTypeAndState } from "../../libs/param-lib";
+import { badRequest, ok } from "../../libs/response-lib";
+import { putReport } from "../../storage/reports";
+import { Report } from "../../types/reports";
+
+export const updateReport = handler(async (event) => {
+  const { allParamsValid, reportType, state } = parseReportTypeAndState(event);
+  if (!allParamsValid) {
+    return badRequest("Invalid path parameters");
+  }
+
+  // TODO: Auth
+
+  if (!event?.body) {
+    return badRequest("Invalid request");
+  }
+
+  const report = JSON.parse(event.body) as Report;
+  if (
+    reportType !== report.type ||
+    report.state !== state ||
+    report.id !== report.id
+  ) {
+    return badRequest("Invalid request");
+  }
+
+  // Validation required.
+  await putReport(report);
+
+  return ok();
+});

--- a/services/app-api/handlers/reports/update.ts
+++ b/services/app-api/handlers/reports/update.ts
@@ -1,11 +1,12 @@
 import handler from "../../libs/handler-lib";
-import { parseReportTypeAndState } from "../../libs/param-lib";
+import { parseReportParameters } from "../../libs/param-lib";
 import { badRequest, ok } from "../../libs/response-lib";
 import { putReport } from "../../storage/reports";
 import { Report } from "../../types/reports";
 
 export const updateReport = handler(async (event) => {
-  const { allParamsValid, reportType, state } = parseReportTypeAndState(event);
+  const { allParamsValid, reportType, state, id } =
+    parseReportParameters(event);
   if (!allParamsValid) {
     return badRequest("Invalid path parameters");
   }
@@ -19,8 +20,8 @@ export const updateReport = handler(async (event) => {
   const report = JSON.parse(event.body) as Report;
   if (
     reportType !== report.type ||
-    report.state !== state ||
-    report.id !== report.id
+    state !== report.state ||
+    id !== report.id
   ) {
     return badRequest("Invalid request");
   }

--- a/services/app-api/serverless.yml
+++ b/services/app-api/serverless.yml
@@ -95,6 +95,20 @@ functions:
               paths:
                 reportType: true
                 state: true
+  updateReport:
+    handler: handlers/reports/update.updateReport
+    events:
+      - http:
+          path: reports/{reportType}/{state}/{id}
+          method: put
+          cors: true
+          authorizer: aws_iam
+          request:
+            parameters:
+              paths:
+                reportType: true
+                state: true
+                id: true
   getReport:
     handler: handlers/reports/get.get
     events:

--- a/services/app-api/types/reports.ts
+++ b/services/app-api/types/reports.ts
@@ -227,8 +227,6 @@ export type ChoiceTemplate = {
 export type MeasureTableTemplate = {
   type: ElementType.MeasureTable;
   measureDisplay: "required" | "stratified" | "optional";
-  modalId: PageId;
-  to: PageId;
 };
 
 export type StatusTableTemplate = {

--- a/services/ui-src/src/components/fields/DateField.test.tsx
+++ b/services/ui-src/src/components/fields/DateField.test.tsx
@@ -36,9 +36,11 @@ const mockedDateTextboxElement = {
   helperText: "helper text",
 };
 
+const testKey = "unique.form.key";
 const dateFieldComponent = (
   <DateField
     element={mockedDateTextboxElement as unknown as PageElement}
+    formkey={testKey}
     index={0}
   />
 );
@@ -71,7 +73,7 @@ describe("<DateField />", () => {
        */
       expect(mockRhfMethods.setValue).toHaveBeenCalledTimes(3);
       expect(mockRhfMethods.setValue).toHaveBeenCalledWith(
-        "answers.1.2",
+        `${testKey}.answer`,
         "10/16/2024"
       );
     });

--- a/services/ui-src/src/components/fields/DateField.tsx
+++ b/services/ui-src/src/components/fields/DateField.tsx
@@ -8,7 +8,7 @@ import { DateTemplate } from "../../types/report";
 
 export const DateField = (props: PageElementProps) => {
   const dateTextbox = props.element as DateTemplate;
-  const defaultValue = "";
+  const defaultValue = dateTextbox.answer ?? "";
   const [displayValue, setDisplayValue] = useState<string>(defaultValue);
 
   // get form context and register form field

--- a/services/ui-src/src/components/fields/DateField.tsx
+++ b/services/ui-src/src/components/fields/DateField.tsx
@@ -13,27 +13,26 @@ export const DateField = (props: PageElementProps) => {
 
   // get form context and register form field
   const form = useFormContext();
-  const inputName = "answers.1.2"; // TODO: id based
-
+  const key = `${props.formkey}.answer`;
   useEffect(() => {
-    form.register(inputName);
+    form.register(key);
   }, []);
 
   const onChangeHandler = (rawValue: string, maskedValue: string) => {
     setDisplayValue(rawValue);
     const isValidDate = checkDateCompleteness(maskedValue);
     if (isValidDate || maskedValue === "") {
-      form.setValue(inputName, maskedValue, { shouldValidate: true });
+      form.setValue(key, maskedValue, { shouldValidate: true });
     }
   };
 
   const onBlurHandler = async (event: React.ChangeEvent<HTMLInputElement>) => {
-    form.setValue(inputName, event.target.value);
+    form.setValue(key, event.target.value);
   };
 
   // prepare error message, hint, and classes
   const formErrorState = form?.formState?.errors;
-  const errorMessage = formErrorState?.[inputName]?.message;
+  const errorMessage = formErrorState?.[key]?.message;
   const parsedHint =
     dateTextbox.helperText && parseCustomHtml(dateTextbox.helperText);
   const labelText = dateTextbox.label;
@@ -41,8 +40,8 @@ export const DateField = (props: PageElementProps) => {
   return (
     <Box>
       <CmsdsDateField
-        id={inputName}
-        name={inputName}
+        id={key}
+        name={key}
         label={labelText || ""}
         onChange={onChangeHandler}
         onBlur={onBlurHandler}

--- a/services/ui-src/src/components/fields/TextField.test.tsx
+++ b/services/ui-src/src/components/fields/TextField.test.tsx
@@ -39,6 +39,7 @@ const textFieldComponent = (
   <TextField
     element={mockedTextboxElement as unknown as PageElement}
     index={0}
+    formkey="elements.0"
   />
 );
 

--- a/services/ui-src/src/components/fields/TextField.tsx
+++ b/services/ui-src/src/components/fields/TextField.tsx
@@ -13,10 +13,9 @@ export const TextField = (props: PageElementProps) => {
 
   // get form context and register field
   const form = useFormContext();
-  const inputName = "answers.1.2"; // TODO: id based
-
+  const key = `${props.formkey}.answer`;
   useEffect(() => {
-    form.register(inputName);
+    form.register(key);
   }, []);
 
   const onChangeHandler = async (
@@ -28,20 +27,20 @@ export const TextField = (props: PageElementProps) => {
   };
 
   const onBlurHandler = async (event: React.ChangeEvent<HTMLInputElement>) => {
-    form.setValue(inputName, event.target.value);
+    form.setValue(key, event.target.value);
   };
 
   // prepare error message, hint, and classes
   const formErrorState = form?.formState?.errors;
-  const errorMessage = formErrorState?.[inputName]?.message;
+  const errorMessage = formErrorState?.[key]?.message;
   const parsedHint = textbox.helperText && parseCustomHtml(textbox.helperText);
   const labelText = textbox.label;
 
   return (
     <Box>
       <CmsdsTextField
-        id={inputName}
-        name={inputName}
+        id={key}
+        name={key}
         label={labelText || ""}
         hint={parsedHint}
         onChange={(e) => onChangeHandler(e)}

--- a/services/ui-src/src/components/fields/TextField.tsx
+++ b/services/ui-src/src/components/fields/TextField.tsx
@@ -8,7 +8,7 @@ import { PageElementProps } from "../report/Elements";
 
 export const TextField = (props: PageElementProps) => {
   const textbox = props.element as TextboxTemplate;
-  const defaultValue = "";
+  const defaultValue = textbox.answer ?? "";
   const [displayValue, setDisplayValue] = useState<string>(defaultValue);
 
   // get form context and register field

--- a/services/ui-src/src/components/report/Elements.tsx
+++ b/services/ui-src/src/components/report/Elements.tsx
@@ -26,6 +26,7 @@ import {
 export interface PageElementProps {
   element: PageElement;
   index: number;
+  formkey: string;
 }
 
 export const headerElement = (props: PageElementProps) => {

--- a/services/ui-src/src/components/report/Page.test.tsx
+++ b/services/ui-src/src/components/report/Page.test.tsx
@@ -1,0 +1,88 @@
+import { render } from "@testing-library/react";
+import { ElementType, PageElement } from "types/report";
+import { Page } from "./Page";
+
+jest.mock("react-router-dom", () => ({
+  useNavigate: jest.fn(),
+}));
+
+jest.mock("../../utils/state/useStore", () => ({
+  useStore: () => ({
+    setCurrentPageId: jest.fn(),
+  }),
+}));
+jest.mock("react-hook-form", () => ({
+  useFormContext: () => ({
+    register: jest.fn(),
+  }),
+}));
+
+// Mock the more complex elements, let them test themselves
+jest.mock("./StatusTable", () => {
+  return { StatusTableElement: () => <div>Status Table</div> };
+});
+jest.mock("./MeasureTable", () => {
+  return { MeasureTableElement: () => <div>Measure Table</div> };
+});
+
+const elements: PageElement[] = [
+  {
+    type: ElementType.Header,
+    text: "My Header",
+  },
+  {
+    type: ElementType.SubHeader,
+    text: "My subheader",
+  },
+  {
+    type: ElementType.Paragraph,
+    text: "Paragraph",
+  },
+  {
+    type: ElementType.Textbox,
+    label: "labeled",
+  },
+  {
+    type: ElementType.Date,
+    label: "date label",
+    helperText: "can you read this?",
+  },
+  {
+    type: ElementType.Accordion,
+    label: "Some text",
+    value: "Other",
+  },
+  {
+    type: ElementType.Radio,
+    label: "date label",
+    value: [{ label: "a", value: "1" }],
+  },
+  {
+    type: ElementType.ButtonLink,
+    to: "report-page-id",
+    label: "click me",
+  },
+  {
+    type: ElementType.MeasureTable,
+    measureDisplay: "stratified",
+  },
+  {
+    type: ElementType.StatusTable,
+  },
+];
+
+describe("Page Component", () => {
+  test.each(elements)("Renders all element types: %p", (element) => {
+    const { container } = render(<Page elements={[element]} />);
+    expect(container).not.toBeEmptyDOMElement();
+  });
+  test("should not render if it is passed missing types", () => {
+    // Page Element prevents us from doing this with typescript, but the real world may have other plans
+    const badObject = { type: "unused element name" };
+
+    const { container } = render(
+      <Page elements={[badObject as unknown as PageElement]} />
+    );
+    expect(container).not.toBeEmptyDOMElement();
+  });
+});

--- a/services/ui-src/src/components/report/Page.tsx
+++ b/services/ui-src/src/components/report/Page.tsx
@@ -46,7 +46,17 @@ export const Page = ({ elements }: Props) => {
 
   const composedElements = elements.map((element, index) => {
     const ComposedElement = renderElement(element);
-    return <ComposedElement key={index} element={element} />;
+    return (
+      <ComposedElement
+        formkey={buildFormKey(index)}
+        key={index}
+        element={element}
+      />
+    );
   });
   return <VStack alignItems="flex-start">{composedElements}</VStack>;
+};
+
+const buildFormKey = (index: number) => {
+  return `elements.${index}`;
 };

--- a/services/ui-src/src/components/report/ReportPageWrapper.test.tsx
+++ b/services/ui-src/src/components/report/ReportPageWrapper.test.tsx
@@ -1,0 +1,112 @@
+import { render, waitFor } from "@testing-library/react";
+import {
+  ElementType,
+  MeasureTemplateName,
+  PageType,
+  Report,
+  ReportType,
+} from "types/report";
+import { ReportPageWrapper } from "./ReportPageWrapper";
+
+const testReport: Report = {
+  type: ReportType.QM,
+  title: "plan id",
+  state: "NJ",
+  id: "NJQM123",
+  pages: [
+    {
+      id: "root",
+      childPageIds: ["general-info", "req-measure-result"],
+    },
+    {
+      id: "general-info",
+      title: "General Information",
+      type: PageType.Standard,
+      sidebar: true,
+      elements: [
+        {
+          type: ElementType.Header,
+          text: "General Information",
+        },
+        {
+          type: ElementType.Textbox,
+          label: "Contact title",
+          helperText:
+            "Enter person's title or a position title for CMS to contact with questions about this request.",
+        },
+      ],
+    },
+    {
+      id: "req-measure-result",
+      title: "Required Measure Results",
+      type: PageType.Standard,
+      sidebar: true,
+      elements: [
+        {
+          type: ElementType.Header,
+          text: "Required Measure Results",
+        },
+      ],
+    },
+  ],
+  measureLookup: { defaultMeasures: [], optionGroups: {} },
+  measureTemplates: {
+    [MeasureTemplateName.StandardMeasure]: {
+      id: "req-measure-report",
+      title: "Example Measure",
+      type: PageType.Measure,
+      sidebar: false,
+      elements: [
+        {
+          type: ElementType.ButtonLink,
+          label: "Return to Required Measures Results Dashboard",
+          to: "req-measure-result",
+        },
+      ],
+    },
+  },
+};
+
+const mockUseParams = jest.fn();
+jest.mock("react-router-dom", () => ({
+  useParams: () => mockUseParams(),
+  useNavigate: jest.fn(),
+}));
+
+const mockGetReport = jest.fn().mockResolvedValue(testReport);
+jest.mock("../../utils/api/requestMethods/report", () => ({
+  getReport: () => mockGetReport(),
+}));
+describe("ReportPageWrapper", () => {
+  beforeEach(() => {
+    mockUseParams.mockReturnValue({
+      reportType: "QM",
+      state: "NJ",
+      reportId: "QMNJ123",
+    });
+  });
+  test("should not render if missing params", () => {
+    mockUseParams.mockReturnValue({
+      reportType: undefined,
+      state: undefined,
+      reportId: undefined,
+    });
+    const { getByText } = render(<ReportPageWrapper />);
+    expect(getByText("bad params")).toBeTruthy(); // To be updated with real error page
+  });
+  test("should render Loading if report not loaded", () => {
+    mockGetReport.mockResolvedValueOnce(undefined);
+    const { getByText } = render(<ReportPageWrapper />);
+    expect(getByText("Loading")).toBeTruthy(); // To be updated with real loading page
+  });
+  test("should render if report exists", async () => {
+    const { queryAllByText, getByText } = render(<ReportPageWrapper />);
+
+    await waitFor(() => {
+      expect(queryAllByText("General Information")).toBeDefined();
+    });
+
+    expect(getByText("Continue")).toBeTruthy();
+    expect(queryAllByText("General Information")[0]).toBeTruthy();
+  });
+});

--- a/services/ui-src/src/components/report/ReportPageWrapper.tsx
+++ b/services/ui-src/src/components/report/ReportPageWrapper.tsx
@@ -23,12 +23,18 @@ export const ReportPageWrapper = () => {
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const methods = useForm({
     defaultValues: useMemo(() => {
-      return pageMap?.get(currentPageId ?? "")!;
+      const pageIndex = pageMap?.get(currentPageId ?? "")!;
+      return report?.pages[pageIndex];
     }, [currentPageId]) as FormPageTemplate,
     shouldUnregister: true,
   });
 
-  const { handleSubmit } = methods;
+  const { handleSubmit, reset } = methods;
+  useEffect(() => {
+    const pageIndex = pageMap?.get(currentPageId ?? "")!;
+    reset(report?.pages[pageIndex]);
+  }, [currentPageId]);
+
   const handleBlur = (data: any) => {
     if (!report) return;
     setAnswers(data);
@@ -57,7 +63,7 @@ export const ReportPageWrapper = () => {
   }
 
   // I'm pretty sure these can all be moved into the state, but have not used the brainpower
-  const currentPage = pageMap.get(currentPageId)!;
+  const currentPage = report.pages[pageMap.get(currentPageId)!];
   const SetPageIndex = (newPageIndex: number) => {
     if (!parentPage) return; // Pages can exist outside of the direct parentage structure
     const childPageCount = parentPage.childPageIds?.length ?? 0;

--- a/services/ui-src/src/components/report/ReportPageWrapper.tsx
+++ b/services/ui-src/src/components/report/ReportPageWrapper.tsx
@@ -41,10 +41,8 @@ export const ReportPageWrapper = () => {
     setAnswers(data);
   };
 
-  if (!reportType || !state || !reportId) {
-    return <div>bad params</div>; // TODO: error page
-  }
   const fetchReport = async () => {
+    if (!reportType || !state || !reportId) return;
     try {
       const result = await getReport(reportType, state, reportId);
       setReport(result);
@@ -57,6 +55,10 @@ export const ReportPageWrapper = () => {
   useEffect(() => {
     fetchReport();
   }, []);
+
+  if (!reportType || !state || !reportId) {
+    return <div>bad params</div>; // TODO: error page
+  }
 
   if (isLoading || !report || !pageMap || !currentPageId) {
     return <p>Loading</p>;

--- a/services/ui-src/src/components/report/ReportPageWrapper.tsx
+++ b/services/ui-src/src/components/report/ReportPageWrapper.tsx
@@ -16,7 +16,6 @@ export const ReportPageWrapper = () => {
     parentPage,
     currentPageId,
     setReport,
-    setParentPage,
     setAnswers,
     setCurrentPageId,
   } = useStore();
@@ -64,16 +63,10 @@ export const ReportPageWrapper = () => {
     return <p>Loading</p>;
   }
 
-  // I'm pretty sure these can all be moved into the state, but have not used the brainpower
   const currentPage = report.pages[pageMap.get(currentPageId)!];
   const SetPageIndex = (newPageIndex: number) => {
     if (!parentPage) return; // Pages can exist outside of the direct parentage structure
-    const childPageCount = parentPage.childPageIds?.length ?? 0;
-
-    if (newPageIndex >= 0 && newPageIndex < childPageCount) {
-      setParentPage({ ...parentPage, index: newPageIndex });
-      setCurrentPageId(parentPage.childPageIds[newPageIndex]);
-    }
+    setCurrentPageId(parentPage.childPageIds[newPageIndex]);
   };
 
   return (

--- a/services/ui-src/src/components/report/ReportPageWrapper.tsx
+++ b/services/ui-src/src/components/report/ReportPageWrapper.tsx
@@ -38,7 +38,6 @@ export const ReportPageWrapper = () => {
   const handleBlur = (data: any) => {
     if (!report) return;
     setAnswers(data);
-    // TODO: Post
   };
 
   if (!reportType || !state || !reportId) {

--- a/services/ui-src/src/components/report/ReportPageWrapper.tsx
+++ b/services/ui-src/src/components/report/ReportPageWrapper.tsx
@@ -1,5 +1,5 @@
 import { Box, Button, Divider, HStack, Stack, VStack } from "@chakra-ui/react";
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Page } from "./Page";
 import { Sidebar } from "./Sidebar";
 import { ReportModal } from "./ReportModal";
@@ -7,6 +7,7 @@ import { getReport } from "utils/api/requestMethods/report";
 import { useParams } from "react-router-dom";
 import { useStore } from "utils";
 import { FormProvider, useForm } from "react-hook-form";
+import { FormPageTemplate } from "types/report";
 
 export const ReportPageWrapper = () => {
   const {
@@ -16,19 +17,21 @@ export const ReportPageWrapper = () => {
     currentPageId,
     setReport,
     setParentPage,
+    setAnswers,
   } = useStore();
   const { reportType, state, reportId } = useParams();
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const methods = useForm({
+    defaultValues: useMemo(() => {
+      return pageMap?.get(currentPageId ?? "")!;
+    }, [currentPageId]) as FormPageTemplate,
     shouldUnregister: true,
   });
 
   const { handleSubmit } = methods;
   const handleBlur = (data: any) => {
-    // TODO: any
     if (!report) return;
-    // console.log(methods.formState);
-    report.answers = [...data.answers];
+    setAnswers(data);
     // TODO: Post
   };
 

--- a/services/ui-src/src/components/report/Sidebar.test.tsx
+++ b/services/ui-src/src/components/report/Sidebar.test.tsx
@@ -1,0 +1,77 @@
+import { act, render } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { Sidebar } from "./Sidebar";
+
+const setCurrentPageId = jest.fn();
+const mockPageMap = new Map();
+mockPageMap.set("root", 0);
+mockPageMap.set("id-1", 1);
+mockPageMap.set("id-2", 2);
+mockPageMap.set("child-1", 3);
+
+const report = {
+  pages: [
+    { childPageIds: ["id-1", "id-2"], id: "root" },
+    { title: "Section 1", id: "id-1" },
+    { title: "Section 2", id: "id-2", childPageIds: [] },
+    { title: "Child 1", id: "child-1" },
+  ],
+};
+
+const mockReportStore = jest.fn().mockImplementation(() => ({
+  pageMap: mockPageMap,
+  report: report,
+  currentPageId: "id-1",
+  setCurrentPageId,
+}));
+jest.mock("../../utils/state/useStore", () => ({
+  useStore: () => mockReportStore(),
+}));
+
+describe("Sidebar", () => {
+  test("should not render if missing details from the store", () => {
+    mockReportStore.mockReturnValueOnce({
+      pageMap: undefined,
+      report: undefined,
+      currentPageId: undefined,
+      setCurrentPageId,
+    });
+    const { container } = render(<Sidebar />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  test("should not render if missing root in page map", () => {
+    mockReportStore.mockReturnValueOnce({
+      pageMap: new Map(),
+      report: report,
+      currentPageId: "id-1",
+      setCurrentPageId,
+    });
+    const { container } = render(<Sidebar />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  test("should render section headers", () => {
+    const { getByText } = render(<Sidebar />);
+    expect(getByText("Section 1")).toBeTruthy();
+    expect(getByText("Section 2")).toBeTruthy();
+  });
+
+  test("should attempt to navigate on Click", async () => {
+    const { getByText } = render(<Sidebar />);
+    const button = getByText("Section 1");
+    await userEvent.click(button);
+    expect(setCurrentPageId).toHaveBeenCalledWith("id-1");
+  });
+
+  test("should collapse on Click", async () => {
+    const { getByText, getByRole, queryByText } = render(<Sidebar />);
+
+    expect(getByText("Section 1")).toBeTruthy();
+    await act(async () => {
+      const button = getByRole("img");
+      await userEvent.click(button);
+    });
+    expect(queryByText("Section 1")).toBeNull();
+  });
+});

--- a/services/ui-src/src/components/report/Sidebar.tsx
+++ b/services/ui-src/src/components/report/Sidebar.tsx
@@ -17,11 +17,16 @@ export const Sidebar = () => {
   if (!report || !pageMap) {
     return null;
   }
+  const root = pageMap.get("root");
+  if (root == undefined) throw new Error("Sidebar missing root object.");
+
   const buildNavList = (childPageIds: string[]) => {
     const builtList: any[] = [];
 
     for (const child of childPageIds) {
-      const page = pageMap.get(child) as ParentPageTemplate;
+      const pageIndex = pageMap.get(child);
+      if (pageIndex == undefined) continue; // how did you do this
+      const page = report.pages[pageIndex];
       if (page.childPageIds) {
         builtList.push(
           <Stack key={page.id} width="100%" spacing="0">
@@ -36,7 +41,7 @@ export const Sidebar = () => {
     return builtList;
   };
   const navList = buildNavList(
-    (pageMap.get("root") as ParentPageTemplate).childPageIds
+    (report.pages[root] as ParentPageTemplate).childPageIds
   );
   return (
     <VStack height="100%" width="320px" background="gray.100" spacing="0">

--- a/services/ui-src/src/components/report/Sidebar.tsx
+++ b/services/ui-src/src/components/report/Sidebar.tsx
@@ -71,7 +71,7 @@ export const Sidebar = () => {
   };
 
   const root = pageMap.get("root");
-  if (root == undefined) throw new Error("Sidebar missing root object.");
+  if (root == undefined) return null;
 
   return (
     <Flex height="100%">

--- a/services/ui-src/src/components/report/Sidebar.tsx
+++ b/services/ui-src/src/components/report/Sidebar.tsx
@@ -1,6 +1,5 @@
 import { Box, Button, Heading, Flex, Image } from "@chakra-ui/react";
 import { useStore } from "utils";
-import { PageTemplate } from "../../types/report";
 import arrowDownIcon from "assets/icons/arrows/icon_arrow_down_gray.svg";
 import arrowUpIcon from "assets/icons/arrows/icon_arrow_up_gray.svg";
 import { ReactNode, useState } from "react";
@@ -33,30 +32,29 @@ export const Sidebar = () => {
     setCurrentPageId(sectonId);
   };
 
-  const navSection = (section: PageTemplate, index: number = 0): ReactNode => {
-    const childSections = section.childPageIds?.map((child) =>
-      pageMap.get(child)
-    );
+  const navSection = (section: number, index: number = 0): ReactNode => {
+    const page = report.pages[section];
+    const childSections = page.childPageIds?.map((child) => pageMap.get(child));
 
     return (
-      <Box key={section.id}>
+      <Box key={page.id}>
         <Button
-          variant={section.id === currentPageId ? "sidebarSelected" : "sidebar"}
+          variant={page.id === currentPageId ? "sidebarSelected" : "sidebar"}
         >
           <Flex justifyContent="space-between" alignItems="center">
             <Box
               width="100%"
               height="100%"
-              onClick={() => onNavSelect(section.id)}
+              onClick={() => onNavSelect(page.id)}
             >
-              {navItem(section.title!, index)}
+              {navItem(page.title!, index)}
             </Box>
             {childSections?.length! > 0 && (
-              <Box onClick={() => setToggle(section.id)}>
+              <Box onClick={() => setToggle(page.id)}>
                 <Image
-                  src={toggleList[section.id] ? arrowUpIcon : arrowDownIcon}
+                  src={toggleList[page.id] ? arrowUpIcon : arrowDownIcon}
                   alt={
-                    toggleList[section.id]
+                    toggleList[page.id]
                       ? "Collapse subitems"
                       : "Expand subitems"
                   }
@@ -66,20 +64,23 @@ export const Sidebar = () => {
           </Flex>
         </Button>
         {childSections?.length! > 0 &&
-          toggleList[section.id] &&
+          toggleList[page.id] &&
           childSections!.map((sec) => navSection(sec!, index + 1))}
       </Box>
     );
   };
+
+  const root = pageMap.get("root");
+  if (root == undefined) throw new Error("Sidebar missing root object.");
 
   return (
     <Flex height="100%">
       {isOpen && (
         <Flex flexDirection="column" background="palette.gray_lightest">
           <Heading variant="sidebar">Quality Measures Report</Heading>
-          {pageMap
-            .get("root")
-            ?.childPageIds?.map((child) => navSection(pageMap.get(child)!))}
+          {report.pages[root].childPageIds?.map((child) =>
+            navSection(pageMap.get(child)!)
+          )}
         </Flex>
       )}
       <Button

--- a/services/ui-src/src/components/report/StatusTable.test.tsx
+++ b/services/ui-src/src/components/report/StatusTable.test.tsx
@@ -19,18 +19,27 @@ describe("StatusTableElement", () => {
   beforeEach(() => {
     (useNavigate as jest.Mock).mockReturnValue(mockNavigate);
     jest.clearAllMocks();
+
+    const mockPageMap = new Map();
+    mockPageMap.set("root", 0);
+    mockPageMap.set("1", 1);
+    mockPageMap.set("2", 2);
+
+    const report = {
+      pages: [
+        { childPageIds: ["1", "2"] },
+        { title: "Section 1", id: "id-1" },
+        { title: "Section 2", id: "id-2" },
+      ],
+    };
+    (useStore as unknown as jest.Mock).mockReturnValue({
+      pageMap: mockPageMap,
+      report: report,
+      setCurrentPageId,
+    });
   });
 
   test("table with section titles and status icons render", () => {
-    const mockPageMap = new Map();
-    mockPageMap.set("root", { childPageIds: ["1", "2"] });
-    mockPageMap.set("1", { title: "Section 1" });
-    mockPageMap.set("2", { title: "Section 2" });
-
-    (useStore as unknown as jest.Mock).mockReturnValue({
-      pageMap: mockPageMap,
-    });
-
     render(<StatusTableElement />);
 
     // Table headers
@@ -44,33 +53,15 @@ describe("StatusTableElement", () => {
   });
 
   test("when Edit button is clicked call setCurrentPageId with the correct pageId", async () => {
-    const mockPageMap = new Map();
-    mockPageMap.set("root", { childPageIds: ["1", "2"] });
-    mockPageMap.set("1", { title: "Section 1" });
-    mockPageMap.set("2", { title: "Section 2" });
-
-    (useStore as unknown as jest.Mock).mockReturnValue({
-      pageMap: mockPageMap,
-      setCurrentPageId,
-    });
-
     render(<StatusTableElement />);
 
     const editButton = screen.getByRole("button", { name: /Edit/i });
     await userEvent.click(editButton);
 
-    expect(setCurrentPageId).toHaveBeenCalledWith("1");
+    expect(setCurrentPageId).toHaveBeenCalledWith("id-1");
   });
 
   test("when the Review PDF button is clicked navigate to PDF", async () => {
-    const mockPageMap = new Map();
-    mockPageMap.set("root", { childPageIds: ["1"] });
-    mockPageMap.set("1", { title: "Section 1" });
-
-    (useStore as unknown as jest.Mock).mockReturnValue({
-      pageMap: mockPageMap,
-    });
-
     render(<StatusTableElement />);
 
     const reviewPdfButton = screen.getByRole("button", { name: /Review PDF/i });

--- a/services/ui-src/src/components/report/StatusTable.tsx
+++ b/services/ui-src/src/components/report/StatusTable.tsx
@@ -20,26 +20,26 @@ import { ParentPageTemplate } from "types/report";
 import { useNavigate } from "react-router-dom";
 
 export const StatusTableElement = () => {
-  const { pageMap, setCurrentPageId } = useStore();
+  const { pageMap, report, setCurrentPageId } = useStore();
   const navigate = useNavigate();
 
   if (!pageMap) {
     return null;
   }
 
-  const childPageIdsList = (pageMap.get("root") as ParentPageTemplate)
+  const childPages = (report?.pages[pageMap.get("root")!] as ParentPageTemplate)
     .childPageIds;
-  const sectionTitles = childPageIdsList
-    .map((id) => {
-      const page = pageMap.get(id) as ParentPageTemplate;
-      return { title: page.title, pageId: id };
-    })
-    .slice(0, -1);
+  const sections = childPages.slice(0, -1).map((id) => {
+    const pageIdx = pageMap.get(id);
+    if (!pageIdx) return;
+    return report?.pages[pageIdx] as ParentPageTemplate;
+  });
 
   // Build Rows
-  const rows = sectionTitles.map((section, index) => {
+  const rows = sections.map((section, index) => {
+    if (!section) return;
     return (
-      <Tr key={section.pageId || index} p={0}>
+      <Tr key={section.id || index} p={0}>
         <Td>
           <Stack flex="1">
             <Text fontWeight="bold">{section.title}</Text>
@@ -60,7 +60,7 @@ export const StatusTableElement = () => {
             colorScheme="blue"
             variant="outline"
             leftIcon={<Image src={editIconPrimary} />}
-            onClick={() => setCurrentPageId(section.pageId)}
+            onClick={() => setCurrentPageId(section.id)}
           >
             Edit
           </Button>

--- a/services/ui-src/src/types/report.ts
+++ b/services/ui-src/src/types/report.ts
@@ -153,13 +153,10 @@ export type AccordionTemplate = {
 export type MeasureTableTemplate = {
   type: ElementType.MeasureTable;
   measureDisplay: "required" | "stratified" | "optional";
-  modalId: PageId;
-  to: PageId;
 };
 
 export type StatusTableTemplate = {
   type: ElementType.StatusTable;
-  to: PageId;
 };
 
 export type RadioTemplate = {

--- a/services/ui-src/src/types/report.ts
+++ b/services/ui-src/src/types/report.ts
@@ -132,6 +132,7 @@ export type DateTemplate = {
   type: ElementType.Date;
   label: string;
   helperText: string;
+  answer?: string;
 };
 
 export type AccordionTemplate = {

--- a/services/ui-src/src/types/states.ts
+++ b/services/ui-src/src/types/states.ts
@@ -1,9 +1,4 @@
-import {
-  ParentPageTemplate,
-  PageData,
-  PageTemplate,
-  Report,
-} from "types/report";
+import { ParentPageTemplate, PageData, Report } from "types/report";
 import React from "react";
 import { HcbsUser } from "types";
 
@@ -20,7 +15,7 @@ export interface HcbsUserState {
 export interface HcbsReportState {
   // INITIAL STATE
   report?: Report;
-  pageMap?: Map<string, PageTemplate>;
+  pageMap?: Map<string, number>;
   rootPage?: ParentPageTemplate;
   parentPage?: PageData; // used for looking up curr & next page
   currentPageId?: string;

--- a/services/ui-src/src/types/states.ts
+++ b/services/ui-src/src/types/states.ts
@@ -19,7 +19,7 @@ export interface HcbsUserState {
 
 export interface HcbsReportState {
   // INITIAL STATE
-  report?: Report; // TODO: report, not template
+  report?: Report;
   pageMap?: Map<string, PageTemplate>;
   rootPage?: ParentPageTemplate;
   parentPage?: PageData; // used for looking up curr & next page
@@ -33,4 +33,5 @@ export interface HcbsReportState {
   setCurrentPageId: (currentPageId: string) => void;
   setModalOpen: (modalOpen: boolean) => void;
   setModalComponent: (modalComponent: React.ReactFragment) => void;
+  setAnswers: (answers: any) => void;
 }

--- a/services/ui-src/src/types/states.ts
+++ b/services/ui-src/src/types/states.ts
@@ -24,7 +24,6 @@ export interface HcbsReportState {
 
   // ACTIONS
   setReport: (report?: Report) => void;
-  setParentPage: (parentPage?: PageData) => void;
   setCurrentPageId: (currentPageId: string) => void;
   setModalOpen: (modalOpen: boolean) => void;
   setModalComponent: (modalComponent: React.ReactFragment) => void;

--- a/services/ui-src/src/utils/api/requestMethods/report.test.ts
+++ b/services/ui-src/src/utils/api/requestMethods/report.test.ts
@@ -1,0 +1,30 @@
+import { getReport, createReport, putReport } from "./report";
+// utils
+import { initAuthManager } from "utils/auth/authLifecycle";
+import { Report, ReportType } from "types/report";
+
+const report = {
+  type: ReportType.QM,
+  state: "NJ",
+  title: "A Title",
+  pages: [],
+} as unknown as Report;
+describe("utils/report", () => {
+  beforeEach(async () => {
+    jest.useFakeTimers();
+    initAuthManager();
+    jest.runAllTimers();
+  });
+
+  test("getReport()", () => {
+    expect(getReport("QM", "NJ", "id")).toBeTruthy();
+  });
+
+  test("createReport()", () => {
+    expect(createReport("QM", "NJ", {})).toBeTruthy();
+  });
+
+  test("putReport()", () => {
+    expect(putReport(report)).toBeTruthy();
+  });
+});

--- a/services/ui-src/src/utils/api/requestMethods/report.ts
+++ b/services/ui-src/src/utils/api/requestMethods/report.ts
@@ -1,6 +1,7 @@
 import { API } from "aws-amplify";
 import { getRequestHeaders } from "./getRequestHeaders";
 import { updateTimeout } from "utils";
+import { Report } from "types/report";
 
 async function createReport(
   reportType: string,
@@ -37,4 +38,20 @@ async function getReport(reportType: string, state: string, id: string) {
   return response;
 }
 
-export { createReport, getReport };
+async function putReport(report: Report) {
+  const requestHeaders = await getRequestHeaders();
+  const request = {
+    headers: { ...requestHeaders },
+    body: { ...report },
+  };
+
+  updateTimeout();
+  const response = await API.put(
+    "hcbs",
+    `/reports/${report.type}/${report.state}/${report.id}`,
+    request
+  );
+  return response;
+}
+
+export { createReport, getReport, putReport };

--- a/services/ui-src/src/utils/state/management/reportState.test.ts
+++ b/services/ui-src/src/utils/state/management/reportState.test.ts
@@ -91,7 +91,7 @@ describe("state/management/reportState: setPage", () => {
   test("updates the page info", () => {
     const state = buildState(testReport) as unknown as HcbsReportState;
     const result = setPage("req-measure-result", state);
-    expect(result.pageId).toEqual("req-measure-result");
+    expect(result.currentPageId).toEqual("req-measure-result");
   });
 });
 

--- a/services/ui-src/src/utils/state/management/reportState.test.ts
+++ b/services/ui-src/src/utils/state/management/reportState.test.ts
@@ -1,0 +1,115 @@
+import { HcbsReportState } from "types";
+import {
+  ElementType,
+  MeasureTemplateName,
+  PageType,
+  Report,
+  ReportType,
+  TextboxTemplate,
+} from "types/report";
+import { buildState, mergeAnswers, setPage } from "./reportState";
+
+jest.mock("../../api/requestMethods/report", () => ({
+  putReport: jest.fn(),
+}));
+const testReport: Report = {
+  type: ReportType.QM,
+  title: "plan id",
+  state: "NJ",
+  id: "NJQM123",
+  pages: [
+    {
+      id: "root",
+      childPageIds: ["general-info", "req-measure-result"],
+    },
+    {
+      id: "general-info",
+      title: "General Information",
+      type: PageType.Standard,
+      sidebar: true,
+      elements: [
+        {
+          type: ElementType.Header,
+          text: "General Information",
+        },
+        {
+          type: ElementType.Textbox,
+          label: "Contact title",
+          helperText:
+            "Enter person's title or a position title for CMS to contact with questions about this request.",
+        },
+      ],
+    },
+    {
+      id: "req-measure-result",
+      title: "Required Measure Results",
+      type: PageType.Standard,
+      sidebar: true,
+      elements: [
+        {
+          type: ElementType.Header,
+          text: "Required Measure Results",
+        },
+      ],
+    },
+  ],
+  measureLookup: { defaultMeasures: [], optionGroups: {} },
+  measureTemplates: {
+    [MeasureTemplateName.StandardMeasure]: {
+      id: "req-measure-report",
+      title: "Example Measure",
+      type: PageType.Measure,
+      sidebar: false,
+      elements: [
+        {
+          type: ElementType.ButtonLink,
+          label: "Return to Required Measures Results Dashboard",
+          to: "req-measure-result",
+        },
+      ],
+    },
+  },
+};
+
+describe("state/management/reportState: buildState", () => {
+  test("initializes relevant parts of the state", () => {
+    const result = buildState(testReport);
+    expect(result.pageMap!.size).toEqual(3);
+    expect(result.report).not.toBeUndefined();
+    expect(result.rootPage).not.toBeUndefined();
+    expect(result.parentPage?.parent).toEqual("root");
+    expect(result.currentPageId).toEqual("general-info");
+  });
+
+  test("returns early when no report provided", () => {
+    const result = buildState(undefined);
+    expect(result.report).toBeUndefined();
+  });
+});
+
+describe("state/management/reportState: setPage", () => {
+  test("updates the page info", () => {
+    const state = buildState(testReport) as unknown as HcbsReportState;
+    const result = setPage("req-measure-result", state);
+    expect(result.pageId).toEqual("req-measure-result");
+  });
+});
+
+describe("state/management/reportState: mergeAnswers", () => {
+  test("Adds answers to a question", () => {
+    // Jest is garbage
+    global.structuredClone = (val) => {
+      return JSON.parse(JSON.stringify(val));
+    };
+
+    const state = buildState(testReport) as unknown as HcbsReportState;
+
+    const answers = { elements: [null, { answer: "ANSWERED" }] };
+    const result = mergeAnswers(answers, state);
+
+    const page = result?.report.pages[1];
+    const elements = page?.elements!;
+    const question = elements[1] as TextboxTemplate;
+    expect(question.answer).toEqual("ANSWERED");
+  });
+});

--- a/services/ui-src/src/utils/state/management/reportState.ts
+++ b/services/ui-src/src/utils/state/management/reportState.ts
@@ -19,17 +19,18 @@ export const buildState = (report: Report | undefined) => {
 };
 
 export const setPage = (
-  currentPageId: string,
+  targetPageId: string,
   currentState: HcbsReportState
 ) => {
   const parent = currentState.report?.pages.find((parentPage) =>
-    parentPage?.childPageIds?.includes(currentPageId)
+    parentPage?.childPageIds?.includes(targetPageId)
   );
+
   let parentPage = undefined;
   if (parent) {
     // @ts-ignore TODO
     const pageIndex = parent.childPageIds.findIndex(
-      (pageId) => pageId === pageId
+      (pageId) => pageId === targetPageId
     );
     parentPage = {
       parent: parent.id,
@@ -37,7 +38,7 @@ export const setPage = (
       index: pageIndex,
     };
   }
-  return { currentPageId, parentPage };
+  return { currentPageId: targetPageId, parentPage };
 };
 
 export const deepMerge = (obj1: any, obj2: any) => {

--- a/services/ui-src/src/utils/state/management/reportState.ts
+++ b/services/ui-src/src/utils/state/management/reportState.ts
@@ -18,9 +18,12 @@ export const buildState = (report: Report | undefined) => {
   return { report, pageMap, rootPage, parentPage, currentPageId };
 };
 
-export const setPage = (pageId: string, currentState: HcbsReportState) => {
+export const setPage = (
+  currentPageId: string,
+  currentState: HcbsReportState
+) => {
   const parent = currentState.report?.pages.find((parentPage) =>
-    parentPage?.childPageIds?.includes(pageId)
+    parentPage?.childPageIds?.includes(currentPageId)
   );
   let parentPage = undefined;
   if (parent) {
@@ -34,7 +37,7 @@ export const setPage = (pageId: string, currentState: HcbsReportState) => {
       index: pageIndex,
     };
   }
-  return { pageId, parentPage };
+  return { currentPageId, parentPage };
 };
 
 export const deepMerge = (obj1: any, obj2: any) => {

--- a/services/ui-src/src/utils/state/management/reportState.ts
+++ b/services/ui-src/src/utils/state/management/reportState.ts
@@ -1,0 +1,64 @@
+import { HcbsReportState } from "types";
+import { ParentPageTemplate, Report } from "types/report";
+import { putReport } from "utils/api/requestMethods/report";
+
+export const buildState = (report: Report | undefined) => {
+  if (!report) return { report: undefined };
+  const pageMap = new Map<string, number>(
+    report.pages.map((page, index) => [page.id, index])
+  );
+  const rootPage = report.pages[pageMap.get("root")!] as ParentPageTemplate; // this cast is safe, per unit tests
+  const parentPage = {
+    parent: rootPage.id,
+    childPageIds: rootPage.childPageIds,
+    index: 0,
+  };
+  const currentPageId = parentPage.childPageIds[parentPage.index];
+
+  return { report, pageMap, rootPage, parentPage, currentPageId };
+};
+
+export const setPage = (pageId: string, currentState: HcbsReportState) => {
+  const parent = currentState.report?.pages.find((parentPage) =>
+    parentPage?.childPageIds?.includes(pageId)
+  );
+  let parentPage = undefined;
+  if (parent) {
+    // @ts-ignore TODO
+    const pageIndex = parent.childPageIds.findIndex(
+      (pageId) => pageId === pageId
+    );
+    parentPage = {
+      parent: parent.id,
+      childPageIds: parent.childPageIds!,
+      index: pageIndex,
+    };
+  }
+  return { pageId, parentPage };
+};
+
+export const deepMerge = (obj1: any, obj2: any) => {
+  const clone1 = structuredClone(obj1);
+  const clone2 = structuredClone(obj2);
+  for (let key in clone2) {
+    if (clone2[key] instanceof Object && clone1[key] instanceof Object) {
+      clone1[key] = deepMerge(clone1[key], clone2[key]);
+    } else {
+      clone1[key] = clone2[key];
+    }
+  }
+  return clone1;
+};
+
+export const mergeAnswers = (answers: any, state: HcbsReportState) => {
+  if (!state.report) return;
+  const report = structuredClone(state.report);
+  const pageIndex = state.report.pages.findIndex(
+    (page) => page.id === state.currentPageId
+  );
+  report.pages[pageIndex] = deepMerge(report.pages[pageIndex], answers);
+
+  putReport(report); // Submit to API
+
+  return { report };
+};

--- a/services/ui-src/src/utils/state/useStore.ts
+++ b/services/ui-src/src/utils/state/useStore.ts
@@ -1,7 +1,7 @@
 import { create } from "zustand";
 import { devtools, persist } from "zustand/middleware";
 import { HcbsUserState, HcbsUser, HcbsReportState } from "types";
-import { PageData, Report } from "types/report";
+import { Report } from "types/report";
 import React from "react";
 import { buildState, mergeAnswers, setPage } from "./management/reportState";
 
@@ -39,8 +39,6 @@ const reportStore = (set: Function): HcbsReportState => ({
     set((state: HcbsReportState) => setPage(currentPageId, state), false, {
       type: "setCurrentPageId",
     }),
-  setParentPage: (parentPage: PageData | undefined) =>
-    set(() => ({ parentPage }), false, { type: "setParentPage" }),
   setModalOpen: (modalOpen: boolean) =>
     set(() => ({ modalOpen }), false, { type: "setModalOpen" }),
   setModalComponent: (modalComponent: React.ReactFragment) =>

--- a/services/ui-src/src/utils/state/useStore.ts
+++ b/services/ui-src/src/utils/state/useStore.ts
@@ -3,6 +3,7 @@ import { devtools, persist } from "zustand/middleware";
 import { HcbsUserState, HcbsUser, HcbsReportState } from "types";
 import { ParentPageTemplate, PageData, Report } from "types/report";
 import React from "react";
+import { putReport } from "utils/api/requestMethods/report";
 
 // USER STORE
 const userStore = (set: Function) => ({
@@ -93,6 +94,9 @@ const reportStore = (set: Function): HcbsReportState => ({
         (page) => page.id === state.currentPageId
       );
       report.pages[pageIndex] = deepMerge(report.pages[pageIndex], answers);
+
+      putReport(report); // Submit to API
+
       return { report };
     };
     set(mergeAction, false, {

--- a/services/ui-src/src/utils/state/useStore.ts
+++ b/services/ui-src/src/utils/state/useStore.ts
@@ -91,7 +91,34 @@ const reportStore = (set: Function): HcbsReportState => ({
     set(() => ({ modalComponent, modalOpen: true }), false, {
       type: "setModalComponent",
     }),
+  setAnswers: (answers) => {
+    const mergeAction = (state: HcbsReportState) => {
+      if (!state.report) return;
+      const report = structuredClone(state.report);
+      const pageIndex = state.report.pages.findIndex(
+        (page) => page.id === state.currentPageId
+      );
+      report.pages[pageIndex] = deepMerge(report.pages[pageIndex], answers);
+      return { report };
+    };
+    set(mergeAction, false, {
+      type: "setAnswers",
+    });
+  },
 });
+
+const deepMerge = (obj1: any, obj2: any) => {
+  const clone1 = structuredClone(obj1);
+  const clone2 = structuredClone(obj2);
+  for (let key in clone2) {
+    if (clone2[key] instanceof Object && clone1[key] instanceof Object) {
+      clone1[key] = deepMerge(clone1[key], clone2[key]);
+    } else {
+      clone1[key] = clone2[key];
+    }
+  }
+  return clone1;
+};
 
 export const useStore = create(
   // devtools is being used for debugging state


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Introduce a light version of autosave and populate the modified form when revisiting the page.

- Merges the answers from the form back into the report, then submits.
- Only triggers that update onBlur, the typing in each field is a separate event that still updates the field.
- Each input object is taking its "formkey" (its path in the json from the page level), and applying "answer" itself. More complex inputs or input groups can follow the same pattern to declare their own field in the json, or structure.
- The report is loaded into react hook form to provide defaults. By virtue of these paths matching, it pre-populates without the hydration logic that is baked into MFP & MCR. 
- Moves PageMap to a dictionary of <Key, Number> where it just keeps track of the index. We can avoid tracking two different copies of the pages and just have a quick lookup. We can further bake the lookups into a util file if they keep recurring.

Open Questions:
- Triggering the post from the action felt like the quickest path to success, but seems like it is a coin flip whether folks say it is good practice or not. We can handle writing to an error state from there if something goes wrong.
- Validation. The lifecycles of onBlur and onChange seem separate, but we'll need to find how we plug it into each field still. Each element component should have the info it needs to get it if we have rules or a rules lookup declared at its level, but more complex validation might be a curveball.


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3998

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
https://dr2j580shd4xj.cloudfront.net/
Login as a state user.
- When you edit a form, and blur, the network tab shows submission of the data
- When you change pages, that data persists
- When you refresh the page, that data persists

Other things touched:
- PageMap lookups. Sidebar and Previous/Continue buttons should continue to work as expected.


### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
