### PR TITLE
Disable delivery system edit buttons, unless selected

### DIFF
--- a/services/app-api/forms/qms.ts
+++ b/services/app-api/forms/qms.ts
@@ -6,6 +6,7 @@ import {
   MeasureTemplateName,
   MeasurePageTemplate,
 } from "../types/reports";
+import { DeliverySystem } from "../utils/constants";
 
 export const qmsReportTemplate: ReportTemplate = {
   type: ReportType.QMS,
@@ -306,16 +307,17 @@ export const qmsReportTemplate: ReportTemplate = {
         },
         {
           type: ElementType.Radio,
+          formKey: "delivery-method-radio",
           label: "Which delivery systems were used to report this measure?",
           value: [
-            { label: "Fee-For-Service (FFS)", value: "fee-for-service" },
+            { label: "Fee-For-Service (FFS)", value: DeliverySystem.FFS },
             {
               label: "Managed Long-Term Services and Supports (MLTSS)",
-              value: "managed-long-term-services-and-supports",
+              value: DeliverySystem.MLTSS,
             },
             {
               label: "Both FFS and MLTSS (separate)",
-              value: "both-ffs-and-mltss",
+              value: [DeliverySystem.FFS, DeliverySystem.MLTSS].join(","),
             },
           ],
         },
@@ -401,16 +403,17 @@ export const qmsReportTemplate: ReportTemplate = {
         },
         {
           type: ElementType.Radio,
+          formKey: "delivery-method-radio",
           label: "Which delivery systems were used to report this measure?",
           value: [
-            { label: "Fee-For-Service (FFS)", value: "fee-for-service" },
+            { label: "Fee-For-Service (FFS)", value: DeliverySystem.FFS },
             {
               label: "Managed Long-Term Services and Supports (MLTSS)",
-              value: "managed-long-term-services-and-supports",
+              value: DeliverySystem.MLTSS,
             },
             {
               label: "Both FFS and MLTSS (separate)",
-              value: "both-ffs-and-mltss",
+              value: [DeliverySystem.FFS, DeliverySystem.MLTSS].join(","),
             },
           ],
         },
@@ -497,16 +500,17 @@ export const qmsReportTemplate: ReportTemplate = {
         },
         {
           type: ElementType.Radio,
+          formKey: "delivery-method-radio",
           label: "Which delivery systems were used to report this measure?",
           value: [
-            { label: "Fee-For-Service (FFS)", value: "fee-for-service" },
+            { label: "Fee-For-Service (FFS)", value: DeliverySystem.FFS },
             {
               label: "Managed Long-Term Services and Supports (MLTSS)",
-              value: "managed-long-term-services-and-supports",
+              value: DeliverySystem.MLTSS,
             },
             {
               label: "Both FFS and MLTSS (separate)",
-              value: "both-ffs-and-mltss",
+              value: [DeliverySystem.FFS, DeliverySystem.MLTSS].join(","),
             },
           ],
         },
@@ -593,16 +597,17 @@ export const qmsReportTemplate: ReportTemplate = {
         },
         {
           type: ElementType.Radio,
+          formKey: "delivery-method-radio",
           label: "Which delivery systems were used to report this measure?",
           value: [
-            { label: "Fee-For-Service (FFS)", value: "fee-for-service" },
+            { label: "Fee-For-Service (FFS)", value: DeliverySystem.FFS },
             {
               label: "Managed Long-Term Services and Supports (MLTSS)",
-              value: "managed-long-term-services-and-supports",
+              value: DeliverySystem.MLTSS,
             },
             {
               label: "Both FFS and MLTSS (separate)",
-              value: "both-ffs-and-mltss",
+              value: [DeliverySystem.FFS, DeliverySystem.MLTSS].join(","),
             },
           ],
         },
@@ -689,16 +694,17 @@ export const qmsReportTemplate: ReportTemplate = {
         },
         {
           type: ElementType.Radio,
+          formKey: "delivery-method-radio",
           label: "Which delivery systems were used to report this measure?",
           value: [
-            { label: "Fee-For-Service (FFS)", value: "fee-for-service" },
+            { label: "Fee-For-Service (FFS)", value: DeliverySystem.FFS },
             {
               label: "Managed Long-Term Services and Supports (MLTSS)",
-              value: "managed-long-term-services-and-supports",
+              value: DeliverySystem.MLTSS,
             },
             {
               label: "Both FFS and MLTSS (separate)",
-              value: "both-ffs-and-mltss",
+              value: [DeliverySystem.FFS, DeliverySystem.MLTSS].join(","),
             },
           ],
         },
@@ -776,16 +782,17 @@ export const qmsReportTemplate: ReportTemplate = {
         },
         {
           type: ElementType.Radio,
+          formKey: "delivery-method-radio",
           label: "Which delivery systems were used to report this measure?",
           value: [
-            { label: "Fee-For-Service (FFS)", value: "fee-for-service" },
+            { label: "Fee-For-Service (FFS)", value: DeliverySystem.FFS },
             {
               label: "Managed Long-Term Services and Supports (MLTSS)",
-              value: "managed-long-term-services-and-supports",
+              value: DeliverySystem.MLTSS,
             },
             {
               label: "Both FFS and MLTSS (separate)",
-              value: "both-ffs-and-mltss",
+              value: [DeliverySystem.FFS, DeliverySystem.MLTSS].join(","),
             },
           ],
         },
@@ -862,16 +869,17 @@ export const qmsReportTemplate: ReportTemplate = {
         },
         {
           type: ElementType.Radio,
+          formKey: "delivery-method-radio",
           label: "Which delivery systems were used to report this measure?",
           value: [
-            { label: "Fee-For-Service (FFS)", value: "fee-for-service" },
+            { label: "Fee-For-Service (FFS)", value: DeliverySystem.FFS },
             {
               label: "Managed Long-Term Services and Supports (MLTSS)",
-              value: "managed-long-term-services-and-supports",
+              value: DeliverySystem.MLTSS,
             },
             {
               label: "Both FFS and MLTSS (separate)",
-              value: "both-ffs-and-mltss",
+              value: [DeliverySystem.FFS, DeliverySystem.MLTSS].join(","),
             },
           ],
         },
@@ -1028,16 +1036,17 @@ export const qmsReportTemplate: ReportTemplate = {
         },
         {
           type: ElementType.Radio,
+          formKey: "delivery-method-radio",
           label: "Which delivery systems were used to report this measure?",
           value: [
-            { label: "Fee-For-Service (FFS)", value: "fee-for-service" },
+            { label: "Fee-For-Service (FFS)", value: DeliverySystem.FFS },
             {
               label: "Managed Long-Term Services and Supports (MLTSS)",
-              value: "managed-long-term-services-and-supports",
+              value: DeliverySystem.MLTSS,
             },
             {
               label: "Both FFS and MLTSS (separate)",
-              value: "both-ffs-and-mltss",
+              value: [DeliverySystem.FFS, DeliverySystem.MLTSS].join(","),
             },
           ],
         },
@@ -1123,16 +1132,17 @@ export const qmsReportTemplate: ReportTemplate = {
         },
         {
           type: ElementType.Radio,
+          formKey: "delivery-method-radio",
           label: "Which delivery systems were used to report this measure?",
           value: [
-            { label: "Fee-For-Service (FFS)", value: "fee-for-service" },
+            { label: "Fee-For-Service (FFS)", value: DeliverySystem.FFS },
             {
               label: "Managed Long-Term Services and Supports (MLTSS)",
-              value: "managed-long-term-services-and-supports",
+              value: DeliverySystem.MLTSS,
             },
             {
               label: "Both FFS and MLTSS (separate)",
-              value: "both-ffs-and-mltss",
+              value: [DeliverySystem.FFS, DeliverySystem.MLTSS].join(","),
             },
           ],
         },

--- a/services/ui-src/src/components/report/Page.test.tsx
+++ b/services/ui-src/src/components/report/Page.test.tsx
@@ -21,6 +21,7 @@ mockedUseStore.mockReturnValue(mockUseStore);
 jest.mock("react-hook-form", () => ({
   useFormContext: () => ({
     register: jest.fn(),
+    getValues: jest.fn(),
   }),
 }));
 

--- a/services/ui-src/src/components/report/Page.tsx
+++ b/services/ui-src/src/components/report/Page.tsx
@@ -52,9 +52,10 @@ export const Page = ({ elements }: Props) => {
 
   const composedElements = elements.map((element, index) => {
     const ComposedElement = renderElement(element);
+    const formKey = (element as any).formKey ?? buildFormKey(index);
     return (
       <ComposedElement
-        formkey={buildFormKey(index)}
+        formkey={formKey}
         key={index}
         element={element}
         disabled={!userIsEndUser}

--- a/services/ui-src/src/components/report/QualityMeasureTable.test.tsx
+++ b/services/ui-src/src/components/report/QualityMeasureTable.test.tsx
@@ -1,0 +1,28 @@
+import { QualityMeasureTableElement } from "./QualityMeasureTable";
+import { render, screen } from "@testing-library/react";
+import { useStore } from "utils";
+import { mockUseStore } from "utils/testing/setupJest";
+
+jest.mock("utils/state/useStore");
+const mockedUseStore = useStore as jest.MockedFunction<typeof useStore>;
+mockedUseStore.mockReturnValue({ ...mockUseStore });
+
+jest.mock("react-hook-form", () => ({
+  useFormContext: jest.fn().mockReturnValue({
+    getValues: jest.fn().mockReturnValue({ answer: "FFS" }),
+  }),
+}));
+
+describe("Quality Measure Table", () => {
+  it("should enable each delivery system's button correctly", () => {
+    render(<QualityMeasureTableElement />);
+
+    const ffsRow = screen.getByRole("row", { name: /FFS CMIT# 960/ });
+    const ffsButton = ffsRow.querySelector("button");
+    expect(ffsButton).toBeEnabled();
+
+    const mltssRow = screen.getByRole("row", { name: /MLTSS CMIT# 960/ });
+    const mltssButton = mltssRow.querySelector("button");
+    expect(mltssButton).toBeDisabled();
+  });
+});

--- a/services/ui-src/src/components/report/QualityMeasureTable.tsx
+++ b/services/ui-src/src/components/report/QualityMeasureTable.tsx
@@ -20,7 +20,7 @@ export const QualityMeasureTableElement = () => {
 
   // Build Rows
   const rows = cmitInfo?.deliverySystem.map((system, index) => {
-    const selections = form.getValues("delivery-method-radio").answer ?? "";
+    const selections = form.getValues("delivery-method-radio")?.answer ?? "";
     const deliverySystemIsSelected = selections.split(",").includes(system);
 
     return (

--- a/services/ui-src/src/components/report/QualityMeasureTable.tsx
+++ b/services/ui-src/src/components/report/QualityMeasureTable.tsx
@@ -11,13 +11,18 @@ import {
 import { useStore } from "utils";
 import { TableStatusIcon } from "components/tables/TableStatusIcon";
 import { CMIT_LIST } from "cmit";
+import { useFormContext } from "react-hook-form";
 
 export const QualityMeasureTableElement = () => {
   const { cmit } = useStore();
   const cmitInfo = CMIT_LIST.find((item) => item.cmit === cmit);
+  const form = useFormContext();
 
   // Build Rows
   const rows = cmitInfo?.deliverySystem.map((system, index) => {
+    const selections = form.getValues("delivery-method-radio").answer ?? "";
+    const deliverySystemIsSelected = selections.split(",").includes(system);
+
     return (
       <Tr key={index}>
         <Td>
@@ -28,7 +33,11 @@ export const QualityMeasureTableElement = () => {
           <Text>CMIT# {cmit}</Text>
         </Td>
         <Td>
-          <Button variant="outline" onClick={() => {}}>
+          <Button
+            variant="outline"
+            disabled={!deliverySystemIsSelected}
+            onClick={() => {}}
+          >
             Edit
           </Button>
         </Td>


### PR DESCRIPTION
### Description
At the bottom of each measure page is a table of delivery systems, with an Edit button for each row. But users are only required to report on the delivery system(s) they indicated they would report on, in a prior question. This pull request wires up these buttons' enabled/disabled states to that prior question.

![image](https://github.com/user-attachments/assets/e1e46505-03ea-4fa3-8c3f-6cc8af28e7ed)

In order to make this happen, I added a field called `formKey` to the delivery system selection radio button. Most inputs will have an auto-generated name like `"elements.7"`; these radio buttons will now have fixed names. Then I can query React Hook Form by the appropriate name to get the selected delivery system instantly (that is, without waiting for the report to update in the store).

I also changed the values of the radio buttons. Whereas previously we had `semantic-kebab-case` values, now the values correspond directly the `DeliverySystem` enum - with multiple systems joined by commas if necessary.

In the future, we may want to add a `formKey` property to the rest of our elements. I don't love the code I added in Page.tsx to "maybe use the formKey we have, or maybe generate one". I'm not sure how much work would be involved in convincing Typescript that the elements we care about will always have form keys. It's possible that we will be able to remove that code entirely, by restructuring the `ComposedElement` pattern... somehow. In fact, we may want to do that before merging this PR. I request your opinion, dear reviewer.

### Related ticket(s)
CMDCT-4182

---
### How to test
1. Log in as a state user
2. Create a QMS report
3. Go to "Required Measure Results" or "Optional Measure Results"
4. Select a measure to update which allows for multiple Delivery Systems, such as FASI or LTSS
5. Note that at the bottom of the page, both rows of the Delivery Systems table have disabled "Edit" buttons
6. Select a delivery method radio button in the last question
7. Note that the "Edit" buttons instantly update, to be enabled or disabled as appropriate

### Important updates
Note that these changes are _not_ backwards-compatible with existing reports, because of the changes I made to `qms.ts`

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
