### PR TITLE
QMS - LTSS-1 - Measure Overview Page

### DIFF
--- a/services/app-api/forms/cmit.ts
+++ b/services/app-api/forms/cmit.ts
@@ -1,5 +1,9 @@
 import { CMIT } from "../types/reports";
-import { DataSource, DeliverySystem } from "../utils/constants";
+import {
+  DataSource,
+  DeliverySystem,
+  MeasureSpecification,
+} from "../utils/constants";
 
 export const CMIT_LIST: CMIT[] = [
   {
@@ -10,6 +14,7 @@ export const CMIT_LIST: CMIT[] = [
     deliverySystem: [DeliverySystem.FFS, DeliverySystem.MLTSS],
     measureSteward: "CMS",
     dataSource: DataSource.Administrative,
+    measureSpecification: [],
   },
   {
     cmit: 222,
@@ -19,5 +24,19 @@ export const CMIT_LIST: CMIT[] = [
     deliverySystem: [DeliverySystem.FFS],
     measureSteward: "CMS",
     dataSource: DataSource.Administrative,
+    measureSpecification: [],
+  },
+  {
+    cmit: 960,
+    name: "LTSS-1: Comprehensive Assessment and Update",
+    uid: "960",
+    measureSteward: "CMS",
+    measureSpecification: [
+      MeasureSpecification.CMS,
+      MeasureSpecification.HEDIS,
+    ],
+    deliverySystem: [DeliverySystem.FFS, DeliverySystem.MLTSS],
+    dataSource: DataSource.Hybrid,
+    options: "",
   },
 ];

--- a/services/app-api/forms/cmit.ts
+++ b/services/app-api/forms/cmit.ts
@@ -7,26 +7,6 @@ import {
 
 export const CMIT_LIST: CMIT[] = [
   {
-    cmit: 111,
-    name: "my measure",
-    uid: "abc",
-    options: "",
-    deliverySystem: [DeliverySystem.FFS, DeliverySystem.MLTSS],
-    measureSteward: "CMS",
-    dataSource: DataSource.Administrative,
-    measureSpecification: [],
-  },
-  {
-    cmit: 222,
-    name: "another measure",
-    uid: "cde",
-    options: "",
-    deliverySystem: [DeliverySystem.FFS],
-    measureSteward: "CMS",
-    dataSource: DataSource.Administrative,
-    measureSpecification: [],
-  },
-  {
     cmit: 960,
     name: "LTSS-1: Comprehensive Assessment and Update",
     uid: "960",

--- a/services/app-api/forms/qm.ts
+++ b/services/app-api/forms/qm.ts
@@ -4,12 +4,7 @@ import {
   ElementType,
   ReportType,
   MeasureTemplateName,
-  ButtonLinkTemplate,
-  HeaderTemplate,
-  AccordionTemplate,
-  SubHeaderTemplate,
-  RadioTemplate,
-  QualityMeasureTableTemplate,
+  MeasurePageTemplate,
 } from "../types/reports";
 
 export const qmReportTemplate: ReportTemplate = {
@@ -206,21 +201,21 @@ export const qmReportTemplate: ReportTemplate = {
           type: ElementType.ButtonLink,
           label: "Return to Required Measures Dashboard",
           to: "req-measure-result",
-        } as ButtonLinkTemplate,
+        },
         {
           type: ElementType.Header,
           text: "{measureName}",
-        } as HeaderTemplate,
+        },
         {
           type: ElementType.Accordion,
           label: "Instructions",
           value:
             "[Optional instructional content that could support the user in completing this page]",
-        } as AccordionTemplate,
+        },
         {
           type: ElementType.SubHeader,
           text: "Measure Details",
-        } as SubHeaderTemplate,
+        },
         {
           type: ElementType.Radio,
           label: "Were the reported measure results audited or validated?",
@@ -238,7 +233,7 @@ export const qmReportTemplate: ReportTemplate = {
               ],
             },
           ],
-        } as RadioTemplate,
+        },
         {
           type: ElementType.Radio,
           label:
@@ -247,7 +242,7 @@ export const qmReportTemplate: ReportTemplate = {
             { label: "CMS", value: "cms" },
             { label: "HEDIS", value: "hedis" },
           ],
-        } as RadioTemplate,
+        },
         {
           type: ElementType.Radio,
           label:
@@ -265,7 +260,7 @@ export const qmReportTemplate: ReportTemplate = {
               ],
             },
           ],
-        } as RadioTemplate,
+        },
         {
           type: ElementType.Radio,
           label: "Which delivery systems were used to report the LTSS measure?",
@@ -274,17 +269,17 @@ export const qmReportTemplate: ReportTemplate = {
             { label: "Free-For-Service", value: "fee-for-service" },
             { label: "Both", value: "both" },
           ],
-        } as RadioTemplate,
+        },
         {
           type: ElementType.SubHeader,
           text: "Quality Measures",
-        } as SubHeaderTemplate,
+        },
         {
           type: ElementType.QualityMeasureTable,
           measureDisplay: "quality",
-        } as QualityMeasureTableTemplate,
+        },
       ],
