### PR TITLE
[NO TICKET]: fix issue where form errors were not getting displayed correctly for text area field

### DIFF
--- a/services/ui-src/src/components/fields/TextAreaField.test.tsx
+++ b/services/ui-src/src/components/fields/TextAreaField.test.tsx
@@ -19,6 +19,7 @@ const mockUseFormContext = useFormContext as unknown as jest.Mock<
 >;
 jest.mock("react-hook-form", () => ({
   useFormContext: jest.fn(() => mockRhfMethods),
+  get: jest.fn(),
 }));
 const mockGetValues = (returnValue: any) =>
   mockUseFormContext.mockImplementation((): any => ({

--- a/services/ui-src/src/components/fields/TextAreaField.tsx
+++ b/services/ui-src/src/components/fields/TextAreaField.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from "react";
-import { useFormContext } from "react-hook-form";
+import { get, useFormContext } from "react-hook-form";
 import { TextField as CmsdsTextField } from "@cmsgov/design-system";
 import { Box } from "@chakra-ui/react";
 import { parseCustomHtml } from "utils";
@@ -38,7 +38,7 @@ export const TextAreaField = (props: PageElementProps) => {
 
   // prepare error message, hint, and classes
   const formErrorState = form?.formState?.errors;
-  const errorMessage = formErrorState?.[key]?.message;
+  const errorMessage: string | undefined = get(formErrorState, key)?.message;
   const parsedHint = textbox.helperText && parseCustomHtml(textbox.helperText);
   const labelText = textbox.label;
 


### PR DESCRIPTION
### Description
I fixed the error propagation display in TextField a long time ago but never made the change for TextAreaField. This is so react hook form errors can be propagated down and grabbed correctly by TextAreaField. 


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4193, CMDCT-4189

---
### How to test
1. Log in as any user and create a report
2. Go to any of the required measures table and click into one to edit. Start filling out the form and try to get some children textboxes to pop up. notice if you blur the children without entering anything, you will get "A response is required" error. Type something in and it will go away