### PR TITLE
Adjust useForm to more gracefully handle page refreshes

### DIFF
--- a/services/ui-src/src/components/report/ReportPageWrapper.tsx
+++ b/services/ui-src/src/components/report/ReportPageWrapper.tsx
@@ -1,8 +1,7 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import { FormProvider, useForm } from "react-hook-form";
 import { Box, Button, Divider, Flex, HStack, VStack } from "@chakra-ui/react";
-import { FormPageTemplate } from "types";
 import { getReport, useStore } from "utils";
 import {
   ReportModal,
@@ -25,10 +24,7 @@ export const ReportPageWrapper = () => {
   const { reportType, state, reportId, pageId } = useParams();
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const methods = useForm({
-    defaultValues: useMemo(() => {
-      const pageIndex = pageMap?.get(currentPageId ?? "")!;
-      return report?.pages[pageIndex];
-    }, [currentPageId]) as FormPageTemplate,
+    defaultValues: {},
     shouldUnregister: true,
   });
 
@@ -41,7 +37,7 @@ export const ReportPageWrapper = () => {
     if (pageId) {
       setCurrentPageId(pageId);
     }
-  }, [pageId]);
+  }, [report, pageMap, pageId]);
 
   const handleBlur = (data: any) => {
     if (!report) return;


### PR DESCRIPTION
### Description
This PR should fix the autosave refresh bug without breaking anything else.

### Related ticket(s)
N/A

---
### How to test
To verify the bug is fixed:
1. Create a new report
2. Navigate to a page with more than one text input
3. Enter a value in one of the text inputs
4. Blur that field - which will trigger an autosave
5. Refresh the browser window
6. Enter a value in a different text input
7. Blur that field - which will trigger another autosave
8. Refresh the browser window
9. Note that both inputs still contain your values

Also:
1. idk, try a bunch of form... stuff. It should all work good.

### Important updates
n/a

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary

