### PR TITLE
[HCBS] PRA Disclosure

### DIFF
--- a/services/ui-src/src/components/report/ReportPageWrapper.tsx
+++ b/services/ui-src/src/components/report/ReportPageWrapper.tsx
@@ -10,6 +10,8 @@ import { FormProvider, useForm } from "react-hook-form";
 import { FormPageTemplate } from "types/report";
 
 export const ReportPageWrapper = () => {
+  const praStatement =
+    "Under the Privacy Act of 1974 any personally identifying information obtained will be kept private to the extent of the law. According to the Paperwork Reduction Act of 1995, no persons are required to respond to a collection of information unless it displays a valid OMB control number. The valid OMB control number for this information collection is 0938-1053. The time required to complete this information collection is estimated to average 2.5 hours per response, including the time to review instructions, search existing data resources, gather the data needed, and complete and review the information collection. If you have comments concerning the accuracy of the time estimate(s) or suggestions for improving this form, please write to: CMS, 7500 Security Boulevard, Attn: PRA Reports Clearance Officer, Mail Stop C4-26-05, Baltimore, Maryland 21244-1850";
   const {
     report,
     pageMap,
@@ -93,7 +95,7 @@ export const ReportPageWrapper = () => {
           </Box>
           {!currentPage.hideNavButtons && parentPage && (
             <>
-              <Divider></Divider>
+              {parentPage.index == 0 && <Divider></Divider>}
               <Flex width="100%">
                 {parentPage.index > 0 && (
                   <Button
@@ -103,15 +105,35 @@ export const ReportPageWrapper = () => {
                     Previous
                   </Button>
                 )}
-                {parentPage.index < parentPage.childPageIds.length - 1 && (
+                {parentPage.index < parentPage.childPageIds.length - 1 &&
+                  parentPage.index !== 0 && (
+                    <Button
+                      onClick={() => SetPageIndex(parentPage.index + 1)}
+                      marginLeft="auto"
+                    >
+                      Continue
+                    </Button>
+                  )}
+                {parentPage.index == 0 && (
                   <Button
                     onClick={() => SetPageIndex(parentPage.index + 1)}
                     marginLeft="auto"
+                    justifyContent={"flex-end"}
                   >
                     Continue
                   </Button>
                 )}
               </Flex>
+              <Box flex="auto" width="97.5%">
+                {parentPage.index == 0 && (
+                  <>
+                    <h4>
+                      <b>PRA Disclosure Statement</b>
+                    </h4>
+                    <p>{praStatement}</p>
+                  </>
+                )}
+              </Box>
             </>
           )}
         </VStack>


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
**Other ideas:**
- Initially, I would have loved to add the PRA disclosure statement as an `ElementType.Paragraph` to our report template file: `qm.ts` but the logic to show that after the button was getting a little quirky. 
- There's also the question of whether that supports the idea of creating a `ReportPageFooter` component yet.

**Present Solution**
- Considering that this is the only content for under the buttons as of now, the most direct way was adding it to the bottom of `ReportPageWrapper`. 
- I also moved the divider because on the following pages, the divider was looking to appear twice due to the existing divider from the tables on those pages.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4001

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Login as a state user to view a Quality Measures Report, 
You should see the following content under **General Information** tab.

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
