### PR TITLE
LTSS-3 Measure Overview Page

### DIFF
--- a/services/app-api/forms/cmit.ts
+++ b/services/app-api/forms/cmit.ts
@@ -19,4 +19,17 @@ export const CMIT_LIST: CMIT[] = [
     dataSource: DataSource.Hybrid,
     options: "",
   },
+  {
+    cmit: 963,
+    name: "LTSS-3: Shared Person-Centered Plan with Primary Care Provider",
+    uid: "963",
+    measureSteward: "CMS",
+    measureSpecification: [
+      MeasureSpecification.CMS,
+      MeasureSpecification.HEDIS,
+    ],
+    deliverySystem: [DeliverySystem.FFS, DeliverySystem.MLTSS],
+    dataSource: DataSource.Hybrid,
+    options: "",
+  },
 ];

--- a/services/app-api/forms/qm.ts
+++ b/services/app-api/forms/qm.ts
@@ -375,7 +375,89 @@ export const qmReportTemplate: ReportTemplate = {
       title: "LTSS-3: Shared Person-Centered Plan with Primary Care Provider",
       type: PageType.Measure,
       sidebar: false,
-      elements: [],
+      elements: [
+        {
+          type: ElementType.ButtonLink,
+          label: "Return to Optional Measures Dashboard",
+          to: "optional-measure-result",
+        },
+        {
+          type: ElementType.Header,
+          text: "{measureName}",
+        },
+        {
+          type: ElementType.Accordion,
+          label: "Instructions",
+          value:
+            "[Optional instructional content that could support the user in completing this page]",
+        },
+        {
+          type: ElementType.SubHeader,
+          text: "Measure Details",
+        },
+        {
+          type: ElementType.Radio,
+          label: "Were the reported measure results audited or validated?",
+          value: [
+            { label: "No, I am reporting on this measure", value: "no" },
+            {
+              label: "Yes, CMS is reporting on my behalf",
+              value: "yes",
+              checkedChildren: [
+                {
+                  type: ElementType.Textbox,
+                  label:
+                    "What is the name of the agency of entity that audited or validated the report?",
+                },
+              ],
+            },
+          ],
+        },
+        {
+          type: ElementType.Radio,
+          label:
+            "What Technical Specifications are you using to report this measure?",
+          value: [
+            { label: "CMS", value: "cms" },
+            { label: "HEDIS", value: "hedis" },
+          ],
+        },
+        {
+          type: ElementType.Radio,
+          label:
+            "Did you deviate from the [reportYear] Technical Specifications?",
+          value: [
+            { label: "No", value: "no" },
+            {
+              label: "Yes",
+              value: "yes",
+              checkedChildren: [
+                {
+                  type: ElementType.Textbox,
+                  label: "Please explain the deviation.",
+                },
+              ],
+            },
+          ],
+        },
+        {
+          type: ElementType.Radio,
+          label: "Which delivery systems were used to report the LTSS measure?",
+          value: [
+            { label: "Managed Care", value: "managed-care" },
+            { label: "Free-For-Service", value: "fee-for-service" },
+            { label: "Both", value: "both" },
+          ],
+        },
+        {
+          type: ElementType.SubHeader,
+          text: "Quality Measures",
+        },
+        {
+          type: ElementType.QualityMeasureTable,
+          measureDisplay: "quality",
+        },
+      ],
     },
     [MeasureTemplateName["LTSS-4"]]: {
       id: "LTSS-4",

--- a/services/ui-src/src/cmit.ts
+++ b/services/ui-src/src/cmit.ts
@@ -14,4 +14,17 @@ export const CMIT_LIST: CMIT[] = [
     dataSource: DataSource.Hybrid,
     options: "",
   },
+  {
+    cmit: 963,
+    name: "LTSS-3: Shared Person-Centered Plan with Primary Care Provider",
+    uid: "963",
+    measureSteward: "CMS",
+    measureSpecification: [
+      MeasureSpecification.CMS,
+      MeasureSpecification.HEDIS,
+    ],
+    deliverySystem: [DeliverySystem.FFS, DeliverySystem.MLTSS],
+    dataSource: DataSource.Hybrid,
+    options: "",
+  },
 ];


### PR DESCRIPTION
### Description
This PR adds the content for the LTSS-3 measure.
As of now, thanks to the all the great work done in setting up [LTSS-1](https://github.com/Enterprise-CMCS/macpro-mdct-hcbs/pull/66), I only had to update the qm.ts and cmit.ts files.

#### For this requirement: 
> I propose, holding off on the edit button going to a blank page at least until the routing by page id PR is merged in, so there's consistency with how we're routing.
 - Clicking the edit button should take you to that measure's delivery method page.

Notes from LTSS-1
1. Children textboxes of the radio button currently does not save any data. Address in a separate PR.
2. The quality measure table [Edit] buttons do not go anywhere yet. Address in a separate PR.

### Related ticket(s)
CMDCT-4143

---
### How to test

1. Sign into HCBS, any state user
2. Create a QM report
3. On the sidebar menu, select [Optional Measure Results]. 
   - The 4th row down will be LTSS-3, CMIT # 963.
4. Click [Edit] and you be taken to the LTSS-3 measure overview page.
5. Check that the questions matches what is written in the jira ticket: [CMDCT-4143](https://jiraent.cms.gov/browse/CMDCT-4143) - same as LTSS-1
6. You should see a page that looks like this
     ![LTSS-3](https://github.com/user-attachments/assets/2186e12e-66ff-4c34-aa69-b008758ff993)


### Important updates

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---