### PR TITLE
LTSS-FFS Delivery Method Page Fixes

### DIFF
--- a/services/app-api/forms/defaultMeasures.ts
+++ b/services/app-api/forms/defaultMeasures.ts
@@ -264,10 +264,6 @@ export const defaultMeasureTemplates = {
           "[Optional instructional content that could support the user in completing this page]",
       },
       {
-        type: ElementType.MeasureDetails,
-        id: "measure-details-section",
-      },
-      {
         type: ElementType.SubHeader,
         id: "measure-information-subheader",
         text: "Measure Information",
@@ -289,7 +285,7 @@ export const defaultMeasureTemplates = {
       {
         type: ElementType.MeasureFooter,
         id: "measure-footer",
-        prevTo: "LTSS-1960",
+        prevTo: "LTSS-1",
         completeSection: true,
       },
     ],

--- a/services/app-api/forms/defaultMeasures.ts
+++ b/services/app-api/forms/defaultMeasures.ts
@@ -241,20 +241,20 @@ export const defaultMeasureTemplates = {
   },
   [MeasureTemplateName["FFS-1"]]: {
     id: "FFS-1",
-    title: "LTSS-1: FFS LTSS Measure Results",
+    title: "LTSS-1: Fee-For-Service (FFS LTSS)",
     type: PageType.MeasureResults,
     sidebar: false,
     elements: [
       {
         type: ElementType.ButtonLink,
         id: "return-button",
-        label: "Return to Required Measures Dashboard",
+        label: "Return to Measure Information",
         to: "LTSS-1",
       },
       {
         type: ElementType.Header,
         id: "measure-header",
-        text: "Fee-For-Service Measure Results",
+        text: "LTSS-1: Fee-For-Service (FFS LTSS)",
       },
       {
         type: ElementType.Accordion,
@@ -265,8 +265,8 @@ export const defaultMeasureTemplates = {
       },
       {
         type: ElementType.SubHeader,
-        id: "measure-information-subheader",
-        text: "Measure Information",
+        id: "measure-subheader",
+        text: "Fee-For-Service Measure Results",
       },
       {
         type: ElementType.TextAreaField,


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
3 tiny fixes: 
- removed `MeasureDetails` from FFS as it was rendering an error page due to not finding cmitInfo and per [Figma](https://www.figma.com/design/B8IEoYKQ7DuQyx5nStls8F/HCBS?node-id=2215-8436&p=f&t=64ppKFGYcGyniMbu-0), these pages do not have this section at the top
- corrected FFS page to return to LTSS-1 as LTSS-1960 was leading to an error page.
- updated header and subheader and order of information to match Figma.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
n/a

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
**Deploy Link:** https://d2mccnewlhkt1o.cloudfront.net/
1. Step in to Measure LTSS-1 measure.
2. Select Delivery Method: `FFS` at the bottom
    <img width="400" alt="Image of questions for Delivery Method" src="https://github.com/user-attachments/assets/ea592694-88a0-47dc-9f3b-0a2e6706da14">

3. Click on `Return to Measure Information` link and it should go back to LTSS-1
    <img width="400" alt="Image of FFS page to show return link" src="https://github.com/user-attachments/assets/f413319d-db56-4216-9bc7-9ed858061bef">

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