-    },
+    } as MeasurePageTemplate,
     [MeasureTemplateName["LTSS-2"]]: {
       id: "LTSS-2",
       title: "LTSS-2: Comprehensive Person-Centered Plan and Update",

--- a/services/app-api/forms/qm.ts
+++ b/services/app-api/forms/qm.ts
@@ -167,6 +167,18 @@ export const qmReportTemplate: ReportTemplate = {
         stratified: true,
         measureTemplate: MeasureTemplateName.StandardMeasure,
       },
+      {
+        cmit: 960,
+        required: false,
+        stratified: false,
+        measureTemplate: MeasureTemplateName.QualityMeasure,
+      },
+      {
+        cmit: 960,
+        required: false,
+        stratified: false,
+        measureTemplate: MeasureTemplateName.QualityMeasure,
+      },
     ],
     optionGroups: {
       rulesOne: [
@@ -196,8 +208,83 @@ export const qmReportTemplate: ReportTemplate = {
       elements: [
         {
           type: ElementType.ButtonLink,
-          label: "Return to Required Measures Results Dashboard",
+          label: "Return to Required Measures Dashboard",
           to: "req-measure-result",
+        },
+        {
+          type: ElementType.Header,
+          text: "{measureName}",
+        },
+        {
+          type: ElementType.Accordion,
+          label: "Instructions",
+          value:
+            "[Optional instructional content that could support the user in completing this page]",
+        },
+        {
+          type: ElementType.SubHeader,
+          text: "Measure Details",
+        },
+        {
+          type: ElementType.Radio,
+          label: "Do you want CMS to calculate this measure on your behalf?",
+          value: [
+            {
+              label: "No, I am reporting on this measure",
+              value: "no",
+            },
+            { label: "Yes, CMS is reporting on my behalf", value: "yes" },
+          ],
+        },
+        {
+          type: ElementType.Textbox,
+          label: "Under what authorities is this measure being reported?",
+          helperText:
+            "Please provide authority demonstration name and control number for each authority being reported.",
+        },
+        {
+          type: ElementType.Radio,
+          label:
+            "Which tehnical specification of quality measure will be reported?",
+          helperText:
+            "Select the correct technical specification for the quality measure.",
+          value: [
+            { label: "CMS", value: "cms" },
+            { label: "HEDIS", value: "hedis" },
+          ],
+        },
+        {
+          type: ElementType.Radio,
+          label:
+            "Which delivery system was used for the quality measure being reported?",
+          helperText:
+            "Select the correct delivery system for the quality measure.",
+          value: [
+            { label: "FFS", value: "ffs" },
+            { label: "MLTSS", value: "mltss" },
+            { label: "Both FFS and MLTSS (separate", value: "ffsAndMltss" },
+          ],
+        },
+        {
+          type: ElementType.SubHeader,
+          text: "Quality Measures",
+        },
+        {
+          type: ElementType.QualityMeasureTable,
+          measureDisplay: "quality",
+        },
+      ],
+    },
+    [MeasureTemplateName.QualityMeasure]: {
+      id: "req-measure-result-report",
+      title: "Example Measure Result",
+      type: PageType.Measure,
+      sidebar: false,
+      elements: [
+        {
+          type: ElementType.ButtonLink,
+          label: "Return to Required Measures Results Dashboard",
+          to: "req-measure-report",
         },
         {
           type: ElementType.Header,
@@ -216,15 +303,67 @@ export const qmReportTemplate: ReportTemplate = {
         {
           type: ElementType.Textbox,
           label:
-            "What is the state performance target for this measure established by the state?",
+            "What is the [two years in the future] state performance target for this measure established by the state?",
         },
         {
           type: ElementType.Radio,
-          label: "Is the performance target approved by CMS?",
+          label:
+            "Did the calculation of the measure results device from the measure technical specification?",
+          value: [
+            { label: "No", value: "no" },
+            { label: "Yes", value: "yes" },
+          ],
+        },
+        {
+          type: ElementType.Radio,
+          label: "Were the reported measure results audited or validated?",
+          value: [
+            { label: "No", value: "no" },
+            { label: "Yes", value: "yes" },
+          ],
+        },
+        {
+          type: ElementType.Textbox,
+          label: "Additional notes/comments",
+          helperText:
+            "If applicable, add any notes or comments to provide context to the reported measure results.",
+        },
+        {
+          type: ElementType.SubHeader,
+          text: "Measure Results",
+        },
+        {
+          type: ElementType.Paragraph,
+          title: "Overall Measure results",
+          text: "What are the overall results for this measure? To calculate the aggregate based on population weight, please use this template.",
+        },
+        {
+          type: ElementType.Textbox,
+          label: "Numerator",
+        },
+        {
+          type: ElementType.Textbox,
+          label: "Denominator",
+        },
+        {
+          type: ElementType.Textbox,
+          helperText: "Auto-calculates",
+          label: "Rate",
+        },
+        {
+          type: ElementType.SubHeader,
+          text: "Measure Stratification",
+        },
+        {
+          type: ElementType.Paragraph,
+          text: "If the stratification factor applies to this measure, select it and enter the stratified measure results specific to the demographic group. Do not select categories and sub-classifications for which you will not be reporting any data",
+        },
+        {
+          type: ElementType.Radio,
+          label: "Are you reporting measure stratification for this measure?",
           value: [
             { label: "Yes", value: "yes" },
             { label: "No", value: "no" },
-            { label: "In process", value: "inProcess" },
           ],
         },
       ],

--- a/services/app-api/forms/qm.ts
+++ b/services/app-api/forms/qm.ts
@@ -4,6 +4,12 @@ import {
   ElementType,
   ReportType,
   MeasureTemplateName,
+  ButtonLinkTemplate,
+  HeaderTemplate,
+  AccordionTemplate,
+  SubHeaderTemplate,
+  RadioTemplate,
+  QualityMeasureTableTemplate,
 } from "../types/reports";
 
 export const qmReportTemplate: ReportTemplate = {
@@ -200,21 +206,21 @@ export const qmReportTemplate: ReportTemplate = {
           type: ElementType.ButtonLink,
           label: "Return to Required Measures Dashboard",
           to: "req-measure-result",
-        },
+        } as ButtonLinkTemplate,
         {
           type: ElementType.Header,
           text: "{measureName}",
-        },
+        } as HeaderTemplate,
         {
           type: ElementType.Accordion,
           label: "Instructions",
           value:
             "[Optional instructional content that could support the user in completing this page]",
-        },
+        } as AccordionTemplate,
         {
           type: ElementType.SubHeader,
           text: "Measure Details",
-        },
+        } as SubHeaderTemplate,
         {
           type: ElementType.Radio,
           label: "Were the reported measure results audited or validated?",
@@ -232,7 +238,7 @@ export const qmReportTemplate: ReportTemplate = {
               ],
             },
           ],
-        },
+        } as RadioTemplate,
         {
           type: ElementType.Radio,
           label:
@@ -241,7 +247,7 @@ export const qmReportTemplate: ReportTemplate = {
             { label: "CMS", value: "cms" },
             { label: "HEDIS", value: "hedis" },
           ],
-        },
+        } as RadioTemplate,
         {
           type: ElementType.Radio,
           label:
@@ -259,7 +265,7 @@ export const qmReportTemplate: ReportTemplate = {
               ],
             },
           ],
