### PR TITLE
Display Banners

### DIFF
--- a/services/ui-src/src/components/layout/HomePage.tsx
+++ b/services/ui-src/src/components/layout/HomePage.tsx
@@ -1,36 +1,61 @@
-import { Box, Heading, Link, Text } from "@chakra-ui/react";
-import { AdminDashSelector, PageTemplate, TemplateCard } from "components";
-import { useStore } from "utils";
+import { Box, Collapse, Heading, Link, Text } from "@chakra-ui/react";
+import {
+  AdminDashSelector,
+  Banner,
+  PageTemplate,
+  TemplateCard,
+} from "components";
+import { useEffect } from "react";
+import { checkDateRangeStatus, useStore } from "utils";
 import verbiage from "verbiage/pages/home";
 
 export const HomePage = () => {
+  const { bannerData, bannerActive, setBannerActive } = useStore();
   const { intro, cards } = verbiage;
   const { userIsEndUser } = useStore().user ?? {};
 
+  useEffect(() => {
+    let bannerActivity = false;
+    if (bannerData && bannerData.startDate && bannerData.endDate) {
+      bannerActivity = checkDateRangeStatus(
+        bannerData.startDate,
+        bannerData.endDate
+      );
+    }
+    setBannerActive(bannerActivity);
+  }, [bannerData]);
+
+  const showBanner = !!bannerData?.key && bannerActive;
+
   return (
-    <PageTemplate>
-      {/* show standard view to state users */}
-      {userIsEndUser ? (
-        <>
-          <Box>
-            <Heading as="h1" variant="h1">
-              {intro.header}
-            </Heading>
-            <Text>
-              {intro.body.preLinkText}
-              <Link href={intro.body.linkLocation} isExternal>
-                {intro.body.linkText}
-              </Link>
-              {intro.body.postLinkText}
-            </Text>
-            <Text></Text>
-          </Box>
-          <TemplateCard templateName="QM" verbiage={cards.QM} />
-        </>
-      ) : (
-        // show read-only view to non-state users
-        <AdminDashSelector verbiage={verbiage.readOnly} />
-      )}
-    </PageTemplate>
+    <>
+      <Collapse in={showBanner}>
+        <Banner bannerData={bannerData} />
+      </Collapse>
+      <PageTemplate>
+        {/* show standard view to state users */}
+        {userIsEndUser ? (
+          <>
+            <Box>
+              <Heading as="h1" variant="h1">
+                {intro.header}
+              </Heading>
+              <Text>
+                {intro.body.preLinkText}
+                <Link href={intro.body.linkLocation} isExternal>
+                  {intro.body.linkText}
+                </Link>
+                {intro.body.postLinkText}
+              </Text>
+              <Text></Text>
+            </Box>
+            <TemplateCard templateName="QM" verbiage={cards.QM} />
+          </>
+        ) : (
+          // show read-only view to non-state users
+          <AdminDashSelector verbiage={verbiage.readOnly} />
+        )}
+      </PageTemplate>
+    </>
   );
 };

--- a/services/ui-src/src/components/layout/HomePage.tsx
+++ b/services/ui-src/src/components/layout/HomePage.tsx
@@ -30,7 +30,9 @@ export const HomePage = () => {
   return (
     <>
       <Collapse in={showBanner}>
-        <Banner bannerData={bannerData} />
+        <Box margin="0 2rem">
+          <Banner bannerData={bannerData} />
+        </Box>
       </Collapse>
       <PageTemplate>
         {/* show standard view to state users */}


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
This PR adds the code for displaying the banner to the home page for any state user and non state user.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4091

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Deploy Link: https://d19jc7bal1zoty.cloudfront.net/

_Generate a banner to be displayed_
Follow the steps [here](https://github.com/Enterprise-CMCS/macpro-mdct-hcbs/pull/58) to generate a banner. Make sure the start and end date encompasses the current date. 

_View the Banner_
1) Once the banner is generated, if you go back to the homepage of the admin user, you should see it.
![Screenshot 2024-11-25 at 3 42 58 PM](https://github.com/user-attachments/assets/8a3a3b88-3a17-45bb-aeaa-e566e34bfa10)

2) Sign out and sign back in as a state user, any user. Once logged in, you should see the banner at the top of the page.
![Screenshot 2024-11-25 at 3 43 21 PM](https://github.com/user-attachments/assets/7f767474-2ca1-4e15-a3e7-73d872709830)


### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
