### PR TITLE
QM Table: State vs Form fix

### DIFF
--- a/services/ui-src/src/components/report/QualityMeasureTable.test.tsx
+++ b/services/ui-src/src/components/report/QualityMeasureTable.test.tsx
@@ -3,14 +3,24 @@ import { render, screen } from "@testing-library/react";
 import { useStore } from "utils";
 import { mockUseStore } from "utils/testing/setupJest";
 import userEvent from "@testing-library/user-event";
+import { useLiveElement } from "utils/state/hooks/useLiveElement";
+import { ElementType } from "types/report";
 
 jest.mock("utils/state/useStore");
 const mockedUseStore = useStore as jest.MockedFunction<typeof useStore>;
 mockedUseStore.mockReturnValue({ ...mockUseStore });
 
-jest.mock("react-hook-form", () => ({
-  useWatch: jest.fn().mockReturnValue("FFS"),
-}));
+jest.mock("utils/state/hooks/useLiveElement");
+const mockedUseLiveElement = useLiveElement as jest.MockedFunction<
+  typeof useLiveElement
+>;
+mockedUseLiveElement.mockReturnValue({
+  type: ElementType.Radio,
+  id: "anId",
+  answer: "FFS",
+  label: "how are you today?",
+  value: [],
+});
 
 const mockUseNavigate = jest.fn();
 