-        },
+        } as RadioTemplate,
         {
           type: ElementType.Radio,
           label: "Which delivery systems were used to report the LTSS measure?",
@@ -268,15 +274,15 @@ export const qmReportTemplate: ReportTemplate = {
             { label: "Free-For-Service", value: "fee-for-service" },
             { label: "Both", value: "both" },
           ],
-        },
+        } as RadioTemplate,
         {
           type: ElementType.SubHeader,
           text: "Quality Measures",
-        },
+        } as SubHeaderTemplate,
         {
           type: ElementType.QualityMeasureTable,
           measureDisplay: "quality",
-        },
+        } as QualityMeasureTableTemplate,
       ],
     },
     [MeasureTemplateName["LTSS-2"]]: {

--- a/services/app-api/forms/qm.ts
+++ b/services/app-api/forms/qm.ts
@@ -169,15 +169,9 @@ export const qmReportTemplate: ReportTemplate = {
       },
       {
         cmit: 960,
-        required: false,
+        required: true,
         stratified: false,
-        measureTemplate: MeasureTemplateName.QualityMeasure,
-      },
-      {
-        cmit: 960,
-        required: false,
-        stratified: false,
-        measureTemplate: MeasureTemplateName.QualityMeasure,
+        measureTemplate: MeasureTemplateName.StandardMeasure,
       },
     ],
     optionGroups: {
@@ -227,27 +221,26 @@ export const qmReportTemplate: ReportTemplate = {
         },
         {
           type: ElementType.Radio,
-          label: "Do you want CMS to calculate this measure on your behalf?",
+          label: "Were the reported measure results audited or validated?",
           value: [
             {
-              label: "No, I am reporting on this measure",
-              value: "no",
+              label: "Yes, CMS is reporting on my behalf",
+              value: "yes",
+              children: [
+                {
+                  type: ElementType.Textbox,
+                  label:
+                    "What is the name of the agency of entity that audited or validated the report?",
+                },
+              ],
             },
-            { label: "Yes, CMS is reporting on my behalf", value: "yes" },
+            { label: "No, I am reporting on this measure", value: "no" },
           ],
-        },
-        {
-          type: ElementType.Textbox,
-          label: "Under what authorities is this measure being reported?",
-          helperText:
-            "Please provide authority demonstration name and control number for each authority being reported.",
         },
         {
           type: ElementType.Radio,
           label:
-            "Which tehnical specification of quality measure will be reported?",
-          helperText:
-            "Select the correct technical specification for the quality measure.",
+            "What Technical Specifications are you using to report this measure?",
           value: [
             { label: "CMS", value: "cms" },
             { label: "HEDIS", value: "hedis" },
@@ -256,13 +249,28 @@ export const qmReportTemplate: ReportTemplate = {
         {
           type: ElementType.Radio,
           label:
-            "Which delivery system was used for the quality measure being reported?",
-          helperText:
-            "Select the correct delivery system for the quality measure.",
+            "Did you deviate from the [reportYear] Technical Specifications?",
           value: [
-            { label: "FFS", value: "ffs" },
-            { label: "MLTSS", value: "mltss" },
-            { label: "Both FFS and MLTSS (separate", value: "ffsAndMltss" },
+            {
+              label: "Yes",
+              value: "yes",
+              children: [
+                {
+                  type: ElementType.Textbox,
+                  label: "Please explain the deviation.",
+                },
+              ],
+            },
+            { label: "No", value: "no" },
+          ],
+        },
+        {
+          type: ElementType.Radio,
+          label: "Which delivery systems were used to report the LTSS measure?",
+          value: [
+            { label: "Managed Care", value: "managed-care" },
+            { label: "Free-For-Service", value: "fee-for-service" },
+            { label: "Both", value: "both" },
           ],
         },
         {

--- a/services/app-api/forms/qm.ts
+++ b/services/app-api/forms/qm.ts
@@ -226,7 +226,7 @@ export const qmReportTemplate: ReportTemplate = {
             {
               label: "Yes, CMS is reporting on my behalf",
               value: "yes",
-              children: [
+              checkedChildren: [
                 {
                   type: ElementType.Textbox,
                   label:
@@ -254,7 +254,7 @@ export const qmReportTemplate: ReportTemplate = {
             {
               label: "Yes",
               value: "yes",
-              children: [
+              checkedChildren: [
                 {
                   type: ElementType.Textbox,
                   label: "Please explain the deviation.",

--- a/services/app-api/forms/qm.ts
+++ b/services/app-api/forms/qm.ts
@@ -279,7 +279,7 @@ export const qmReportTemplate: ReportTemplate = {
           measureDisplay: "quality",
         },
       ],
-    } as MeasurePageTemplate,
+    },
     [MeasureTemplateName["LTSS-2"]]: {
       id: "LTSS-2",
       title: "LTSS-2: Comprehensive Person-Centered Plan and Update",
@@ -309,5 +309,5 @@ export const qmReportTemplate: ReportTemplate = {
       sidebar: false,
       elements: [],
     },
-  },
+  } as Record<MeasureTemplateName, MeasurePageTemplate>,
 };

--- a/services/app-api/forms/qm.ts
+++ b/services/app-api/forms/qm.ts
@@ -223,6 +223,7 @@ export const qmReportTemplate: ReportTemplate = {
           type: ElementType.Radio,
           label: "Were the reported measure results audited or validated?",
           value: [
+            { label: "No, I am reporting on this measure", value: "no" },
             {
               label: "Yes, CMS is reporting on my behalf",
               value: "yes",
@@ -234,7 +235,6 @@ export const qmReportTemplate: ReportTemplate = {
                 },
               ],
             },
-            { label: "No, I am reporting on this measure", value: "no" },
           ],
         },
         {
@@ -251,6 +251,7 @@ export const qmReportTemplate: ReportTemplate = {
           label:
             "Did you deviate from the [reportYear] Technical Specifications?",
           value: [
+            { label: "No", value: "no" },
             {
               label: "Yes",
               value: "yes",
@@ -261,7 +262,6 @@ export const qmReportTemplate: ReportTemplate = {
                 },
               ],
             },
-            { label: "No", value: "no" },
           ],
         },
         {

--- a/services/app-api/forms/qm.ts
+++ b/services/app-api/forms/qm.ts
@@ -186,25 +186,14 @@ export const qmReportTemplate: ReportTemplate = {
         stratified: false,
         measureTemplate: MeasureTemplateName["LTSS-8"],
       },
-      {
-        cmit: 234,
-        required: false,
-        stratified: false,
-        measureTemplate: MeasureTemplateName.StandardMeasure,
-      },
-      {
-        cmit: 960,
-        required: true,
-        stratified: false,
-        measureTemplate: MeasureTemplateName.StandardMeasure,
-      },
     ],
   },
   measureTemplates: {
-    [MeasureTemplateName.StandardMeasure]: {
-      id: "req-measure-report",
-      title: "Example Measure",
+    [MeasureTemplateName["LTSS-1"]]: {
+      id: "LTSS-1",
+      title: "LTSS-1: Comprehensive Assessment and Update",
       type: PageType.Measure,
+      substitutable: true,
       sidebar: false,
       elements: [
         {
@@ -289,107 +278,6 @@ export const qmReportTemplate: ReportTemplate = {
           measureDisplay: "quality",
         },
       ],
-    },
-    [MeasureTemplateName.QualityMeasure]: {
-      id: "req-measure-result-report",
-      title: "Example Measure Result",
-      type: PageType.Measure,
-      sidebar: false,
-      elements: [
-        {
-          type: ElementType.ButtonLink,
-          label: "Return to Required Measures Results Dashboard",
-          to: "req-measure-report",
-        },
-        {
-          type: ElementType.Header,
-          text: "{measureName}",
-        },
-        {
-          type: ElementType.Accordion,
-          label: "Instructions",
-          value:
-            "[Optional instructional content that could support the user in completing this page]",
-        },
-        {
-          type: ElementType.SubHeader,
-          text: "Measure Information",
-        },
-        {
-          type: ElementType.Textbox,
-          label:
-            "What is the [two years in the future] state performance target for this measure established by the state?",
-        },
-        {
-          type: ElementType.Radio,
-          label:
-            "Did the calculation of the measure results device from the measure technical specification?",
-          value: [
-            { label: "No", value: "no" },
-            { label: "Yes", value: "yes" },
-          ],
-        },
-        {
-          type: ElementType.Radio,
-          label: "Were the reported measure results audited or validated?",
-          value: [
-            { label: "No", value: "no" },
-            { label: "Yes", value: "yes" },
-          ],
-        },
-        {
-          type: ElementType.Textbox,
-          label: "Additional notes/comments",
-          helperText:
-            "If applicable, add any notes or comments to provide context to the reported measure results.",
-        },
-        {
-          type: ElementType.SubHeader,
-          text: "Measure Results",
-        },
-        {
-          type: ElementType.Paragraph,
-          title: "Overall Measure results",
-          text: "What are the overall results for this measure? To calculate the aggregate based on population weight, please use this template.",
-        },
-        {
-          type: ElementType.Textbox,
-          label: "Numerator",
-        },
-        {
-          type: ElementType.Textbox,
-          label: "Denominator",
-        },
-        {
-          type: ElementType.Textbox,
-          helperText: "Auto-calculates",
-          label: "Rate",
-        },
-        {
-          type: ElementType.SubHeader,
-          text: "Measure Stratification",
-        },
-        {
-          type: ElementType.Paragraph,
-          text: "If the stratification factor applies to this measure, select it and enter the stratified measure results specific to the demographic group. Do not select categories and sub-classifications for which you will not be reporting any data",
-        },
-        {
-          type: ElementType.Radio,
-          label: "Are you reporting measure stratification for this measure?",
-          value: [
-            { label: "Yes", value: "yes" },
-            { label: "No", value: "no" },
-          ],
-        },
-      ],
-    },
-    [MeasureTemplateName["LTSS-1"]]: {
-      id: "LTSS-1",
-      title: "LTSS-1: Comprehensive Assessment and Update",
-      type: PageType.Measure,
-      substitutable: true,
-      sidebar: false,
-      elements: [],
     },
     [MeasureTemplateName["LTSS-2"]]: {
       id: "LTSS-2",

--- a/services/app-api/handlers/reports/buildReport.ts
+++ b/services/app-api/handlers/reports/buildReport.ts
@@ -1,8 +1,15 @@
 import KSUID from "ksuid";
 import { qmReportTemplate } from "../../forms/qm";
 import { putReport } from "../../storage/reports";
-import { Report, ReportStatus, ReportType } from "../../types/reports";
+import {
+  ElementType,
+  PageElement,
+  Report,
+  ReportStatus,
+  ReportType,
+} from "../../types/reports";
 import { User } from "../../types/types";
+import { CMIT_LIST } from "../../forms/cmit";
 
 const reportTemplates = {
   [ReportType.QM]: qmReportTemplate,
@@ -47,6 +54,11 @@ export const buildReport = async (
       page.id += measure.cmit; // TODO this will need some logic if a measure is substituted
       page.stratified = measure.stratified;
       page.required = measure.required;
+      page.elements = [
+        ...page.elements.map((element) =>
+          findAndReplace(element, measure.cmit)
+        ),
+      ];
       // TODO: let the parent know what it relates to
       return page;
     });
@@ -57,4 +69,14 @@ export const buildReport = async (
   // Save
   await putReport(report);
   return report;
+};
+
+export const findAndReplace = (element: PageElement, cmit: number) => {
+  const cmitInfo = CMIT_LIST.find((list) => list.cmit === cmit);
+  if (cmitInfo) {
+    if (element.type === ElementType.Header) {
+      element.text = element.text.replace("{measureName}", cmitInfo.name);
+    }
+  }
+  return element;
 };

--- a/services/app-api/types/reports.ts
+++ b/services/app-api/types/reports.ts
@@ -1,6 +1,10 @@
 // Templates
 
-import { DataSource, DeliverySystem, MeasureSpecification } from "../utils/constants";
+import {
+  DataSource,
+  DeliverySystem,
+  MeasureSpecification,
+} from "../utils/constants";
 
 export enum ReportType {
   QM = "QM",
@@ -235,6 +239,7 @@ export type ButtonLinkTemplate = {
 export type ChoiceTemplate = {
   label: string;
   value: string;
+  children?: PageElement[];
 };
 
 export type MeasureTableTemplate = {

--- a/services/app-api/types/reports.ts
+++ b/services/app-api/types/reports.ts
@@ -36,8 +36,6 @@ export interface MeasureOptions {
 }
 
 export enum MeasureTemplateName {
-  StandardMeasure,
-  QualityMeasure,
   "LTSS-1",
   "LTSS-2",
   "LTSS-6",

--- a/services/app-api/types/reports.ts
+++ b/services/app-api/types/reports.ts
@@ -175,7 +175,7 @@ export type PageElement =
   | RadioTemplate
   | ButtonLinkTemplate
   | MeasureTableTemplate
-  | QualityMeasureTable
+  | QualityMeasureTableTemplate
   | StatusTableTemplate;
 
 export type HeaderTemplate = {
@@ -249,7 +249,7 @@ export type MeasureTableTemplate = {
   measureDisplay: "required" | "stratified" | "optional";
 };
 
-export type QualityMeasureTable = {
+export type QualityMeasureTableTemplate = {
   type: ElementType.QualityMeasureTable;
   measureDisplay: "quality";
 };

--- a/services/app-api/types/reports.ts
+++ b/services/app-api/types/reports.ts
@@ -1,6 +1,6 @@
 // Templates
 
-import { DataSource, DeliverySystem } from "../utils/constants";
+import { DataSource, DeliverySystem, MeasureSpecification } from "../utils/constants";
 
 export enum ReportType {
   QM = "QM",
@@ -23,6 +23,7 @@ export interface CMIT {
   options: string;
   deliverySystem: DeliverySystem[];
   measureSteward: string;
+  measureSpecification: MeasureSpecification[];
   dataSource: DataSource;
 }
 
@@ -35,6 +36,7 @@ export interface MeasureOptions {
 
 export enum MeasureTemplateName {
   StandardMeasure,
+  QualityMeasure,
 }
 
 export enum ReportStatus {
@@ -153,6 +155,7 @@ export enum ElementType {
   Radio = "radio",
   ButtonLink = "buttonLink",
   MeasureTable = "measureTable",
+  QualityMeasureTable = "qualityMeasureTable",
   StatusTable = "statusTable",
 }
 
@@ -167,6 +170,7 @@ export type PageElement =
   | RadioTemplate
   | ButtonLinkTemplate
   | MeasureTableTemplate
+  | QualityMeasureTable
   | StatusTableTemplate;
 
 export type HeaderTemplate = {
@@ -218,6 +222,7 @@ export const isResultRowButton = (
 export type RadioTemplate = {
   type: ElementType.Radio;
   label: string;
+  helperText?: string;
   value: ChoiceTemplate[];
 };
 
@@ -235,6 +240,11 @@ export type ChoiceTemplate = {
 export type MeasureTableTemplate = {
   type: ElementType.MeasureTable;
   measureDisplay: "required" | "stratified" | "optional";
+};
+
+export type QualityMeasureTable = {
+  type: ElementType.QualityMeasureTable;
+  measureDisplay: "quality";
 };
 
 export type StatusTableTemplate = {

--- a/services/app-api/types/reports.ts
+++ b/services/app-api/types/reports.ts
@@ -239,7 +239,8 @@ export type ButtonLinkTemplate = {
 export type ChoiceTemplate = {
   label: string;
   value: string;
-  children?: PageElement[];
+  checked?: boolean;
+  checkedChildren?: PageElement[];
 };
 
 export type MeasureTableTemplate = {

--- a/services/app-api/utils/constants.ts
+++ b/services/app-api/utils/constants.ts
@@ -15,7 +15,7 @@ export enum DeliverySystem {
 export enum DataSource {
   CaseRecordManagement = "CaseRecordManagement",
   Administrative = "Administrative",
-  Hybrid = "Hybrid"
+  Hybrid = "Hybrid",
 }
 
 export enum MeasureSteward {

--- a/services/app-api/utils/constants.ts
+++ b/services/app-api/utils/constants.ts
@@ -15,10 +15,16 @@ export enum DeliverySystem {
 export enum DataSource {
   CaseRecordManagement = "CaseRecordManagement",
   Administrative = "Administrative",
+  Hybrid = "Hybrid"
 }
 
 export enum MeasureSteward {
   CMS = "CMS",
+}
+
+export enum MeasureSpecification {
+  CMS = "CMS",
+  HEDIS = "HEDIS",
 }
 
 export enum StateNames {

--- a/services/ui-src/src/cmit.ts
+++ b/services/ui-src/src/cmit.ts
@@ -1,0 +1,17 @@
+import { CMIT, DeliverySystem, DataSource, MeasureSpecification } from "types";
+
+export const CMIT_LIST: CMIT[] = [
+  {
+    cmit: 960,
+    name: "LTSS-1: Comprehensive Assessment and Update",
+    uid: "960",
+    measureSteward: "CMS",
+    measureSpecification: [
+      MeasureSpecification.CMS,
+      MeasureSpecification.HEDIS,
+    ],
+    deliverySystem: [DeliverySystem.FFS, DeliverySystem.MLTSS],
+    dataSource: DataSource.Hybrid,
+    options: "",
+  },
+];

--- a/services/ui-src/src/components/fields/RadioField.test.tsx
+++ b/services/ui-src/src/components/fields/RadioField.test.tsx
@@ -2,7 +2,7 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { RadioField } from "components";
 import { useFormContext } from "react-hook-form";
-import { PageElement } from "types";
+import { ElementType, PageElement } from "types";
 import { testA11y } from "utils/testing/commonTests";
 
 const mockTrigger = jest.fn();
@@ -37,6 +37,12 @@ const mockRadioElement = {
     {
       label: "Choice 2",
       value: "B",
+      checkedChildren: [
+        {
+          type: ElementType.Textbox,
+          label: "mock-text-box",
+        },
+      ],
       checked: false,
     },
     {
@@ -73,6 +79,17 @@ describe("<RadioField />", () => {
     expect(mockSetValue).toHaveBeenCalledWith("elements.0.answer", "A", {
       shouldValidate: true,
     });
+  });
+
+  test("RadioField displays children fields after selection", async () => {
+    mockGetValues(undefined);
+    render(RadioFieldComponent);
+    const firstRadio = screen.getByLabelText("Choice 2") as HTMLInputElement;
+    await userEvent.click(firstRadio);
+    expect(mockSetValue).toHaveBeenCalledWith("elements.0.answer", "B", {
+      shouldValidate: true,
+    });
+    expect(screen.getByLabelText("mock-text-box")).toBeInTheDocument();
   });
 
   testA11y(RadioFieldComponent, () => {

--- a/services/ui-src/src/components/fields/RadioField.tsx
+++ b/services/ui-src/src/components/fields/RadioField.tsx
@@ -10,17 +10,18 @@ import { TextField } from "components";
 export const formatChoices = (choices: ChoiceTemplate[], answer?: string) => {
   return choices.map((choice) => {
     const formatFields =
-      choice?.checkedChildren?.map((element) => {
+      choice?.checkedChildren?.map((element, index) => {
         if (element.type === ElementType.Textbox) {
           return (
-            <TextField
-              key={element.label}
-              element={{
-                type: ElementType.Textbox,
-                label: element.label,
-              }}
-              formkey={element.label}
-            ></TextField>
+            <Box key={element.label} sx={sx.children}>
+              <TextField
+                element={{
+                  type: ElementType.Textbox,
+                  label: element.label,
+                }}
+                formkey={`${choice.value}.${index}`}
+              ></TextField>
+            </Box>
           );
         }
         return <></>;
@@ -83,4 +84,13 @@ export const RadioField = (props: PageElementProps) => {
       />
     </Box>
   );
+};
+
+const sx = {
+  children: {
+    padding: "0 22px",
+    border: "4px #0071BC solid",
+    borderWidth: "0 0 0 4px",
+    margin: "0 14px",
+  },
 };

--- a/services/ui-src/src/components/fields/RadioField.tsx
+++ b/services/ui-src/src/components/fields/RadioField.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, createElement } from "react";
+import React, { useState, useEffect } from "react";
 import { Box } from "@chakra-ui/react";
 import { PageElementProps } from "components/report/Elements";
 import { useFormContext } from "react-hook-form";

--- a/services/ui-src/src/components/fields/RadioField.tsx
+++ b/services/ui-src/src/components/fields/RadioField.tsx
@@ -2,14 +2,38 @@ import React, { useState, useEffect } from "react";
 import { Box } from "@chakra-ui/react";
 import { PageElementProps } from "components/report/Elements";
 import { useFormContext } from "react-hook-form";
-import { ChoiceTemplate, RadioTemplate } from "types";
+import { ChoiceTemplate, ElementType, RadioTemplate } from "types";
 import { parseCustomHtml } from "utils";
 import { ChoiceList as CmsdsChoiceList } from "@cmsgov/design-system";
+import { TextField } from "components";
+
+export const formatChoices = (choices: ChoiceTemplate[]) => {
+  return choices.map((choice) => {
+    if (choice.children) {
+      const formatFields = choice.children.map((element) => {
+        if (element.type === ElementType.Textbox) {
+          return (
+            <TextField
+              element={{
+                type: ElementType.Textbox,
+                label: element.label,
+              }}
+              formkey={element.label}
+            ></TextField>
+          );
+        }
+        return <>Not Found</>;
+      });
+      return { ...choice, children: formatFields };
+    }
+    return choice;
+  });
+};
 
 export const RadioField = (props: PageElementProps) => {
   const radio = props.element as RadioTemplate;
 
-  const defaultValue = radio.value ?? [];
+  const defaultValue = formatChoices(radio.value) ?? [];
   const [displayValue, setDisplayValue] =
     useState<ChoiceTemplate[]>(defaultValue);
 

--- a/services/ui-src/src/components/fields/RadioField.tsx
+++ b/services/ui-src/src/components/fields/RadioField.tsx
@@ -2,34 +2,24 @@ import React, { useState, useEffect } from "react";
 import { Box } from "@chakra-ui/react";
 import { PageElementProps } from "components/report/Elements";
 import { useFormContext } from "react-hook-form";
-import { ChoiceTemplate, ElementType, RadioTemplate } from "types";
+import { ChoiceTemplate, RadioTemplate } from "types";
 import { parseCustomHtml } from "utils";
 import { ChoiceList as CmsdsChoiceList } from "@cmsgov/design-system";
-import { TextField } from "components";
+import { Page } from "components/report/Page";
 
 export const formatChoices = (choices: ChoiceTemplate[], answer?: string) => {
   return choices.map((choice) => {
-    const formatFields =
-      choice?.checkedChildren?.map((element, index) => {
-        if (element.type === ElementType.Textbox) {
-          return (
-            <Box key={element.label} sx={sx.children}>
-              <TextField
-                element={{
-                  type: ElementType.Textbox,
-                  label: element.label,
-                }}
-                formkey={`${choice.value}.${index}`}
-              ></TextField>
-            </Box>
-          );
-        }
-        return <></>;
-      }) ?? [];
+    const formatFields = choice?.checkedChildren ? (
+      <Box sx={sx.children}>
+        <Page elements={choice?.checkedChildren} />
+      </Box>
+    ) : (
+      <></>
+    );
     return {
       ...choice,
       checked: choice.value === answer,
-      checkedChildren: formatFields,
+      checkedChildren: [formatFields],
     };
   });
 };

--- a/services/ui-src/src/components/fields/RadioField.tsx
+++ b/services/ui-src/src/components/fields/RadioField.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, createElement } from "react";
 import { Box } from "@chakra-ui/react";
 import { PageElementProps } from "components/report/Elements";
 import { useFormContext } from "react-hook-form";
@@ -9,11 +9,12 @@ import { TextField } from "components";
 
 export const formatChoices = (choices: ChoiceTemplate[]) => {
   return choices.map((choice) => {
-    if (choice.children) {
-      const formatFields = choice.children.map((element) => {
+    const formatFields =
+      choice?.checkedChildren?.map((element) => {
         if (element.type === ElementType.Textbox) {
           return (
             <TextField
+              key={element.label}
               element={{
                 type: ElementType.Textbox,
                 label: element.label,
@@ -22,20 +23,20 @@ export const formatChoices = (choices: ChoiceTemplate[]) => {
             ></TextField>
           );
         }
-        return <>Not Found</>;
-      });
-      return { ...choice, children: formatFields };
-    }
-    return choice;
+        return <></>;
+      }) ?? [];
+    return {
+      ...choice,
+      checkedChildren: formatFields,
+    };
   });
 };
 
 export const RadioField = (props: PageElementProps) => {
   const radio = props.element as RadioTemplate;
-
-  const defaultValue = formatChoices(radio.value) ?? [];
-  const [displayValue, setDisplayValue] =
-    useState<ChoiceTemplate[]>(defaultValue);
+  const [displayValue, setDisplayValue] = useState<ChoiceTemplate[]>(
+    radio.value ?? []
+  );
 
   // get form context and register field
   const form = useFormContext();

--- a/services/ui-src/src/components/fields/RadioField.tsx
+++ b/services/ui-src/src/components/fields/RadioField.tsx
@@ -7,7 +7,7 @@ import { parseCustomHtml } from "utils";
 import { ChoiceList as CmsdsChoiceList } from "@cmsgov/design-system";
 import { TextField } from "components";
 
-export const formatChoices = (choices: ChoiceTemplate[]) => {
+export const formatChoices = (choices: ChoiceTemplate[], answer?: string) => {
   return choices.map((choice) => {
     const formatFields =
       choice?.checkedChildren?.map((element) => {
@@ -27,6 +27,7 @@ export const formatChoices = (choices: ChoiceTemplate[]) => {
       }) ?? [];
     return {
       ...choice,
+      checked: choice.value === answer,
       checkedChildren: formatFields,
     };
   });
@@ -35,7 +36,7 @@ export const formatChoices = (choices: ChoiceTemplate[]) => {
 export const RadioField = (props: PageElementProps) => {
   const radio = props.element as RadioTemplate;
   const [displayValue, setDisplayValue] = useState<ChoiceTemplate[]>(
-    radio.value ?? []
+    formatChoices(radio.value, radio.answer) ?? []
   );
 
   // get form context and register field

--- a/services/ui-src/src/components/report/MeasureTable.test.tsx
+++ b/services/ui-src/src/components/report/MeasureTable.test.tsx
@@ -21,6 +21,7 @@ const MeasureTableComponent = (
   ></MeasureTableElement>
 );
 
+/* To do: add real test */
 describe("Test MeasureTable", () => {
   beforeEach(() => {
     render(MeasureTableComponent);

--- a/services/ui-src/src/components/report/MeasureTable.test.tsx
+++ b/services/ui-src/src/components/report/MeasureTable.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { MeasureTableElement } from "./MeasureTable";
+import { mockUseStore } from "utils/testing/setupJest";
+import { useStore } from "utils/state/useStore";
+import { ElementType, PageElement } from "types";
+
+jest.mock("utils/state/useStore");
+const mockedUseStore = useStore as jest.MockedFunction<typeof useStore>;
+mockedUseStore.mockReturnValue(mockUseStore);
+
+const mockedMeasureTableElement = {
+  type: ElementType.MeasureTable,
+  measureDisplay: "required",
+};
+
+const MeasureTableComponent = (
+  <MeasureTableElement
+    element={mockedMeasureTableElement as unknown as PageElement}
+    formkey={""}
+  ></MeasureTableElement>
+);
+
+describe("Test MeasureTable", () => {
+  beforeEach(() => {
+    render(MeasureTableComponent);
+  });
+  it("Test MeasureTable render", () => {
+    expect(screen.getByText("mock-title")).toBeInTheDocument();
+  });
+  it("Test Sustitute button", async () => {
+    const substituteBtn = screen.getByText("Substitute measure");
+    await userEvent.click(substituteBtn);
+  });
+  it("Test Edit button", async () => {
+    const editBtn = screen.getByText("Edit");
+    await userEvent.click(editBtn);
+  });
+});

--- a/services/ui-src/src/components/report/MeasureTable.tsx
+++ b/services/ui-src/src/components/report/MeasureTable.tsx
@@ -21,8 +21,13 @@ import { TableStatusIcon } from "components/tables/TableStatusIcon";
 
 export const MeasureTableElement = (props: PageElementProps) => {
   const table = props.element as MeasureTableTemplate;
-  const { report, setModalComponent, setModalOpen, setCurrentPageId } =
-    useStore();
+  const {
+    report,
+    setMeasure,
+    setModalComponent,
+    setModalOpen,
+    setCurrentPageId,
+  } = useStore();
   const measures = report?.pages.filter((page) =>
     isMeasureTemplate(page)
   ) as MeasurePageTemplate[];
@@ -43,6 +48,11 @@ export const MeasureTableElement = (props: PageElementProps) => {
     setModalComponent(modal);
   };
 
+  const onEdit = (measure: MeasurePageTemplate) => {
+    setCurrentPageId(measure.id);
+    setMeasure(measure.cmit!);
+  };
+
   // Build Rows
   const rows = selectedMeasures.map((measure, index) => {
     return (
@@ -60,10 +70,7 @@ export const MeasureTableElement = (props: PageElementProps) => {
           </Link>
         </Td>
         <Td>
-          <Button
-            variant="outline"
-            onClick={() => setCurrentPageId(measure.id)}
-          >
+          <Button variant="outline" onClick={() => onEdit(measure)}>
             Edit
           </Button>
         </Td>

--- a/services/ui-src/src/components/report/Page.test.tsx
+++ b/services/ui-src/src/components/report/Page.test.tsx
@@ -9,6 +9,7 @@ jest.mock("react-router-dom", () => ({
 jest.mock("../../utils/state/useStore", () => ({
   useStore: () => ({
     setCurrentPageId: jest.fn(),
+    cmit: 960,
   }),
 }));
 jest.mock("react-hook-form", () => ({
@@ -68,6 +69,10 @@ const elements: PageElement[] = [
   },
   {
     type: ElementType.StatusTable,
+  },
+  {
+    type: ElementType.QualityMeasureTable,
+    measureDisplay: "quality",
   },
 ];
 

--- a/services/ui-src/src/components/report/Page.test.tsx
+++ b/services/ui-src/src/components/report/Page.test.tsx
@@ -55,7 +55,7 @@ const elements: PageElement[] = [
   {
     type: ElementType.Radio,
     label: "date label",
-    value: [{ label: "a", value: "1" }],
+    value: [{ label: "a", value: "1", checkedChildren: [] }],
   },
   {
     type: ElementType.ButtonLink,

--- a/services/ui-src/src/components/report/Page.test.tsx
+++ b/services/ui-src/src/components/report/Page.test.tsx
@@ -1,17 +1,17 @@
 import { render } from "@testing-library/react";
 import { ElementType, PageElement } from "types/report";
 import { Page } from "./Page";
+import { mockUseStore } from "utils/testing/setupJest";
+import { useStore } from "utils/state/useStore";
 
 jest.mock("react-router-dom", () => ({
   useNavigate: jest.fn(),
 }));
 
-jest.mock("../../utils/state/useStore", () => ({
-  useStore: () => ({
-    setCurrentPageId: jest.fn(),
-    cmit: 960,
-  }),
-}));
+jest.mock("utils/state/useStore");
+const mockedUseStore = useStore as jest.MockedFunction<typeof useStore>;
+mockedUseStore.mockReturnValue(mockUseStore);
+
 jest.mock("react-hook-form", () => ({
   useFormContext: () => ({
     register: jest.fn(),
@@ -22,9 +22,9 @@ jest.mock("react-hook-form", () => ({
 jest.mock("./StatusTable", () => {
   return { StatusTableElement: () => <div>Status Table</div> };
 });
-jest.mock("./MeasureTable", () => {
-  return { MeasureTableElement: () => <div>Measure Table</div> };
-});
+// jest.mock("./MeasureTable", () => {
+//   return { MeasureTableElement: () => <div>Measure Table</div> };
+// });
 
 const elements: PageElement[] = [
   {
@@ -66,6 +66,14 @@ const elements: PageElement[] = [
   {
     type: ElementType.MeasureTable,
     measureDisplay: "stratified",
+  },
+  {
+    type: ElementType.MeasureTable,
+    measureDisplay: "required",
+  },
+  {
+    type: ElementType.MeasureTable,
+    measureDisplay: "optional",
   },
   {
     type: ElementType.StatusTable,

--- a/services/ui-src/src/components/report/Page.test.tsx
+++ b/services/ui-src/src/components/report/Page.test.tsx
@@ -22,9 +22,6 @@ jest.mock("react-hook-form", () => ({
 jest.mock("./StatusTable", () => {
   return { StatusTableElement: () => <div>Status Table</div> };
 });
-// jest.mock("./MeasureTable", () => {
-//   return { MeasureTableElement: () => <div>Measure Table</div> };
-// });
 
 const elements: PageElement[] = [
   {

--- a/services/ui-src/src/components/report/Page.tsx
+++ b/services/ui-src/src/components/report/Page.tsx
@@ -8,6 +8,7 @@ import {
 } from "./Elements";
 import { assertExhaustive, ElementType, PageElement } from "../../types/report";
 import { MeasureTableElement } from "./MeasureTable";
+import { QualityMeasureTableElement } from "./QualityMeasureTable";
 import { StatusTableElement } from "./StatusTable";
 import { TextField, DateField, RadioField } from "components";
 
@@ -37,6 +38,8 @@ export const Page = ({ elements }: Props) => {
         return buttonLinkElement;
       case ElementType.MeasureTable:
         return MeasureTableElement;
+      case ElementType.QualityMeasureTable:
+        return QualityMeasureTableElement;
       case ElementType.StatusTable:
         return StatusTableElement;
       default:

--- a/services/ui-src/src/components/report/QualityMeasureTable.tsx
+++ b/services/ui-src/src/components/report/QualityMeasureTable.tsx
@@ -16,8 +16,6 @@ export const QualityMeasureTableElement = () => {
   const { cmit } = useStore();
   const cmitInfo = CMIT_LIST.find((item) => item.cmit === cmit);
 
-  const onEdit = () => {};
-
   // Build Rows
   const rows = cmitInfo?.deliverySystem.map((system, index) => {
     return (
@@ -30,7 +28,7 @@ export const QualityMeasureTableElement = () => {
           <Text>CMIT# {cmit}</Text>
         </Td>
         <Td>
-          <Button variant="outline" onClick={() => onEdit()}>
+          <Button variant="outline" onClick={() => {}}>
             Edit
           </Button>
         </Td>

--- a/services/ui-src/src/components/report/QualityMeasureTable.tsx
+++ b/services/ui-src/src/components/report/QualityMeasureTable.tsx
@@ -9,13 +9,11 @@ import {
   Text,
 } from "@chakra-ui/react";
 import { useStore } from "utils";
-import { PageElementProps } from "./Elements";
 import { TableStatusIcon } from "components/tables/TableStatusIcon";
 import { CMIT_LIST } from "cmit";
 
-export const QualityMeasureTableElement = (props: PageElementProps) => {
+export const QualityMeasureTableElement = () => {
   const { cmit } = useStore();
-
   const cmitInfo = CMIT_LIST.find((item) => item.cmit === cmit);
 
   const onEdit = () => {};

--- a/services/ui-src/src/components/report/QualityMeasureTable.tsx
+++ b/services/ui-src/src/components/report/QualityMeasureTable.tsx
@@ -1,0 +1,70 @@
+import {
+  Button,
+  Table,
+  Tbody,
+  Td,
+  Th,
+  Thead,
+  Tr,
+  Text,
+} from "@chakra-ui/react";
+import { useStore } from "utils";
+import {
+  isMeasureTemplate,
+  MeasurePageTemplate,
+  QualityMeasureTableTemplate,
+} from "../../types/report";
+import { PageElementProps } from "./Elements";
+import { TableStatusIcon } from "components/tables/TableStatusIcon";
+
+export const QualityMeasureTableElement = (props: PageElementProps) => {
+  const table = props.element as QualityMeasureTableTemplate;
+  const { report, setCurrentPageId } = useStore();
+  const measures = report?.pages.filter((page) =>
+    isMeasureTemplate(page)
+  ) as MeasurePageTemplate[];
+
+  console.log("hello");
+  console.log("measures", report);
+
+  const selectedMeasures = measures.filter(
+    (page) => table.measureDisplay == "quality"
+  );
+
+  // Build Rows
+  const rows = selectedMeasures.map((measure, index) => {
+    return (
+      <Tr key={index}>
+        <Td>
+          <TableStatusIcon tableStatus=""></TableStatusIcon>
+        </Td>
+        <Td width="100%">
+          <Text fontWeight="bold">{measure.title}</Text>
+          <Text>CMIT# {measure.cmit}</Text>
+        </Td>
+        <Td>
+          <Button
+            variant="outline"
+            onClick={() => setCurrentPageId(measure.id)}
+          >
+            Edit
+          </Button>
+        </Td>
+      </Tr>
+    );
+  });
+  return (
+    <Table variant="measure">
+      <Thead>
+        <Tr>
+          <Th></Th>
+          <Th>
+            Measure Name <br />
+            CMIT Number
+          </Th>
+        </Tr>
+      </Thead>
+      <Tbody>{rows}</Tbody>
+    </Table>
+  );
+};

--- a/services/ui-src/src/components/report/QualityMeasureTable.tsx
+++ b/services/ui-src/src/components/report/QualityMeasureTable.tsx
@@ -19,16 +19,13 @@ import { TableStatusIcon } from "components/tables/TableStatusIcon";
 
 export const QualityMeasureTableElement = (props: PageElementProps) => {
   const table = props.element as QualityMeasureTableTemplate;
-  const { report, setCurrentPageId } = useStore();
+  const { report, cmit, setCurrentPageId } = useStore();
   const measures = report?.pages.filter((page) =>
     isMeasureTemplate(page)
   ) as MeasurePageTemplate[];
 
-  console.log("hello");
-  console.log("measures", report);
-
   const selectedMeasures = measures.filter(
-    (page) => table.measureDisplay == "quality"
+    (_page) => table.measureDisplay == "quality"
   );
 
   // Build Rows

--- a/services/ui-src/src/components/report/QualityMeasureTable.tsx
+++ b/services/ui-src/src/components/report/QualityMeasureTable.tsx
@@ -9,41 +9,30 @@ import {
   Text,
 } from "@chakra-ui/react";
 import { useStore } from "utils";
-import {
-  isMeasureTemplate,
-  MeasurePageTemplate,
-  QualityMeasureTableTemplate,
-} from "../../types/report";
 import { PageElementProps } from "./Elements";
 import { TableStatusIcon } from "components/tables/TableStatusIcon";
+import { CMIT_LIST } from "cmit";
 
 export const QualityMeasureTableElement = (props: PageElementProps) => {
-  const table = props.element as QualityMeasureTableTemplate;
-  const { report, cmit, setCurrentPageId } = useStore();
-  const measures = report?.pages.filter((page) =>
-    isMeasureTemplate(page)
-  ) as MeasurePageTemplate[];
+  const { cmit } = useStore();
 
-  const selectedMeasures = measures.filter(
-    (_page) => table.measureDisplay == "quality"
-  );
+  const cmitInfo = CMIT_LIST.find((item) => item.cmit === cmit);
+
+  const onEdit = () => {};
 
   // Build Rows
-  const rows = selectedMeasures.map((measure, index) => {
+  const rows = cmitInfo?.deliverySystem.map((system, index) => {
     return (
       <Tr key={index}>
         <Td>
           <TableStatusIcon tableStatus=""></TableStatusIcon>
         </Td>
         <Td width="100%">
-          <Text fontWeight="bold">{measure.title}</Text>
-          <Text>CMIT# {measure.cmit}</Text>
+          <Text fontWeight="bold">Delivery Method: {system}</Text>
+          <Text>CMIT# {cmit}</Text>
         </Td>
         <Td>
-          <Button
-            variant="outline"
-            onClick={() => setCurrentPageId(measure.id)}
-          >
+          <Button variant="outline" onClick={() => onEdit()}>
             Edit
           </Button>
         </Td>

--- a/services/ui-src/src/components/report/ReportPageWrapper.test.tsx
+++ b/services/ui-src/src/components/report/ReportPageWrapper.test.tsx
@@ -1,6 +1,7 @@
 import { render, waitFor } from "@testing-library/react";
 import {
   ElementType,
+  MeasurePageTemplate,
   MeasureTemplateName,
   PageType,
   Report,
@@ -69,7 +70,7 @@ const testReport: Report = {
           measureDisplay: "quality",
         },
       ],
-    },
+    } as MeasurePageTemplate,
     [MeasureTemplateName["LTSS-2"]]: {
       id: "",
       title: "",

--- a/services/ui-src/src/components/report/ReportPageWrapper.test.tsx
+++ b/services/ui-src/src/components/report/ReportPageWrapper.test.tsx
@@ -53,7 +53,7 @@ const testReport: Report = {
   ],
   measureLookup: { defaultMeasures: [], optionGroups: {} },
   measureTemplates: {
-    [MeasureTemplateName.StandardMeasure]: {
+    [MeasureTemplateName["LTSS-1"]]: {
       id: "req-measure-report",
       title: "Example Measure",
       type: PageType.Measure,
@@ -65,6 +65,30 @@ const testReport: Report = {
           to: "req-measure-result",
         },
       ],
+    },
+    [MeasureTemplateName["LTSS-2"]]: {
+      id: "",
+      title: "",
+      type: PageType.Measure,
+      elements: [],
+    },
+    [MeasureTemplateName["LTSS-6"]]: {
+      id: "",
+      title: "",
+      type: PageType.Measure,
+      elements: [],
+    },
+    [MeasureTemplateName["LTSS-7"]]: {
+      id: "",
+      title: "",
+      type: PageType.Measure,
+      elements: [],
+    },
+    [MeasureTemplateName["LTSS-8"]]: {
+      id: "",
+      title: "",
+      type: PageType.Measure,
+      elements: [],
     },
   },
 };

--- a/services/ui-src/src/components/report/ReportPageWrapper.test.tsx
+++ b/services/ui-src/src/components/report/ReportPageWrapper.test.tsx
@@ -64,6 +64,10 @@ const testReport: Report = {
           label: "Return to Required Measures Results Dashboard",
           to: "req-measure-result",
         },
+        {
+          type: ElementType.QualityMeasureTable,
+          measureDisplay: "quality",
+        },
       ],
     },
     [MeasureTemplateName["LTSS-2"]]: {

--- a/services/ui-src/src/components/report/ReportPageWrapper.test.tsx
+++ b/services/ui-src/src/components/report/ReportPageWrapper.test.tsx
@@ -70,7 +70,7 @@ const testReport: Report = {
           measureDisplay: "quality",
         },
       ],
-    } as MeasurePageTemplate,
+    },
     [MeasureTemplateName["LTSS-2"]]: {
       id: "",
       title: "",
@@ -95,7 +95,7 @@ const testReport: Report = {
       type: PageType.Measure,
       elements: [],
     },
-  },
+  } as Record<MeasureTemplateName, MeasurePageTemplate>,
 };
 
 const mockUseParams = jest.fn();

--- a/services/ui-src/src/types/report.ts
+++ b/services/ui-src/src/types/report.ts
@@ -201,21 +201,27 @@ export type ChoiceTemplate = {
   label: string;
   value: string;
   checked?: boolean;
-  children: PageElement[];
+  checkedChildren: PageElement[];
 };
 
 export enum DeliverySystem {
-  FFS,
-  MLTSS,
+  FFS = "FFS",
+  MLTSS = "MLTSS",
 }
 
 export enum DataSource {
   CaseRecordManagement,
   Administrative,
+  Hybrid,
 }
 
 export enum MeasureSteward {
   CMS,
+}
+
+export enum MeasureSpecification {
+  CMS = "CMS",
+  HEDIS = "HEDIS",
 }
 
 export interface CMIT {
@@ -225,6 +231,7 @@ export interface CMIT {
   options: string;
   deliverySystem: DeliverySystem[];
   measureSteward: string;
+  measureSpecification: MeasureSpecification[];
   dataSource: DataSource;
 }
 

--- a/services/ui-src/src/types/report.ts
+++ b/services/ui-src/src/types/report.ts
@@ -116,6 +116,7 @@ export enum ElementType {
   Radio = "radio",
   ButtonLink = "buttonLink",
   MeasureTable = "measureTable",
+  QualityMeasureTable = "qualityMeasureTable",
   StatusTable = "statusTable",
 }
 
@@ -129,6 +130,7 @@ export type PageElement =
   | RadioTemplate
   | ButtonLinkTemplate
   | MeasureTableTemplate
+  | QualityMeasureTableTemplate
   | StatusTableTemplate;
 
 export type HeaderTemplate = {
@@ -170,6 +172,11 @@ export type AccordionTemplate = {
 export type MeasureTableTemplate = {
   type: ElementType.MeasureTable;
   measureDisplay: "required" | "stratified" | "optional";
+};
+
+export type QualityMeasureTableTemplate = {
+  type: ElementType.QualityMeasureTable;
+  measureDisplay: "quality";
 };
 
 export type StatusTableTemplate = {

--- a/services/ui-src/src/types/report.ts
+++ b/services/ui-src/src/types/report.ts
@@ -201,6 +201,7 @@ export type ChoiceTemplate = {
   label: string;
   value: string;
   checked?: boolean;
+  children: PageElement[];
 };
 
 export enum DeliverySystem {

--- a/services/ui-src/src/types/report.ts
+++ b/services/ui-src/src/types/report.ts
@@ -248,7 +248,11 @@ export interface MeasureOptions {
 }
 
 export enum MeasureTemplateName {
-  StandardMeasure,
+  "LTSS-1",
+  "LTSS-2",
+  "LTSS-6",
+  "LTSS-7",
+  "LTSS-8",
 }
 
 export interface FormComponent {

--- a/services/ui-src/src/types/states.ts
+++ b/services/ui-src/src/types/states.ts
@@ -39,6 +39,7 @@ export interface HcbsReportState {
   modalOpen: boolean;
   modalComponent?: React.ReactFragment;
   lastSavedTime?: string;
+  cmit?: number;
 
   // ACTIONS
   setReport: (report?: Report) => void;
@@ -46,4 +47,5 @@ export interface HcbsReportState {
   setModalOpen: (modalOpen: boolean) => void;
   setModalComponent: (modalComponent: React.ReactFragment) => void;
   setAnswers: (answers: any) => void;
+  setMeasure: (cmit: number) => void;
 }

--- a/services/ui-src/src/utils/state/management/reportState.test.ts
+++ b/services/ui-src/src/utils/state/management/reportState.test.ts
@@ -1,6 +1,7 @@
 import { HcbsReportState } from "types";
 import {
   ElementType,
+  MeasurePageTemplate,
   MeasureTemplateName,
   PageType,
   Report,
@@ -57,7 +58,7 @@ const testReport: Report = {
   ],
   measureLookup: { defaultMeasures: [], optionGroups: {} },
   measureTemplates: {
-    [MeasureTemplateName.StandardMeasure]: {
+    [MeasureTemplateName["LTSS-1"]]: {
       id: "req-measure-report",
       title: "Example Measure",
       type: PageType.Measure,
@@ -68,7 +69,35 @@ const testReport: Report = {
           label: "Return to Required Measures Results Dashboard",
           to: "req-measure-result",
         },
+        {
+          type: ElementType.QualityMeasureTable,
+          measureDisplay: "quality",
+        },
       ],
+    } as MeasurePageTemplate,
+    [MeasureTemplateName["LTSS-2"]]: {
+      id: "",
+      title: "",
+      type: PageType.Measure,
+      elements: [],
+    },
+    [MeasureTemplateName["LTSS-6"]]: {
+      id: "",
+      title: "",
+      type: PageType.Measure,
+      elements: [],
+    },
+    [MeasureTemplateName["LTSS-7"]]: {
+      id: "",
+      title: "",
+      type: PageType.Measure,
+      elements: [],
+    },
+    [MeasureTemplateName["LTSS-8"]]: {
+      id: "",
+      title: "",
+      type: PageType.Measure,
+      elements: [],
     },
   },
 };

--- a/services/ui-src/src/utils/state/management/reportState.test.ts
+++ b/services/ui-src/src/utils/state/management/reportState.test.ts
@@ -99,7 +99,7 @@ const testReport: Report = {
       type: PageType.Measure,
       elements: [],
     },
-  },
+  } as Record<MeasureTemplateName, MeasurePageTemplate>,
 };
 
 describe("state/management/reportState: buildState", () => {

--- a/services/ui-src/src/utils/state/useStore.ts
+++ b/services/ui-src/src/utils/state/useStore.ts
@@ -68,6 +68,7 @@ const reportStore = (set: Function): HcbsReportState => ({
   modalOpen: false,
   modalComponent: undefined,
   lastSavedTime: undefined,
+  cmit: undefined,
 
   // actions
   setReport: (report: Report | undefined) =>
@@ -88,6 +89,9 @@ const reportStore = (set: Function): HcbsReportState => ({
     set((state: HcbsReportState) => mergeAnswers(answers, state), false, {
       type: "setAnswers",
     }),
+  setMeasure: (cmit: number) => {
+    set(() => ({ cmit }), false, { type: "setMeasure" });
+  },
 });
 
 export const useStore = create(

--- a/services/ui-src/src/utils/testing/setupJest.tsx
+++ b/services/ui-src/src/utils/testing/setupJest.tsx
@@ -8,6 +8,8 @@ import {
   HcbsUserState,
   UserContextShape,
   AdminBannerState,
+  HcbsReportState,
+  Report,
 } from "types";
 import { mockBannerData } from "./mockBanner";
 // GLOBALS
@@ -182,12 +184,25 @@ export const mockAdminUserStore: HcbsUserState = {
   setShowLocalLogins: () => {},
 };
 
+export const mockReportStore: HcbsReportState = {
+  modalOpen: false,
+  cmit: 960,
+  setReport: () => {},
+  setCurrentPageId: () => {},
+  setModalOpen: () => {},
+  setModalComponent: () => {},
+  setAnswers: () => {},
+  setMeasure: () => {},
+};
+
 // BOUND STORE
 
-export const mockUseStore: HcbsUserState & AdminBannerState = {
-  ...mockStateUserStore,
-  ...mockBannerStore,
-};
+export const mockUseStore: HcbsUserState & AdminBannerState & HcbsReportState =
+  {
+    ...mockStateUserStore,
+    ...mockBannerStore,
+    ...mockReportStore,
+  };
 
 export const mockUseAdminStore: HcbsUserState & AdminBannerState = {
   ...mockAdminUserStore,

--- a/services/ui-src/src/utils/testing/setupJest.tsx
+++ b/services/ui-src/src/utils/testing/setupJest.tsx
@@ -13,6 +13,7 @@ import {
   ReportStatus,
   PageType,
   MeasureTemplateName,
+  MeasurePageTemplate,
 } from "types";
 import { mockBannerData } from "./mockBanner";
 // GLOBALS
@@ -187,10 +188,12 @@ export const mockAdminUserStore: HcbsUserState = {
   setShowLocalLogins: () => {},
 };
 
-const mockMeasureTemplate = {
+const mockMeasureTemplate: MeasurePageTemplate = {
   id: "mock-template-id",
   title: "mock-title",
   type: PageType.Measure,
+  required: true,
+  substitutable: true,
   elements: [],
 };
 

--- a/services/ui-src/src/utils/testing/setupJest.tsx
+++ b/services/ui-src/src/utils/testing/setupJest.tsx
@@ -9,7 +9,10 @@ import {
   UserContextShape,
   AdminBannerState,
   HcbsReportState,
-  Report,
+  ReportType,
+  ReportStatus,
+  PageType,
+  MeasureTemplateName,
 } from "types";
 import { mockBannerData } from "./mockBanner";
 // GLOBALS
@@ -184,9 +187,44 @@ export const mockAdminUserStore: HcbsUserState = {
   setShowLocalLogins: () => {},
 };
 
+const mockMeasureTemplate = {
+  id: "mock-template-id",
+  title: "mock-title",
+  type: PageType.Measure,
+  elements: [],
+};
+
 export const mockReportStore: HcbsReportState = {
   modalOpen: false,
   cmit: 960,
+  report: {
+    id: "mock-id",
+    type: ReportType.QM,
+    status: ReportStatus.IN_PROGRESS,
+    title: "mock-report-title",
+    state: "PR",
+    pages: [{ ...mockMeasureTemplate, cmit: 960 }],
+    measureLookup: {
+      defaultMeasures: [],
+      optionGroups: {},
+    },
+    measureTemplates: {
+      [MeasureTemplateName["LTSS-1"]]: {
+        ...mockMeasureTemplate,
+        required: true,
+      },
+      [MeasureTemplateName["LTSS-2"]]: {
+        ...mockMeasureTemplate,
+        optional: true,
+      },
+      [MeasureTemplateName["LTSS-6"]]: {
+        ...mockMeasureTemplate,
+        stratified: true,
+      },
+      [MeasureTemplateName["LTSS-7"]]: mockMeasureTemplate,
+      [MeasureTemplateName["LTSS-8"]]: mockMeasureTemplate,
+    },
+  },
   setReport: () => {},
   setCurrentPageId: () => {},
   setModalOpen: () => {},


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
This PR builds out LTSS-1 measure overview page. The content of what's suppose to be on this page is written in the jira ticket, the figma is just for a general idea of what the page might look like,

I also expanded the radio button to have children elements underneath. 
![Screenshot 2024-12-03 at 3 52 55 PM](https://github.com/user-attachments/assets/30341a89-6ad6-45c2-a469-a34171e63ee8)

**Note**
1) Children textboxes of the radio button currently does not save any data. Will address in a separate PR.
2) The quality measure table [Edit] buttons do not go anywhere yet. Also will address in a separate PR. 

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4139

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
1) Sign into HCBS, any state user
2) Create a QM report
3) On the sidebar menu, select [**Required Measure Results**]. You should see a row for CMIT # 960.
     - The generation for this table is covered by another ticket.
4) Click [**Edit**] and you be taken to the  LTSS-1 measure overview page.
5) Check that the questions matches what is written in the jira ticket: CMDCT-4139.
6) You should see a page that looks like this
![localhost_3000_report_QM_PR_2pir7juQ4TtESKqww3nP30icY6A](https://github.com/user-attachments/assets/b21cb2c6-6068-404c-8053-d617ea88b389)


### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
