### PR TITLE
Layout & Mobile

### DIFF
--- a/services/app-api/forms/qm.ts
+++ b/services/app-api/forms/qm.ts
@@ -141,19 +141,13 @@ export const qmReportTemplate: ReportTemplate = {
           text: "Review & Submit",
         },
         {
-          type: ElementType.SubHeader,
-          text: "Ready to Submit?",
-        },
-        {
           type: ElementType.Paragraph,
+          title: "Ready to Submit?",
           text: "Double check that everything in your QMS Report is accurate. You will be able to make edits after submitting if you contact your [CMS representative] to unlock your report while it is in “Submitted” status.",
         },
         {
-          type: ElementType.SubHeader,
-          text: "Compliance review",
-        },
-        {
           type: ElementType.Paragraph,
+          title: "Compliance review",
           text: "Your Project Officer will review your report and may contact you and unlock your report for editing if there are corrections to be made.",
         },
         {

--- a/services/app-api/types/reports.ts
+++ b/services/app-api/types/reports.ts
@@ -174,6 +174,7 @@ export type SubHeaderTemplate = {
 
 export type ParagraphTemplate = {
   type: ElementType.Paragraph;
+  title?: string;
   text: string;
 };
 

--- a/services/ui-src/src/components/accordions/TemplateCardAccordion.tsx
+++ b/services/ui-src/src/components/accordions/TemplateCardAccordion.tsx
@@ -9,7 +9,7 @@ export const TemplateCardAccordion = ({ verbiage, ...props }: Props) => (
       {parseCustomHtml(verbiage.text)}
       {verbiage.table && <Table content={verbiage.table} variant="striped" />}
       {verbiage.list && (
-        <UnorderedList variant="accordian">
+        <UnorderedList variant="accordion">
           {verbiage.list.map((listItem: string, index: number) => (
             <ListItem key={index}>{listItem}</ListItem>
           ))}

--- a/services/ui-src/src/components/app/App.tsx
+++ b/services/ui-src/src/components/app/App.tsx
@@ -50,7 +50,7 @@ export const App = () => {
       {!user && showLocalLogins && (
         <main>
           <Container sx={sx.appContainer}>
-            <Heading as="h1" size="xl" sx={sx.loginHeading}>
+            <Heading as="h1" size="xl" variant="login">
               Home &amp; Community Based Services
             </Heading>
           </Container>
@@ -81,30 +81,18 @@ const sx = {
     minHeight: "100vh",
     flexDirection: "column",
   },
-  skipnav: {
-    position: "absolute",
-  },
   appContainer: {
     display: "flex",
     maxW: "appMax",
+    padding: "0",
     flex: "1 0 auto",
-    ".desktop &": {
-      padding: "0",
-    },
-    "#main-content": {
-      section: {
-        flex: "1",
-      },
+    section: {
+      padding: "1rem",
     },
   },
   loginContainer: {
     maxWidth: "25rem",
     height: "full",
     marginY: "auto",
-  },
-  loginHeading: {
-    my: "6rem",
-    textAlign: "center",
-    width: "100%",
   },
 };

--- a/services/ui-src/src/components/app/App.tsx
+++ b/services/ui-src/src/components/app/App.tsx
@@ -84,10 +84,15 @@ const sx = {
   appContainer: {
     display: "flex",
     maxW: "appMax",
-    padding: "0",
     flex: "1 0 auto",
+    padding: "0rem",
     section: {
-      padding: "1rem",
+      padding: "1rem 2rem",
+    },
+    ".tablet &, .mobile &": {
+      section: {
+        padding: "1rem",
+      },
     },
   },
   loginContainer: {

--- a/services/ui-src/src/components/layout/PageTemplate.tsx
+++ b/services/ui-src/src/components/layout/PageTemplate.tsx
@@ -29,7 +29,6 @@ const sx = {
   contentBox: {
     "&.standard": {
       flexShrink: "0",
-      padding: "2rem",
     },
     "&.report": {
       height: "100%",

--- a/services/ui-src/src/components/report/Elements.tsx
+++ b/services/ui-src/src/components/report/Elements.tsx
@@ -12,6 +12,7 @@ import { useStore } from "utils";
 import {
   HeaderTemplate,
   SubHeaderTemplate,
+  ParagraphTemplate,
   AccordionTemplate,
   RadioTemplate,
   ButtonLinkTemplate,
@@ -42,10 +43,17 @@ export const subHeaderElement = (props: PageElementProps) => {
 };
 
 export const paragraphElement = (props: PageElementProps) => {
+  const element = props.element as ParagraphTemplate;
+
   return (
-    <Text fontSize="18px" pb={6}>
-      {(props.element as SubHeaderTemplate).text}
-    </Text>
+    <Stack>
+      {element?.title && (
+        <Text fontSize="16px" fontWeight="bold">
+          {(props.element as ParagraphTemplate).title}
+        </Text>
+      )}
+      <Text fontSize="16px">{(props.element as ParagraphTemplate).text}</Text>
+    </Stack>
   );
 };
 

--- a/services/ui-src/src/components/report/Elements.tsx
+++ b/services/ui-src/src/components/report/Elements.tsx
@@ -27,7 +27,7 @@ export interface PageElementProps {
 
 export const headerElement = (props: PageElementProps) => {
   return (
-    <Heading fontWeight="hairline" textAlign="left" mb={6}>
+    <Heading fontWeight="hairline" textAlign="left">
       {(props.element as HeaderTemplate).text}
     </Heading>
   );

--- a/services/ui-src/src/components/report/Elements.tsx
+++ b/services/ui-src/src/components/report/Elements.tsx
@@ -27,7 +27,7 @@ export interface PageElementProps {
 
 export const headerElement = (props: PageElementProps) => {
   return (
-    <Heading fontWeight="hairline" textAlign="left">
+    <Heading as="h1" variant="h1">
       {(props.element as HeaderTemplate).text}
     </Heading>
   );
@@ -35,7 +35,7 @@ export const headerElement = (props: PageElementProps) => {
 
 export const subHeaderElement = (props: PageElementProps) => {
   return (
-    <Heading variant="subHeader">
+    <Heading as="h2" variant="subHeader">
       {(props.element as SubHeaderTemplate).text}
     </Heading>
   );

--- a/services/ui-src/src/components/report/MeasureTable.tsx
+++ b/services/ui-src/src/components/report/MeasureTable.tsx
@@ -16,7 +16,7 @@ import {
   MeasureTableTemplate,
 } from "../../types/report";
 import { PageElementProps } from "./Elements";
-import { TableStatueIcon } from "components/tables/TableStatusIcon";
+import { TableStatusIcon } from "components/tables/TableStatusIcon";
 
 export const MeasureTableElement = (props: PageElementProps) => {
   const table = props.element as MeasureTableTemplate;
@@ -47,7 +47,7 @@ export const MeasureTableElement = (props: PageElementProps) => {
     return (
       <Tr>
         <Td>
-          <TableStatueIcon tableStatus=""></TableStatueIcon>
+          <TableStatusIcon tableStatus=""></TableStatusIcon>
         </Td>
         <Td width="100%">
           <Text>{measure.title}</Text>

--- a/services/ui-src/src/components/report/MeasureTable.tsx
+++ b/services/ui-src/src/components/report/MeasureTable.tsx
@@ -7,6 +7,7 @@ import {
   Thead,
   Tr,
   Text,
+  Link,
 } from "@chakra-ui/react";
 import { useStore } from "utils";
 import { MeasureReplacementModal } from "./MeasureReplacementModal";
@@ -50,16 +51,13 @@ export const MeasureTableElement = (props: PageElementProps) => {
           <TableStatusIcon tableStatus=""></TableStatusIcon>
         </Td>
         <Td width="100%">
-          <Text>{measure.title}</Text>
+          <Text fontWeight="bold">{measure.title}</Text>
           <Text>CMIT# {measure.cmit}</Text>
         </Td>
         <Td>
-          <Button
-            variant="link"
-            onClick={() => buildModal(measure.cmit)} // TODO: modal per link
-          >
+          <Link onClick={() => buildModal(measure.cmit)}>
             Substitute measure
-          </Button>
+          </Link>
         </Td>
         <Td>
           <Button

--- a/services/ui-src/src/components/report/Page.tsx
+++ b/services/ui-src/src/components/report/Page.tsx
@@ -52,7 +52,7 @@ export const Page = ({ elements }: Props) => {
     return <ComposedElement key={index} element={element} />;
   });
   return (
-    <VStack alignItems="flex-start" gap="1.5rem">
+    <VStack alignItems="flex-start" gap="1rem">
       {composedElements}
     </VStack>
   );

--- a/services/ui-src/src/components/report/ReportPageWrapper.tsx
+++ b/services/ui-src/src/components/report/ReportPageWrapper.tsx
@@ -68,11 +68,11 @@ export const ReportPageWrapper = () => {
 
   return (
     <FormProvider {...methods}>
-      <HStack width="100%" height="100%">
+      <HStack width="100%" height="100%" position="relative">
         {currentPage.sidebar && <Sidebar />}
         <VStack
           height="100%"
-          padding="4rem 2rem 2rem 2rem"
+          padding={{ base: "4rem 1rem", md: "4rem 2rem 2rem 2rem" }}
           width="100%"
           maxWidth="640px"
           gap="6"

--- a/services/ui-src/src/components/report/ReportPageWrapper.tsx
+++ b/services/ui-src/src/components/report/ReportPageWrapper.tsx
@@ -75,7 +75,7 @@ export const ReportPageWrapper = () => {
           padding={{ base: "4rem 1rem", md: "4rem 2rem 2rem 2rem" }}
           width="100%"
           maxWidth="reportPageWidth"
-          gap="6"
+          gap="1rem"
         >
           <Box flex="auto" alignItems="flex-start" width="100%">
             <form
@@ -90,7 +90,7 @@ export const ReportPageWrapper = () => {
           </Box>
           {!currentPage.hideNavButtons && parentPage && (
             <>
-              <Divider borderColor="palette.gray_light"></Divider>
+              <Divider></Divider>
               <Flex width="100%">
                 {parentPage.index > 0 && (
                   <Button

--- a/services/ui-src/src/components/report/ReportPageWrapper.tsx
+++ b/services/ui-src/src/components/report/ReportPageWrapper.tsx
@@ -68,13 +68,13 @@ export const ReportPageWrapper = () => {
 
   return (
     <FormProvider {...methods}>
-      <HStack width="100%" height="100%" position="relative">
+      <HStack width="100%" height="100%" position="relative" spacing="0">
         {currentPage.sidebar && <Sidebar />}
         <VStack
           height="100%"
           padding={{ base: "4rem 1rem", md: "4rem 2rem 2rem 2rem" }}
           width="100%"
-          maxWidth="640px"
+          maxWidth="reportPageWidth"
           gap="6"
         >
           <Box flex="auto" alignItems="flex-start" width="100%">

--- a/services/ui-src/src/components/report/Sidebar.test.tsx
+++ b/services/ui-src/src/components/report/Sidebar.test.tsx
@@ -1,4 +1,4 @@
-import { act, render } from "@testing-library/react";
+import { act, getByAltText, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Sidebar } from "./Sidebar";
 
@@ -12,8 +12,8 @@ mockPageMap.set("child-1", 3);
 const report = {
   pages: [
     { childPageIds: ["id-1", "id-2"], id: "root" },
-    { title: "Section 1", id: "id-1" },
-    { title: "Section 2", id: "id-2", childPageIds: [] },
+    { title: "Section 1", id: "id-1", childPageIds: ["child-1"] },
+    { title: "Section 2", id: "id-2" },
     { title: "Child 1", id: "child-1" },
   ],
 };
@@ -64,14 +64,14 @@ describe("Sidebar", () => {
     expect(setCurrentPageId).toHaveBeenCalledWith("id-1");
   });
 
-  test("should collapse on Click", async () => {
-    const { getByText, getByRole, queryByText } = render(<Sidebar />);
+  test("should expand on Click", async () => {
+    const { getByText, queryByText } = render(<Sidebar />);
 
     expect(getByText("Section 1")).toBeTruthy();
     await act(async () => {
-      const button = getByRole("img");
+      const button = screen.getByAltText("Expand subitems");
       await userEvent.click(button);
     });
-    expect(queryByText("Section 1")).toBeNull();
+    expect(queryByText("Child 1")).toBeInTheDocument();
   });
 });

--- a/services/ui-src/src/components/report/Sidebar.test.tsx
+++ b/services/ui-src/src/components/report/Sidebar.test.tsx
@@ -1,4 +1,4 @@
-import { act, getByAltText, render, screen } from "@testing-library/react";
+import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { Sidebar } from "./Sidebar";
 

--- a/services/ui-src/src/components/report/Sidebar.tsx
+++ b/services/ui-src/src/components/report/Sidebar.tsx
@@ -1,4 +1,11 @@
-import { Box, Button, Heading, Flex, Image } from "@chakra-ui/react";
+import {
+  Box,
+  Button,
+  Heading,
+  Flex,
+  Image,
+  background,
+} from "@chakra-ui/react";
 import { useStore } from "utils";
 import { PageTemplate } from "../../types/report";
 import arrowDownIcon from "assets/icons/arrows/icon_arrow_down_gray.svg";
@@ -73,7 +80,7 @@ export const Sidebar = () => {
   };
 
   return (
-    <Flex height="100%">
+    <Flex height="100%" sx={sx.sidebar}>
       {isOpen && (
         <Flex flexDirection="column" background="palette.gray_lightest">
           <Heading variant="sidebar">Quality Measures Report</Heading>
@@ -95,4 +102,16 @@ export const Sidebar = () => {
       </Button>
     </Flex>
   );
+};
+
+const sx = {
+  sidebar: {
+    ".mobile &": {
+      position: "absolute",
+      display: "flex",
+      top: 0,
+      left: 0,
+      zIndex: "50",
+    },
+  },
 };

--- a/services/ui-src/src/components/report/Sidebar.tsx
+++ b/services/ui-src/src/components/report/Sidebar.tsx
@@ -106,12 +106,12 @@ export const Sidebar = () => {
 
 const sx = {
   sidebar: {
-    ".mobile &": {
-      position: "absolute",
+    ".tablet &, .mobile &": {
+      position: "fixed",
       display: "flex",
       top: 0,
       left: 0,
-      zIndex: "50",
+      zIndex: "dropdown",
     },
   },
 };

--- a/services/ui-src/src/components/report/Sidebar.tsx
+++ b/services/ui-src/src/components/report/Sidebar.tsx
@@ -1,11 +1,4 @@
-import {
-  Box,
-  Button,
-  Heading,
-  Flex,
-  Image,
-  background,
-} from "@chakra-ui/react";
+import { Box, Button, Heading, Flex, Image } from "@chakra-ui/react";
 import { useStore } from "utils";
 import { PageTemplate } from "../../types/report";
 import arrowDownIcon from "assets/icons/arrows/icon_arrow_down_gray.svg";
@@ -80,38 +73,42 @@ export const Sidebar = () => {
   };
 
   return (
-    <Flex height="100%" sx={sx.sidebar}>
-      {isOpen && (
-        <Flex flexDirection="column" background="palette.gray_lightest">
-          <Heading variant="sidebar">Quality Measures Report</Heading>
-          {pageMap
-            .get("root")
-            ?.childPageIds?.map((child) => navSection(pageMap.get(child)!))}
-        </Flex>
-      )}
-      <Button
-        aria-label="Open/Close sidebar menu"
-        variant="sidebarToggle"
-        onClick={() => setIsOpen(!isOpen)}
-      >
-        <Image
-          src={arrowDownIcon}
-          alt={isOpen ? "Arrow left" : "Arrow right"}
-          className={isOpen ? "left" : "right"}
-        />
-      </Button>
-    </Flex>
+    <Box sx={sx.sidebar}>
+      <Flex sx={sx.sidebarNav}>
+        {isOpen && (
+          <Flex flexDirection="column" background="palette.gray_lightest">
+            <Heading variant="sidebar">Quality Measures Report</Heading>
+            {pageMap
+              .get("root")
+              ?.childPageIds?.map((child) => navSection(pageMap.get(child)!))}
+          </Flex>
+        )}
+        <Button
+          aria-label="Open/Close sidebar menu"
+          variant="sidebarToggle"
+          onClick={() => setIsOpen(!isOpen)}
+        >
+          <Image
+            src={arrowDownIcon}
+            alt={isOpen ? "Arrow left" : "Arrow right"}
+            className={isOpen ? "left" : "right"}
+          />
+        </Button>
+      </Flex>
+    </Box>
   );
 };
 
 const sx = {
   sidebar: {
+    height: "100%",
+    zIndex: "dropdown",
+  },
+  sidebarNav: {
+    height: "100%",
     ".tablet &, .mobile &": {
       position: "fixed",
       display: "flex",
-      top: 0,
-      left: 0,
-      zIndex: "dropdown",
     },
   },
 };

--- a/services/ui-src/src/components/report/Sidebar.tsx
+++ b/services/ui-src/src/components/report/Sidebar.tsx
@@ -42,7 +42,8 @@ export const Sidebar = () => {
     return (
       <Box key={section.id}>
         <Button
-          variant={section.id === currentPageId ? "sidebarSelected" : "sidebar"}
+          variant={"sidebar"}
+          className={section.id === currentPageId ? "selected" : ""}
         >
           <Flex justifyContent="space-between" alignItems="center">
             <Box
@@ -74,16 +75,14 @@ export const Sidebar = () => {
   };
 
   return (
-    <Box sx={sx.sidebar}>
-      <Flex sx={isOpen ? sx.sidebarNav : ""}>
-        {isOpen && (
-          <Flex flexDirection="column" background="palette.gray_lightest">
-            <Heading variant="sidebar">Quality Measures Report</Heading>
-            {pageMap
-              .get("root")
-              ?.childPageIds?.map((child) => navSection(pageMap.get(child)!))}
-          </Flex>
-        )}
+    <Box sx={sx.sidebar} className={isOpen ? "open" : "closed"}>
+      <Flex sx={sx.sidebarNav}>
+        <Flex flexDirection="column" background="palette.gray_lightest">
+          <Heading variant="sidebar">Quality Measures Report</Heading>
+          {pageMap
+            .get("root")
+            ?.childPageIds?.map((child) => navSection(pageMap.get(child)!))}
+        </Flex>
         <Button
           aria-label="Open/Close sidebar menu"
           variant="sidebarToggle"
@@ -103,15 +102,31 @@ export const Sidebar = () => {
 
 const sx = {
   sidebar: {
+    position: "relative",
+    transition: "all 0.3s ease",
+    minWidth: "23rem",
     height: "100%",
     zIndex: "dropdown",
+    "&.open": {
+      marginLeft: "0rem",
+    },
+    "&.closed": {
+      marginLeft: "-20rem",
+    },
+    ".tablet &": {
+      position: "absolute",
+    },
+    ".mobile &": {
+      position: "absolute",
+    },
   },
   sidebarNav: {
-    transition: "all 0.3s ease",
-    position: "relative",
-    width: "22.5rem",
     height: "100%",
-    ".tablet &, .mobile &": {
+    ".tablet &": {
+      position: "fixed",
+      display: "flex",
+    },
+    ".mobile &": {
       position: "fixed",
       display: "flex",
     },

--- a/services/ui-src/src/components/report/Sidebar.tsx
+++ b/services/ui-src/src/components/report/Sidebar.tsx
@@ -111,7 +111,7 @@ const sx = {
       marginLeft: "0rem",
     },
     "&.closed": {
-      marginLeft: "-20rem",
+      marginLeft: "-20.5rem",
     },
     ".tablet &": {
       position: "absolute",

--- a/services/ui-src/src/components/report/Sidebar.tsx
+++ b/services/ui-src/src/components/report/Sidebar.tsx
@@ -1,5 +1,5 @@
 import { Box, Button, Heading, Flex, Image } from "@chakra-ui/react";
-import { useStore } from "utils";
+import { useBreakpoint, useStore } from "utils";
 import { PageTemplate } from "../../types/report";
 import arrowDownIcon from "assets/icons/arrows/icon_arrow_down_gray.svg";
 import arrowUpIcon from "assets/icons/arrows/icon_arrow_up_gray.svg";
@@ -16,7 +16,8 @@ const navItem = (title: string, index: number) => {
 
 export const Sidebar = () => {
   const { report, pageMap, currentPageId, setCurrentPageId } = useStore();
-  const [isOpen, setIsOpen] = useState<boolean>(true);
+  const { isDesktop } = useBreakpoint();
+  const [isOpen, setIsOpen] = useState<boolean>(isDesktop);
   const [toggleList, setToggleList] = useState<{ [key: string]: boolean }>({});
 
   if (!report || !pageMap) {
@@ -74,7 +75,7 @@ export const Sidebar = () => {
 
   return (
     <Box sx={sx.sidebar}>
-      <Flex sx={sx.sidebarNav}>
+      <Flex sx={isOpen ? sx.sidebarNav : ""}>
         {isOpen && (
           <Flex flexDirection="column" background="palette.gray_lightest">
             <Heading variant="sidebar">Quality Measures Report</Heading>
@@ -87,6 +88,7 @@ export const Sidebar = () => {
           aria-label="Open/Close sidebar menu"
           variant="sidebarToggle"
           onClick={() => setIsOpen(!isOpen)}
+          className={isOpen ? "open" : "closed"}
         >
           <Image
             src={arrowDownIcon}
@@ -105,6 +107,9 @@ const sx = {
     zIndex: "dropdown",
   },
   sidebarNav: {
+    transition: "all 0.3s ease",
+    position: "relative",
+    width: "22.5rem",
     height: "100%",
     ".tablet &, .mobile &": {
       position: "fixed",

--- a/services/ui-src/src/components/report/StatusTable.test.tsx
+++ b/services/ui-src/src/components/report/StatusTable.test.tsx
@@ -40,7 +40,7 @@ describe("StatusTableElement", () => {
     // Section title and status for Section 1
     expect(screen.getByText("Section 1")).toBeInTheDocument();
     expect(screen.getByText("Complete")).toBeInTheDocument();
-    expect(screen.getByAltText("icon description")).toBeInTheDocument();
+    expect(screen.getByAltText("complete icon")).toBeInTheDocument();
   });
 
   test("when Edit button is clicked call setCurrentPageId with the correct pageId", async () => {

--- a/services/ui-src/src/components/report/StatusTable.tsx
+++ b/services/ui-src/src/components/report/StatusTable.tsx
@@ -42,7 +42,11 @@ export const StatusTableElement = () => {
           <Text>{section.title}</Text>
         </Td>
         <Td>
-          <TableStatusIcon tableStatus={"error"} isPdf={true}></TableStatusIcon>
+          {/* TODO: Logic for when a page is incomplete to change status icon and text */}
+          <TableStatusIcon
+            tableStatus={"complete"}
+            isPdf={true}
+          ></TableStatusIcon>
         </Td>
         <Td>
           <Button

--- a/services/ui-src/src/components/report/StatusTable.tsx
+++ b/services/ui-src/src/components/report/StatusTable.tsx
@@ -1,6 +1,5 @@
 import {
   Button,
-  Flex,
   Image,
   Stack,
   Table,
@@ -12,12 +11,11 @@ import {
   Text,
 } from "@chakra-ui/react";
 import { useStore } from "utils";
-import iconStatusCheck from "assets/icons/status/icon_status_check.svg";
-import iconStatusError from "assets/icons/status/icon_status_alert.svg";
 import editIconPrimary from "assets/icons/edit/icon_edit_primary.svg";
 import lookupIconPrimary from "assets/icons/search/icon_search_primary.svg";
 import { ParentPageTemplate } from "types/report";
 import { useNavigate } from "react-router-dom";
+import { TableStatusIcon } from "components/tables/TableStatusIcon";
 
 export const StatusTableElement = () => {
   const { pageMap, setCurrentPageId } = useStore();
@@ -41,23 +39,13 @@ export const StatusTableElement = () => {
     return (
       <Tr key={section.pageId || index} p={0}>
         <Td>
-          <Stack flex="1">
-            <Text fontWeight="bold">{section.title}</Text>
-          </Stack>
+          <Text>{section.title}</Text>
         </Td>
         <Td>
-          <Flex align="right">
-            {/* TODO: Logic for when a page is incomplete to change status icon and text */}
-            <Image
-              src={iconStatusCheck ? iconStatusCheck : iconStatusError}
-              alt="icon description"
-            />
-            <Text ml={1}>{iconStatusCheck ? "Complete" : "Error"}</Text>
-          </Flex>
+          <TableStatusIcon tableStatus={"error"} isPdf={true}></TableStatusIcon>
         </Td>
         <Td>
           <Button
-            colorScheme="blue"
             variant="outline"
             leftIcon={<Image src={editIconPrimary} />}
             onClick={() => setCurrentPageId(section.pageId)}
@@ -70,7 +58,7 @@ export const StatusTableElement = () => {
   });
   return (
     <>
-      <Table>
+      <Table variant="status">
         <Thead>
           <Tr>
             <Th>Section</Th>

--- a/services/ui-src/src/components/tables/Table.tsx
+++ b/services/ui-src/src/components/tables/Table.tsx
@@ -119,10 +119,7 @@ const sx = {
   },
   tableHeader: {
     padding: "0.75rem 0.5rem",
-    fontSize: "sm",
-    fontWeight: "semibold",
     borderColor: "palette.gray_lighter",
-    letterSpacing: "normal",
     ".mobile &": {
       fontSize: "xs",
     },

--- a/services/ui-src/src/components/tables/Table.tsx
+++ b/services/ui-src/src/components/tables/Table.tsx
@@ -122,7 +122,6 @@ const sx = {
     fontSize: "sm",
     fontWeight: "semibold",
     borderColor: "palette.gray_lighter",
-    textTransform: "none",
     letterSpacing: "normal",
     ".mobile &": {
       fontSize: "xs",

--- a/services/ui-src/src/components/tables/TableStatusIcon.tsx
+++ b/services/ui-src/src/components/tables/TableStatusIcon.tsx
@@ -1,4 +1,4 @@
-import { Box, Image, Text } from "@chakra-ui/react";
+import { Box, HStack, Image, Text } from "@chakra-ui/react";
 import successIcon from "assets/icons/status/icon_status_check.svg";
 import unfinishedIcon from "assets/icons/status/icon_status_alert.svg";
 
@@ -33,10 +33,10 @@ export const TableStatusIcon = ({ tableStatus, isPdf }: Props) => {
   return (
     <Box>
       {status && (
-        <>
+        <HStack>
           <Image src={status.src} alt={status.alt} boxSize="xl" />
-          {isPdf && <Text fontWeight="bold">{status.text}</Text>}
-        </>
+          {isPdf && <Text>{status.text}</Text>}
+        </HStack>
       )}
     </Box>
   );

--- a/services/ui-src/src/components/tables/TableStatusIcon.tsx
+++ b/services/ui-src/src/components/tables/TableStatusIcon.tsx
@@ -11,7 +11,7 @@ export enum TableStatuses {
 
 export type TableStatusType = TableStatuses | string;
 
-export const TableStatueIcon = ({ tableStatus, isPdf }: Props) => {
+export const TableStatusIcon = ({ tableStatus, isPdf }: Props) => {
   const statusIcon = (status: TableStatusType) => {
     switch (status) {
       case TableStatuses.COMPLETE:

--- a/services/ui-src/src/components/tables/TableStatusIcon.tsx
+++ b/services/ui-src/src/components/tables/TableStatusIcon.tsx
@@ -17,13 +17,13 @@ export const TableStatusIcon = ({ tableStatus, isPdf }: Props) => {
       case TableStatuses.COMPLETE:
         return {
           src: successIcon,
-          alt: isPdf ? "" : "complete icon",
+          alt: "complete icon",
           text: "Complete",
         };
       default:
         return {
           src: unfinishedIcon,
-          alt: isPdf ? "" : "warning icon",
+          alt: "warning icon",
           text: "Error",
         };
     }

--- a/services/ui-src/src/components/tables/TableStatusIcon.tsx
+++ b/services/ui-src/src/components/tables/TableStatusIcon.tsx
@@ -35,11 +35,7 @@ export const TableStatusIcon = ({ tableStatus, isPdf }: Props) => {
       {status && (
         <>
           <Image src={status.src} alt={status.alt} boxSize="xl" />
-          {isPdf && (
-            <Text>
-              <b>{status.text}</b>
-            </Text>
-          )}
+          {isPdf && <Text fontWeight="bold">{status.text}</Text>}
         </>
       )}
     </Box>

--- a/services/ui-src/src/styles/index.scss
+++ b/services/ui-src/src/styles/index.scss
@@ -139,4 +139,8 @@ button {
 
 .ds-c-label {
   margin: 0;
+  font-size: 14px;
+  > span:first-of-type {
+    font-size: 16px;
+  }
 }

--- a/services/ui-src/src/styles/index.scss
+++ b/services/ui-src/src/styles/index.scss
@@ -144,3 +144,7 @@ button {
     font-size: 16px;
   }
 }
+
+.ds-c-field {
+  margin: 8px 0 0 0;
+}

--- a/services/ui-src/src/styles/theme.ts
+++ b/services/ui-src/src/styles/theme.ts
@@ -187,22 +187,15 @@ const theme = extendTheme({
             borderColor: "palette.secondary",
             borderWidth: "0 0 0 4px",
           },
-        },
-        sidebarSelected: {
-          display: "block",
-          textAlign: "left",
-          color: "palette.secondary_darkest",
-          backgroundColor: "palette.gray_lightest_highlight",
-          border: "1px solid",
-          borderColor: "palette.secondary",
-          borderWidth: "0 0 0 2px",
-          fontSize: "14px",
-          paddingLeft: "1rem",
-          width: "100%",
+          "&.selected": {
+            border: "1px solid",
+            borderColor: "palette.secondary",
+            borderWidth: "0 0 0 2px",
+            color: "palette.secondary_darkest",
+            backgroundColor: "palette.gray_lightest_highlight",
+          },
         },
         sidebarToggle: {
-          position: "absolute",
-          padding: "0",
           background: "palette.gray_lightest",
           borderRadius: "0px 10px 10px 0px",
           "img.left": {
@@ -210,15 +203,6 @@ const theme = extendTheme({
           },
           "img.right": {
             transform: "rotate(270deg)",
-          },
-          ".tablet &, .mobile &": {
-            position: "fixed",
-          },
-          "&.open": {
-            left: "20rem",
-          },
-          "&.closed": {
-            left: "0",
           },
         },
         outline: () => ({

--- a/services/ui-src/src/styles/theme.ts
+++ b/services/ui-src/src/styles/theme.ts
@@ -179,7 +179,7 @@ const theme = extendTheme({
           borderColor: "palette.gray_lighter",
           borderWidth: "0 0 1px 0",
           fontSize: "14px",
-          paddingLeft: "2rem",
+          paddingLeft: "1rem",
           _hover: {
             color: "palette.secondary_darkest",
             backgroundColor: "palette.gray_lightest_highlight",
@@ -195,9 +195,9 @@ const theme = extendTheme({
           backgroundColor: "palette.gray_lightest_highlight",
           border: "1px solid",
           borderColor: "palette.secondary",
-          borderWidth: "0 0 0 4px",
+          borderWidth: "0 0 0 2px",
           fontSize: "14px",
-          paddingLeft: "2rem",
+          paddingLeft: "1rem",
           width: "100%",
         },
         sidebarToggle: {
@@ -504,6 +504,10 @@ const theme = extendTheme({
             },
             a: {
               fontSize: "14px",
+              whiteSpace: "nowrap",
+              ".mobile &": {
+                whiteSpace: "wrap",
+              },
             },
           },
         },

--- a/services/ui-src/src/styles/theme.ts
+++ b/services/ui-src/src/styles/theme.ts
@@ -324,7 +324,7 @@ const theme = extendTheme({
       },
       variants: {
         h1: {
-          fontSize: "2rem",
+          fontSize: "2.25rem",
           paddingBottom: "0.5rem",
         },
         sidebar: {
@@ -334,17 +334,17 @@ const theme = extendTheme({
           margin: "0",
         },
         subHeader: {
-          fontSize: "23px",
+          fontSize: "21px",
           fontWeight: "700",
           p: {
             margin: "0",
           },
         },
-        login:{
+        login: {
           my: "6rem",
           textAlign: "center",
           width: "100%",
-        }
+        },
       },
     },
     Link: {
@@ -452,6 +452,7 @@ const theme = extendTheme({
             borderColor: "palette.gray_light",
             color: "palette.gray_medium",
             fontWeight: "bold",
+            textTransform: "none",
           },
           tr: {
             borderBottom: "1px solid",

--- a/services/ui-src/src/styles/theme.ts
+++ b/services/ui-src/src/styles/theme.ts
@@ -1,5 +1,5 @@
 // Chakra UI theme info: https://chakra-ui.com/docs/styled-system/theming/theme
-import { background, extendTheme, position } from "@chakra-ui/react";
+import { extendTheme } from "@chakra-ui/react";
 
 export const svgFilters = {
   primary:

--- a/services/ui-src/src/styles/theme.ts
+++ b/services/ui-src/src/styles/theme.ts
@@ -316,6 +316,12 @@ const theme = extendTheme({
         variant: "primary",
       },
     },
+    Divider: {
+      baseStyle: {
+        borderColor: "palette.gray_light",
+        paddingTop: "1rem",
+      },
+    },
     Heading: {
       baseStyle: {
         color: "palette.base",

--- a/services/ui-src/src/styles/theme.ts
+++ b/services/ui-src/src/styles/theme.ts
@@ -1,5 +1,5 @@
 // Chakra UI theme info: https://chakra-ui.com/docs/styled-system/theming/theme
-import { extendTheme } from "@chakra-ui/react";
+import { background, extendTheme, position } from "@chakra-ui/react";
 
 export const svgFilters = {
   primary:
@@ -201,6 +201,7 @@ const theme = extendTheme({
           width: "100%",
         },
         sidebarToggle: {
+          position: "absolute",
           padding: "0",
           background: "palette.gray_lightest",
           borderRadius: "0px 10px 10px 0px",
@@ -209,6 +210,15 @@ const theme = extendTheme({
           },
           "img.right": {
             transform: "rotate(270deg)",
+          },
+          ".tablet &, .mobile &": {
+            position: "fixed",
+          },
+          "&.open": {
+            left: "20rem",
+          },
+          "&.closed": {
+            left: "0",
           },
         },
         outline: () => ({

--- a/services/ui-src/src/styles/theme.ts
+++ b/services/ui-src/src/styles/theme.ts
@@ -461,7 +461,6 @@ const theme = extendTheme({
             borderColor: "palette.gray_light",
           },
           td: {
-            minWidth: "6rem",
             paddingLeft: 0,
             borderTop: "1px solid",
             borderBottom: "1px solid",
@@ -508,6 +507,19 @@ const theme = extendTheme({
               ".mobile &": {
                 whiteSpace: "wrap",
               },
+            },
+          },
+        },
+        status: {
+          td: {
+            fontSize: "14px",
+            padding: "0.75rem 0",
+            "&:first-of-type": {
+              width: "65%",
+              fontWeight: "bold",
+            },
+            "&:nth-child(2)": {
+              width: "25%",
             },
           },
         },

--- a/services/ui-src/src/styles/theme.ts
+++ b/services/ui-src/src/styles/theme.ts
@@ -424,6 +424,7 @@ const theme = extendTheme({
             position: "absolute",
             right: "2rem",
           },
+          borderRadius: "none",
         },
         header: {
           padding: "0 0 1.50rem 0",
@@ -518,7 +519,7 @@ const theme = extendTheme({
               width: "65%",
               fontWeight: "bold",
             },
-            "&:nth-child(2)": {
+            "&:nth-of-type(2)": {
               width: "25%",
             },
           },

--- a/services/ui-src/src/styles/theme.ts
+++ b/services/ui-src/src/styles/theme.ts
@@ -330,7 +330,7 @@ const theme = extendTheme({
         sidebar: {
           fontSize: "21px",
           fontWeight: "700",
-          padding: "32px",
+          padding: "2rem",
           margin: "0",
         },
         subHeader: {
@@ -453,6 +453,8 @@ const theme = extendTheme({
             color: "palette.gray_medium",
             fontWeight: "bold",
             textTransform: "none",
+            letterSpacing: "normal",
+            fontSize: "sm",
           },
           tr: {
             borderBottom: "1px solid",
@@ -499,6 +501,9 @@ const theme = extendTheme({
               button: {
                 fontWeight: "800",
               },
+            },
+            a: {
+              fontSize: "14px",
             },
           },
         },

--- a/services/ui-src/src/styles/theme.ts
+++ b/services/ui-src/src/styles/theme.ts
@@ -340,6 +340,11 @@ const theme = extendTheme({
             margin: "0",
           },
         },
+        login:{
+          my: "6rem",
+          textAlign: "center",
+          width: "100%",
+        }
       },
     },
     Link: {
@@ -361,7 +366,6 @@ const theme = extendTheme({
         },
         return: {
           width: "fit-content",
-          padding: "0.5rem 0 0 2rem",
           textDecoration: "none",
           _hover: {
             textDecoration: "underline",
@@ -404,7 +408,7 @@ const theme = extendTheme({
         container: {},
       },
       variants: {
-        accordian: {
+        accordion: {
           container: {
             paddingLeft: "1rem",
           },

--- a/services/ui-src/src/types/report.ts
+++ b/services/ui-src/src/types/report.ts
@@ -127,6 +127,7 @@ export type SubHeaderTemplate = {
 
 export type ParagraphTemplate = {
   type: ElementType.Paragraph;
+  title?: string;
   text: string;
 };
 


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
**1)** This PR is for fixing font sizing, padding and margin spacing for the report page layout. 
Also, the report page width has changed to the same width as MFP/MCR report page.

Examples:
![Screenshot 2024-10-23 at 1 06 53 PM](https://github.com/user-attachments/assets/08969c38-0a48-46ac-865b-523b3db00155)

![Screenshot 2024-10-23 at 1 08 44 PM](https://github.com/user-attachments/assets/12fe8163-b5ee-4d12-8bbe-5b3ce694df1e)

![Screenshot 2024-10-23 at 1 12 25 PM](https://github.com/user-attachments/assets/6802eec8-6e68-4249-a468-66e272c52a1f)

**2)** There are also code for adding/fixing mobile view.

Previous mobile view
https://github.com/user-attachments/assets/5ff609d1-592d-425d-a90c-ad8248626cfa

Updated mobile view
https://github.com/user-attachments/assets/7357398e-9a19-4c61-a166-de6855e4ce56

**3)** Other Changes:
- Fixed spelling of statue to status 
- Fixed spelling of accordian to accordion
- The sidebar now has a slide transition animation

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-3996

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Deploy Link: https://d1m9pfnv945hir.cloudfront.net/

1) Sign into HCBS, any user
2) Run through the app and make sure nothing is broken
3) To test mobile: shrink the width of your browser. We don't currently have a min width for mobile (still working on that with Megan), but it should handle up to width = 440px with no issues. 


### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->
N/A

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