--- a/services/ui-src/src/components/report/QualityMeasureTable.tsx
+++ b/services/ui-src/src/components/report/QualityMeasureTable.tsx
@@ -11,12 +11,15 @@ import {
 import { useStore } from "utils";
 import { TableStatusIcon } from "components/tables/TableStatusIcon";
 import { CMIT_LIST } from "cmit";
-import { MeasurePageTemplate } from "types";
+import { MeasurePageTemplate, RadioTemplate } from "types";
 import { useParams, useNavigate } from "react-router-dom";
 import { useWatch } from "react-hook-form";
+import { useEffect, useState } from "react";
 
 export const QualityMeasureTableElement = () => {
   const { report, pageMap, currentPageId } = useStore();
+  const { reportType, state, reportId } = useParams();
+  const navigate = useNavigate();
 
   if (!currentPageId) return null;
   const currentPage = report?.pages[
@@ -27,11 +30,23 @@ export const QualityMeasureTableElement = () => {
   const deliveryMethodIndex = currentPage?.elements?.findIndex(
     (element) => element.id === "delivery-method-radio"
   );
-  const deliveryMethods = useWatch({
+  const stateRadio = currentPage?.elements[
+    deliveryMethodIndex
+  ] as RadioTemplate;
+  const [activeDeliveryMethod, setActiveDeliveryMethod] = useState(
+    stateRadio.answer
+  );
+  const formDeliveryMethods = useWatch({
     name: `elements.${deliveryMethodIndex}.answer`,
   }); // the formkey of the radio button
-  const { reportType, state, reportId } = useParams();
-  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (!formDeliveryMethods) return;
+    setActiveDeliveryMethod(formDeliveryMethods);
+  }, [formDeliveryMethods]);
+  useEffect(() => {
+    setActiveDeliveryMethod(stateRadio.answer);
+  }, [stateRadio]);
 
   const handleEditClick = (deliverySystem: string) => {
     if (report && report.measureLookup) {
@@ -48,7 +63,7 @@ export const QualityMeasureTableElement = () => {
 
   // Build Rows
   const rows = cmitInfo?.deliverySystem.map((system, index) => {
-    const selections = deliveryMethods ?? "";
+    const selections = activeDeliveryMethod ?? "";
     const deliverySystemIsSelected = selections.split(",").includes(system);
     return (
       <Tr key={index}>

--- a/services/ui-src/src/components/report/QualityMeasureTable.tsx
+++ b/services/ui-src/src/components/report/QualityMeasureTable.tsx
@@ -13,8 +13,7 @@ import { TableStatusIcon } from "components/tables/TableStatusIcon";
 import { CMIT_LIST } from "cmit";
 import { MeasurePageTemplate, RadioTemplate } from "types";
 import { useParams, useNavigate } from "react-router-dom";
-import { useWatch } from "react-hook-form";
-import { useEffect, useState } from "react";
+import { useLiveElement } from "utils/state/hooks/useLiveElement";
 
 export const QualityMeasureTableElement = () => {
   const { report, pageMap, currentPageId } = useStore();
@@ -27,26 +26,9 @@ export const QualityMeasureTableElement = () => {
   ] as MeasurePageTemplate;
 
   const cmitInfo = CMIT_LIST.find((item) => item.uid === currentPage?.cmitId);
-  const deliveryMethodIndex = currentPage?.elements?.findIndex(
-    (element) => element.id === "delivery-method-radio"
-  );
-  const stateRadio = currentPage?.elements[
-    deliveryMethodIndex
-  ] as RadioTemplate;
-  const [activeDeliveryMethod, setActiveDeliveryMethod] = useState(
-    stateRadio.answer
-  );
-  const formDeliveryMethods = useWatch({
-    name: `elements.${deliveryMethodIndex}.answer`,
-  }); // the formkey of the radio button
-
-  useEffect(() => {
-    if (!formDeliveryMethods) return;
-    setActiveDeliveryMethod(formDeliveryMethods);
-  }, [formDeliveryMethods]);
-  useEffect(() => {
-    setActiveDeliveryMethod(stateRadio.answer);
-  }, [stateRadio]);
+  const deliveryMethodRadio = useLiveElement(
+    "delivery-method-radio"
+  ) as RadioTemplate;
 
   const handleEditClick = (deliverySystem: string) => {
     if (report && report.measureLookup) {
@@ -63,7 +45,7 @@ export const QualityMeasureTableElement = () => {
 
   // Build Rows
   const rows = cmitInfo?.deliverySystem.map((system, index) => {
-    const selections = activeDeliveryMethod ?? "";
+    const selections = deliveryMethodRadio?.answer ?? "";
     const deliverySystemIsSelected = selections.split(",").includes(system);
     return (
       <Tr key={index}>

--- a/services/ui-src/src/utils/state/hooks/useLiveElement.ts
+++ b/services/ui-src/src/utils/state/hooks/useLiveElement.ts
@@ -3,6 +3,16 @@ import { useWatch } from "react-hook-form";
 import { PageElement } from "types";
 import { useStore } from "utils";
 
+/**
+ * This hook gives the most up to date version of an element on the current page.
+ * This solves two problems:
+ *   - The react-hook-form hooks can init empty but they are always the most up to date after
+ *   - The store only updates (in most instances) on blur
+ * When we need elements to visually change immediately based on other elements, this bridges the divide
+ * Useful for instances like the QM table display, but not for everything
+ * @param elementId The id of the element on the current page to watch
+ * @returns A page element or undefined
+ */
 export const useLiveElement = (elementId: string) => {
   const [liveElement, setLiveElement] = useState<PageElement | undefined>();
   const { report, pageMap, currentPageId } = useStore();
@@ -14,9 +24,12 @@ export const useLiveElement = (elementId: string) => {
   const elementIndex = currentPage?.elements?.findIndex(
     (element) => element.id === elementId
   );
+
+  // Get elements from both sources
   const stateElement = currentPage?.elements[elementIndex];
   const hookFormElement = useWatch({ name: `elements.${elementIndex}` });
 
+  // Hook runs whenever either source updates, merge
   useEffect(() => {
     setLiveElement({
       ...stateElement,

--- a/services/ui-src/src/utils/state/hooks/useLiveElement.ts
+++ b/services/ui-src/src/utils/state/hooks/useLiveElement.ts
@@ -1,0 +1,28 @@
+import { useEffect, useState } from "react";
+import { useWatch } from "react-hook-form";
+import { PageElement } from "types";
+import { useStore } from "utils";
+
+export const useLiveElement = (elementId: string) => {
+  const [liveElement, setLiveElement] = useState<PageElement | undefined>();
+  const { report, pageMap, currentPageId } = useStore();
+
+  if (!currentPageId) return;
+  const currentPage = report?.pages[pageMap?.get(currentPageId)!];
+
+  if (!currentPage || !currentPage.elements) return;
+  const elementIndex = currentPage?.elements?.findIndex(
+    (element) => element.id === elementId
+  );
+  const stateElement = currentPage?.elements[elementIndex];
+  const hookFormElement = useWatch({ name: `elements.${elementIndex}` });
+
+  useEffect(() => {
+    setLiveElement({
+      ...stateElement,
+      ...hookFormElement,
+    });
+  }, [hookFormElement, stateElement]);
+
+  return liveElement;
+};


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
React Hook Form and our store are enemies some days, but today we make them friends.
The QM component needs to update when radio buttons are clicked and be informed.

React Hook form:
- Hands off its updates on change successfully but sometimes has an empty initial state for useWatch()
- Our store always has the correct initial state, but only updates on blur actions. We need the info on a click.

This custom hook merges those two together, given an elementId on the current page. It is a little chattier than normal, and doesn't make sense everywhere, but it does make sense for QM tables.


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
N/A

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
https://d1pa8viu70th2x.cloudfront.net/
- Login as state user
- Go to a report measure page
- Fill out reporting type, it should live update
- Refresh, the Edit link should still be highlighted
- Clear the measure, it should also clear

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ x I have performed a self-review of my code
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
