### PR TITLE
1/x Create Report by Name - Setup backend

### DIFF
--- a/services/app-api/forms/qm.ts
+++ b/services/app-api/forms/qm.ts
@@ -168,24 +168,6 @@ export const qmReportTemplate: ReportTemplate = {
         measureTemplate: MeasureTemplateName.StandardMeasure,
       },
     ],
-    optionGroups: {
-      rulesOne: [
-        {
-          cmit: 888,
-          required: true,
-          stratified: false,
-          measureTemplate: MeasureTemplateName.StandardMeasure,
-        },
-      ],
-      rulesTwo: [
-        {
-          cmit: 999,
-          required: true,
-          stratified: false,
-          measureTemplate: MeasureTemplateName.StandardMeasure,
-        },
-      ],
-    },
   },
   measureTemplates: {
     [MeasureTemplateName.StandardMeasure]: {

--- a/services/app-api/handlers/reports/buildReport.test.ts
+++ b/services/app-api/handlers/reports/buildReport.test.ts
@@ -1,4 +1,4 @@
-import { ReportType } from "../../types/reports";
+import { ReportOptions, ReportType } from "../../types/reports";
 import { User } from "../../types/types";
 import { buildReport } from "./buildReport";
 
@@ -18,7 +18,10 @@ describe("Test create report handler", () => {
       fullName: "James Holden",
       email: "james.holden@test.com",
     } as User;
-    const report = await buildReport(ReportType.QM, state, ["rulesOne"], user);
+    const reportOptions = {
+      name: "report1",
+    } as ReportOptions;
+    const report = await buildReport(ReportType.QM, state, reportOptions, user);
 
     expect(report.state).toBe("PA");
     expect(report.type).toBe(ReportType.QM);

--- a/services/app-api/handlers/reports/buildReport.ts
+++ b/services/app-api/handlers/reports/buildReport.ts
@@ -1,7 +1,12 @@
 import KSUID from "ksuid";
 import { qmReportTemplate } from "../../forms/qm";
 import { putReport } from "../../storage/reports";
-import { Report, ReportStatus, ReportType } from "../../types/reports";
+import {
+  Report,
+  ReportStatus,
+  ReportOptions,
+  ReportType,
+} from "../../types/reports";
 import { User } from "../../types/types";
 
 const reportTemplates = {
@@ -11,7 +16,7 @@ const reportTemplates = {
 export const buildReport = async (
   reportType: ReportType,
   state: string,
-  measureOptions: string[],
+  reportOptions: ReportOptions,
   user: User
 ) => {
   const report = structuredClone(reportTemplates[reportType]) as Report;
@@ -25,6 +30,7 @@ export const buildReport = async (
   report.lastEditedByEmail = user.email;
   report.type = reportType;
   report.status = ReportStatus.NOT_STARTED;
+  report.name = reportOptions.name;
 
   if (reportType == ReportType.QM) {
     /*
@@ -32,11 +38,7 @@ export const buildReport = async (
      * TODO is measure order important? May need to sort.
      * TODO could a measure be included by multiple rules? May need to deduplicate.
      */
-    const measuresFromRules = Object.entries(report.measureLookup.optionGroups)
-      .filter(([ruleName, _measures]) => measureOptions.includes(ruleName))
-      .flatMap(([_ruleName, measures]) => measures);
-    const measures =
-      report.measureLookup.defaultMeasures.concat(measuresFromRules);
+    const measures = report.measureLookup.defaultMeasures;
 
     const measurePages = measures.map((measure) => {
       // TODO: make reusable. This will be used on the optional page when adding a measure.

--- a/services/app-api/handlers/reports/buildReport.ts
+++ b/services/app-api/handlers/reports/buildReport.ts
@@ -30,7 +30,7 @@ export const buildReport = async (
   report.lastEditedByEmail = user.email;
   report.type = reportType;
   report.status = ReportStatus.NOT_STARTED;
-  report.name = reportOptions.name;
+  report.name = reportOptions["name"];
 
   if (reportType == ReportType.QM) {
     /*

--- a/services/app-api/handlers/reports/create.ts
+++ b/services/app-api/handlers/reports/create.ts
@@ -22,7 +22,6 @@ export const createReport = handler(
     }
 
     const options = body as ReportOptions;
-
     const report = await buildReport(reportType, state, options, user);
 
     return ok(report);

--- a/services/app-api/handlers/reports/create.ts
+++ b/services/app-api/handlers/reports/create.ts
@@ -4,12 +4,14 @@ import { badRequest, forbidden, ok } from "../../libs/response-lib";
 import { canWriteState } from "../../utils/authorization";
 import { error } from "../../utils/constants";
 import { buildReport } from "./buildReport";
+import { ReportOptions } from "../../types/reports";
 
 export const createReport = handler(
   parseReportTypeAndState,
   async (request) => {
     const { reportType, state } = request.parameters;
     const user = request.user;
+    const body = request.body;
 
     if (!canWriteState(user, state)) {
       return forbidden(error.UNAUTHORIZED);
@@ -18,9 +20,10 @@ export const createReport = handler(
     if (!request?.body) {
       return badRequest("Invalid request");
     }
-    // const options = JSON.parse(event.body);
 
-    const report = await buildReport(reportType, state, [], user);
+    const options = body as ReportOptions;
+
+    const report = await buildReport(reportType, state, options, user);
 
     return ok(report);
   }

--- a/services/app-api/types/reports.ts
+++ b/services/app-api/types/reports.ts
@@ -9,11 +9,8 @@ export const isReportType = (x: string | undefined): x is ReportType => {
   return Object.values(ReportType).includes(x as ReportType);
 };
 
-export interface FormOptions {
-  type: ReportType;
-  stateOptions: string[];
-  state: string | undefined;
-  createdBy: string | undefined;
+export interface ReportOptions {
+  name: string;
 }
 
 export interface CMIT {
@@ -51,6 +48,7 @@ export interface Report extends ReportTemplate {
   lastEditedBy: string;
   lastEditedByEmail: string;
   status: ReportStatus;
+  name?: string;
 }
 
 export interface MeasurePageTemplate extends FormPageTemplate {
@@ -97,7 +95,6 @@ export type ReportTemplate = {
   pages: (ParentPageTemplate | FormPageTemplate | MeasurePageTemplate)[];
   measureLookup: {
     defaultMeasures: MeasureOptions[];
-    optionGroups: Record<string, MeasureOptions[]>;
   };
   measureTemplates: Record<MeasureTemplateName, MeasurePageTemplate>;
 };

--- a/services/ui-src/src/components/pages/CreateReportOptions/CreateReportOptions.tsx
+++ b/services/ui-src/src/components/pages/CreateReportOptions/CreateReportOptions.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { useStore } from "utils";
 import { useNavigate } from "react-router-dom";
 import { createReport } from "utils/api/requestMethods/report";
+import { ReportOptions } from "types";
 
 export const CreateReportOptions = () => {
   const [rulesOne, setRulesOne] = useState("0");
@@ -13,18 +14,13 @@ export const CreateReportOptions = () => {
 
   const createForm = async () => {
     if (!state) throw new Error("Cannot create report without state on user");
-    const stateOptions = [];
 
-    // Jank but proof of concept
-    if (rulesOne == "1") {
-      stateOptions.push("rulesOne");
-    }
-    if (rulesTwo == "1") {
-      stateOptions.push("rulesTwo");
-    }
+    // proof of concept
+    const reportOptions = {
+      name: "report1",
+    } as ReportOptions;
 
-    const formOptions = { stateOptions };
-    const report = await createReport("QM", state, formOptions);
+    const report = await createReport("QM", state, reportOptions);
     navigate(`${state}/${report.id}`);
   };
 

--- a/services/ui-src/src/types/report.ts
+++ b/services/ui-src/src/types/report.ts
@@ -210,6 +210,10 @@ export enum MeasureSteward {
   CMS,
 }
 
+export interface ReportOptions {
+  name: string;
+}
+
 export interface CMIT {
   cmit: number;
   name: string;

--- a/services/ui-src/src/utils/api/requestMethods/report.test.ts
+++ b/services/ui-src/src/utils/api/requestMethods/report.test.ts
@@ -5,7 +5,7 @@ import {
   putReport,
 } from "./report";
 // types
-import { Report, ReportType } from "types/report";
+import { Report, ReportOptions, ReportType } from "types/report";
 import { AnyObject } from "types";
 
 const report = {
@@ -27,8 +27,8 @@ jest.mock("../apiLib", () => ({
 }));
 
 const mockReport = {
-  "mock-report-field": "value",
-};
+  name: "report name",
+} as ReportOptions;
 
 describe("utils/report", () => {
   beforeEach(() => {

--- a/services/ui-src/src/utils/api/requestMethods/report.ts
+++ b/services/ui-src/src/utils/api/requestMethods/report.ts
@@ -1,7 +1,6 @@
 import { apiLib } from "utils";
 import { getRequestHeaders } from "./getRequestHeaders";
-import { Report } from "types/report";
-import { ReportOptions } from "../../../../../app-api/types/reports";
+import { Report, ReportOptions } from "types/report";
 
 export async function createReport(
   reportType: string,

--- a/services/ui-src/src/utils/api/requestMethods/report.ts
+++ b/services/ui-src/src/utils/api/requestMethods/report.ts
@@ -1,11 +1,12 @@
 import { apiLib } from "utils";
 import { getRequestHeaders } from "./getRequestHeaders";
 import { Report } from "types/report";
+import { ReportOptions } from "../../../../../app-api/types/reports";
 
 export async function createReport(
   reportType: string,
   state: string,
-  reportOptions: any // TODO: correct
+  reportOptions: ReportOptions
 ) {
   const requestHeaders = await getRequestHeaders();
   const options = {


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
This is the first PR in the Create Report by Name stack. This PR sets up the backend so that a report name can be a part of createReport(). I'm restructuring FormOptions -> ReportOptions, which will for now contain one parameter "name". This is where the user-inputted name will be written to and then retrieved.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4058

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
cloudfront link: https://d14t2we268cnpm.cloudfront.net/
Make sure the app runs normally, no UI changes yet

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
