### PR TITLE
CMDCT-4185: adding edit button to dashboard table rows so that user can edit report name

### DIFF
--- a/services/ui-src/src/components/modals/AddEditReportModal.test.tsx
+++ b/services/ui-src/src/components/modals/AddEditReportModal.test.tsx
@@ -14,7 +14,7 @@ const mockReportHandler = jest.fn();
 jest.mock("utils/state/useStore");
 const mockedUseStore = useStore as jest.MockedFunction<typeof useStore>;
 
-const modalComponent = (
+const addModalComponent = (
   <RouterWrappedComponent>
     <AddEditReportModal
       activeState="AB"
@@ -28,35 +28,87 @@ const modalComponent = (
   </RouterWrappedComponent>
 );
 
-describe("Test AddEditProgramModal", () => {
+const editModalComponent = (
+  <RouterWrappedComponent>
+    <AddEditReportModal
+      activeState="AB"
+      reportType={"QM"}
+      modalDisclosure={{
+        isOpen: true,
+        onClose: mockCloseHandler,
+      }}
+      reportHandler={mockReportHandler}
+      selectedReport={
+        {
+          name: "report name thing",
+        } as unknown as any
+      }
+    />
+  </RouterWrappedComponent>
+);
+
+describe("Test general modal functionality", () => {
   beforeEach(() => {
     mockedUseStore.mockReturnValue(mockStateUserStore);
-    render(modalComponent);
+    render(addModalComponent);
   });
 
   afterEach(() => {
     jest.clearAllMocks();
   });
 
-  test("AddEditReportModal shows the contents", () => {
-    expect(screen.getByText("QMS report name")).toBeInTheDocument();
-    expect(screen.getByText("Start new")).toBeInTheDocument();
-  });
-
-  test("AddEditReportModal top close button can be clicked", async () => {
+  test("Modal top close button can be clicked", async () => {
     await userEvent.click(screen.getByText("Close"));
     expect(mockCloseHandler).toHaveBeenCalledTimes(1);
   });
 
-  test("AddEditReportModal bottom cancel button can be clicked", async () => {
+  test("Modal bottom cancel button can be clicked", async () => {
     await userEvent.click(screen.getByText("Cancel"));
     expect(mockCloseHandler).toHaveBeenCalledTimes(1);
   });
 });
 
+describe("Test Add Report Modal", () => {
+  beforeEach(() => {
+    mockedUseStore.mockReturnValue(mockStateUserStore);
+    render(addModalComponent);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("Add Report Modal shows proper add contents", () => {
+    expect(
+      screen.getByText("Add new Quality Measure Set Report")
+    ).toBeInTheDocument();
+    expect(screen.getByText("QMS report name")).toBeInTheDocument();
+    expect(screen.getByText("Start new")).toBeInTheDocument();
+  });
+});
+
+describe("Test Edit Report Modal", () => {
+  beforeEach(() => {
+    mockedUseStore.mockReturnValue(mockStateUserStore);
+    render(editModalComponent);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test("Edit report modal shows the proper edit contents with editable name", () => {
+    expect(
+      screen.getByText("Edit Quality Measure Set Report")
+    ).toBeInTheDocument();
+    expect(screen.getByText("Save")).toBeInTheDocument();
+    expect(screen.getByDisplayValue("report name thing")).toBeInTheDocument();
+  });
+});
+
 describe("Test AddEditReportModal accessibility", () => {
   it("Should not have basic accessibility issues", async () => {
-    const { container } = render(modalComponent);
+    const { container } = render(addModalComponent);
     const results = await axe(container);
     expect(results).toHaveNoViolations();
   });

--- a/services/ui-src/src/components/pages/Dashboard/DashboardPage.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardPage.tsx
@@ -29,6 +29,9 @@ export const DashboardPage = () => {
   const { reportType, state } = useParams();
   const [isLoading, setIsLoading] = useState(true);
   const [reports, setReports] = useState<Report[]>([]);
+  const [selectedReport, setSelectedReport] = useState<Report | undefined>(
+    undefined
+  );
   const { intro, body } = dashboardVerbiage;
   const fullStateName = StateNames[state as keyof typeof StateNames];
 
@@ -49,9 +52,8 @@ export const DashboardPage = () => {
     })();
   };
 
-  const openAddEditReportModal = () => {
-    // TO-DO: setSelectedReport with formData
-
+  const openAddEditReportModal = (report?: Report) => {
+    setSelectedReport(report);
     // use disclosure to open modal
     addEditReportModalOnOpenHandler();
   };
@@ -85,7 +87,13 @@ export const DashboardPage = () => {
         {parseCustomHtml(intro.body)}
       </Box>
       <Flex sx={sx.bodyBox} gap="2rem" flexDirection="column">
-        {!isLoading && <DashboardTable reports={reports} />}
+        {!isLoading && (
+          <DashboardTable
+            reports={reports}
+            openAddEditReportModal={openAddEditReportModal}
+            readOnlyUser={!userIsEndUser}
+          />
+        )}
         {!reports?.length && <Text variant="tableEmpty">{body.empty}</Text>}
         {userIsEndUser && (
           <Flex justifyContent="center">
@@ -103,6 +111,7 @@ export const DashboardPage = () => {
           onClose: addEditReportModalOnCloseHandler,
         }}
         reportHandler={reloadReports}
+        selectedReport={selectedReport}
       />
     </PageTemplate>
   );

--- a/services/ui-src/src/components/pages/Dashboard/DashboardTable.test.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardTable.test.tsx
@@ -1,0 +1,48 @@
+import { render, screen } from "@testing-library/react";
+import { DashboardTable } from "components";
+import { RouterWrappedComponent } from "utils/testing/setupJest";
+
+const dashboardTableComponent = (
+  <RouterWrappedComponent>
+    <DashboardTable
+      reports={[
+        {
+          name: "report 1",
+        } as unknown as any,
+      ]}
+      openAddEditReportModal={jest.fn}
+    />
+  </RouterWrappedComponent>
+);
+
+const readOnlyDashboardTableComponent = (
+  <RouterWrappedComponent>
+    <DashboardTable
+      reports={[
+        {
+          name: "report 1",
+        } as unknown as any,
+      ]}
+      openAddEditReportModal={jest.fn}
+      readOnlyUser={true}
+    />
+  </RouterWrappedComponent>
+);
+
+describe("Dashboard table with state user", () => {
+  beforeEach(() => jest.clearAllMocks());
+  it("should render report name and edit button in table", async () => {
+    render(dashboardTableComponent);
+    expect(screen.getByText("report 1")).toBeInTheDocument();
+    expect(screen.getByAltText("Edit Report")).toBeInTheDocument();
+  });
+});
+
+describe("Dashboard table with Read only user", () => {
+  beforeEach(() => jest.clearAllMocks());
+  it("should not render the edit button when read only", async () => {
+    render(readOnlyDashboardTableComponent);
+    expect(screen.getByText("report 1")).toBeInTheDocument();
+    expect(screen.queryByAltText("Edit Report")).not.toBeInTheDocument();
+  });
+});

--- a/services/ui-src/src/components/pages/Dashboard/DashboardTable.test.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardTable.test.tsx
@@ -34,7 +34,7 @@ describe("Dashboard table with state user", () => {
   it("should render report name and edit button in table", async () => {
     render(dashboardTableComponent);
     expect(screen.getByText("report 1")).toBeInTheDocument();
-    expect(screen.getByAltText("Edit Report")).toBeInTheDocument();
+    expect(screen.getByAltText("Edit Report Name")).toBeInTheDocument();
   });
 });
 
@@ -43,6 +43,6 @@ describe("Dashboard table with Read only user", () => {
   it("should not render the edit button when read only", async () => {
     render(readOnlyDashboardTableComponent);
     expect(screen.getByText("report 1")).toBeInTheDocument();
-    expect(screen.queryByAltText("Edit Report")).not.toBeInTheDocument();
+    expect(screen.queryByAltText("Edit Report Name")).not.toBeInTheDocument();
   });
 });

--- a/services/ui-src/src/components/pages/Dashboard/DashboardTable.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardTable.tsx
@@ -11,6 +11,15 @@ interface DashboardTableProps {
   openAddEditReportModal: Function;
 }
 
+/**
+ * Return the dashboard table column headers. If user is admin, there will be
+ * an extra empty row that is for the edit report name button column.
+ */
+const getHeadRow = (readOnlyUser?: boolean) =>
+  readOnlyUser
+    ? ["Submission name", "Last edited", "Edited by", "Status", ""]
+    : ["", "Submission name", "Last edited", "Edited by", "Status", ""];
+
 export const DashboardTable = ({
   reports,
   readOnlyUser,
@@ -23,14 +32,9 @@ export const DashboardTable = ({
   const editButtonText = isStateUser ? "Edit" : "View";
 
   const tableContent = {
-    caption: "Quality Measure Reports",
-    headRow: ["", "Submission name", "Last edited", "Edited by", "Status", ""],
+    caption: "QMR",
+    headRow: getHeadRow(readOnlyUser),
   };
-
-  // pop off the edit button heading if the user is read only
-  if (readOnlyUser) {
-    tableContent.headRow.shift();
-  }
 
   return (
     <Table content={tableContent}>
@@ -39,7 +43,7 @@ export const DashboardTable = ({
           {!readOnlyUser && (
             <Td fontWeight={"bold"}>
               <button onClick={() => openAddEditReportModal(report)}>
-                <Image src={editIcon} alt="Edit Report" />
+                <Image src={editIcon} alt="Edit Report Name" />
               </button>
             </Td>
           )}

--- a/services/ui-src/src/components/pages/Dashboard/DashboardTable.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardTable.tsx
@@ -1,14 +1,21 @@
-import { Button, Td, Tr } from "@chakra-ui/react";
+import { Button, Image, Td, Tr } from "@chakra-ui/react";
 import { Table } from "components";
 import { useNavigate } from "react-router-dom";
 import { Report, UserRoles } from "types";
 import { formatMonthDayYear, reportBasePath, useStore } from "utils";
+import editIcon from "assets/icons/edit/icon_edit_square_gray.svg";
 
 interface DashboardTableProps {
   reports: Report[];
+  readOnlyUser?: boolean;
+  openAddEditReportModal: Function;
 }
 
-export const DashboardTable = ({ reports }: DashboardTableProps) => {
+export const DashboardTable = ({
+  reports,
+  readOnlyUser,
+  openAddEditReportModal,
+}: DashboardTableProps) => {
   const navigate = useNavigate();
   const store = useStore();
   const user = store.user;
@@ -17,13 +24,25 @@ export const DashboardTable = ({ reports }: DashboardTableProps) => {
 
   const tableContent = {
     caption: "Quality Measure Reports",
-    headRow: ["Submission name", "Last edited", "Edited by", "Status", ""],
+    headRow: ["", "Submission name", "Last edited", "Edited by", "Status", ""],
   };
+
+  // pop off the edit button heading if the user is read only
+  if (readOnlyUser) {
+    tableContent.headRow.shift();
+  }
 
   return (
     <Table content={tableContent}>
       {reports.map((report) => (
         <Tr key={report.id}>
+          {!readOnlyUser && (
+            <Td fontWeight={"bold"}>
+              <button onClick={() => openAddEditReportModal(report)}>
+                <Image src={editIcon} alt="Edit Report" />
+              </button>
+            </Td>
+          )}
           <Td fontWeight={"bold"}>
             {report.name ? report.name : "{Name of form}"}
           </Td>

--- a/services/ui-src/src/components/pages/Dashboard/DashboardTable.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardTable.tsx
@@ -32,7 +32,7 @@ export const DashboardTable = ({
   const editButtonText = isStateUser ? "Edit" : "View";
 
   const tableContent = {
-    caption: "QMR",
+    caption: "Quality Measure Reports",
     headRow: getHeadRow(readOnlyUser),
   };
 


### PR DESCRIPTION
### Description
Pretty simple PR to allow users to edit report name from the dashboard table. I went pretty simple here since there is just one field. I did not use any useForm magic so let me know if that is more appropriate here.


### Related ticket(s)
CMDCT-4185

---
### How to test
https://d2nvrsyhsh8gv1.cloudfront.net/

Test as state user:
1. Log in as any state user
2. Navigate to report table
3. You should see an edit button next to every report. Click on the edit button and you should see the edit modal
4. it should say "Edit Quality Measure Set Report" and the button should say "Save"
5. The text box should be populated with the current name. Change the name and hit save and the row should update with the name you just changed to
6. Click on the edit button again and the name in the text field should reflect the current name
7. hit save without editing the name and it should keep the same name

Test as read only user:
1. Log in as any read only user (helpdeskuser@test.com)
2. Navigate to report table
3. You should not see any edit button column, as read only users will not have the power to edit report names

