### PR TITLE
QMS - LTSS-2 - Measure Overview Page

### DIFF
--- a/services/app-api/forms/cmit.ts
+++ b/services/app-api/forms/cmit.ts
@@ -19,4 +19,17 @@ export const CMIT_LIST: CMIT[] = [
     dataSource: DataSource.Hybrid,
     options: "",
   },
+  {
+    cmit: 961,
+    name: "LTSS-2: Comprehensive Person-Centered Plan and Update",
+    uid: "961",
+    measureSteward: "CMS",
+    measureSpecification: [
+      MeasureSpecification.CMS,
+      MeasureSpecification.HEDIS,
+    ],
+    deliverySystem: [DeliverySystem.FFS, DeliverySystem.MLTSS],
+    dataSource: DataSource.Hybrid,
+    options: "",
+  },
 ];

--- a/services/app-api/forms/qm.ts
+++ b/services/app-api/forms/qm.ts
@@ -324,7 +324,89 @@ export const qmReportTemplate: ReportTemplate = {
       type: PageType.Measure,
       sidebar: false,
       substitutable: true,
-      elements: [],
+      elements: [
+        {
+          type: ElementType.ButtonLink,
+          label: "Return to Optional Measures Dashboard",
+          to: "optional-measure-result",
+        },
+        {
+          type: ElementType.Header,
+          text: "{measureName}",
+        },
+        {
+          type: ElementType.Accordion,
+          label: "Instructions",
+          value:
+            "[Optional instructional content that could support the user in completing this page]",
+        },
+        {
+          type: ElementType.SubHeader,
+          text: "Measure Details",
+        },
+        {
+          type: ElementType.Radio,
+          label: "Were the reported measure results audited or validated?",
+          value: [
+            { label: "No, I am reporting on this measure", value: "no" },
+            {
+              label: "Yes, CMS is reporting on my behalf",
+              value: "yes",
+              checkedChildren: [
+                {
+                  type: ElementType.Textbox,
+                  label:
+                    "What is the name of the agency of entity that audited or validated the report?",
+                },
+              ],
+            },
+          ],
+        },
+        {
+          type: ElementType.Radio,
+          label:
+            "What Technical Specifications are you using to report this measure?",
+          value: [
+            { label: "CMS", value: "cms" },
+            { label: "HEDIS", value: "hedis" },
+          ],
+        },
+        {
+          type: ElementType.Radio,
+          label:
+            "Did you deviate from the [reportYear] Technical Specifications?",
+          value: [
+            { label: "No", value: "no" },
+            {
+              label: "Yes",
+              value: "yes",
+              checkedChildren: [
+                {
+                  type: ElementType.Textbox,
+                  label: "Please explain the deviation.",
+                },
+              ],
+            },
+          ],
+        },
+        {
+          type: ElementType.Radio,
+          label: "Which delivery systems were used to report the LTSS measure?",
+          value: [
+            { label: "Managed Care", value: "managed-care" },
+            { label: "Fee-For-Service", value: "fee-for-service" },
+            { label: "Both", value: "both" },
+          ],
+        },
+        {
+          type: ElementType.SubHeader,
+          text: "Quality Measures",
+        },
+        {
+          type: ElementType.QualityMeasureTable,
+          measureDisplay: "quality",
+        },
+      ],
     },
     [MeasureTemplateName["LTSS-6"]]: {
       id: "LTSS-6",

--- a/services/ui-src/src/cmit.ts
+++ b/services/ui-src/src/cmit.ts
@@ -14,4 +14,18 @@ export const CMIT_LIST: CMIT[] = [
     dataSource: DataSource.Hybrid,
     options: "",
   },
+
+  {
+    cmit: 961,
+    name: "LTSS-2: Comprehensive Person-Centered Plan and Update",
+    uid: "961",
+    measureSteward: "CMS",
+    measureSpecification: [
+      MeasureSpecification.CMS,
+      MeasureSpecification.HEDIS,
+    ],
+    deliverySystem: [DeliverySystem.FFS, DeliverySystem.MLTSS],
+    dataSource: DataSource.Hybrid,
+    options: "",
+  },
 ];


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
This PR adds the content for the LTSS-2 measure overview page. The content of what's suppose to be on this page is written in the jira ticket, the figma is just for a general idea of what the page might look like

Notes from LTSS-3:
"I propose, holding off on the edit button going to a blank page at least until the routing by page id PR is merged in, so there's consistency with how we're routing."

Notes from LTSS-1:
"Children textboxes of the radio button currently does not save any data. Address in a separate PR."
"The quality measure table [Edit] buttons do not go anywhere yet. Address in a separate PR."

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4141

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Sign into HCBS, any state user: https://d23qdxt8dq336v.cloudfront.net/
Create a QM report
On the sidebar menu, select [Required Measure Results]. You should see a row for CMIT # 961.
The generation for this table is covered by another ticket.
Click [Edit] and you be taken to the LTSS-2 measure overview page.
Check that the questions matches what is written in the jira ticket: [CMDCT-4141](https://jiraent.cms.gov/browse/CMDCT-4141).
You should see a page that looks like this
<img width="385" alt="Screenshot 2024-12-11 at 10 21 07 AM" src="https://github.com/user-attachments/assets/d43e704c-8459-4435-8ea8-5077dab8b962" />


### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
