### PR TITLE
CDMCT-4239: Hiding all other elements when user selects "CMS is reporting measure on state's behalf"

### DIFF
--- a/services/app-api/forms/defaultMeasures.ts
+++ b/services/app-api/forms/defaultMeasures.ts
@@ -134,21 +134,6 @@ export const defaultMeasureTemplates = {
         text: "Measure Information",
       },
       {
-        type: ElementType.ReportingRadio,
-        label: "Is the state reporting on this measure?",
-        id: "measure-reporting-radio",
-        value: [
-          {
-            label: "Yes, the state is reporting on this measure",
-            value: "yes",
-          },
-          {
-            label: "No, CMS is reporting this measure on the state's behalf",
-            value: "no",
-          },
-        ],
-      },
-      {
         type: ElementType.Radio,
         id: "measure-audited-radio",
         label: "Were the reported measure results audited or validated?",
@@ -328,21 +313,6 @@ export const defaultMeasureTemplates = {
         text: "Measure Information",
       },
       {
-        type: ElementType.ReportingRadio,
-        label: "Is the state reporting on this measure?",
-        id: "measure-reporting-radio",
-        value: [
-          {
-            label: "Yes, the state is reporting on this measure",
-            value: "yes",
-          },
-          {
-            label: "No, CMS is reporting this measure on the state's behalf",
-            value: "no",
-          },
-        ],
-      },
-      {
         type: ElementType.Radio,
         id: "measure-audited-radio",
         label: "Were the reported measure results audited or validated?",
@@ -469,6 +439,8 @@ export const defaultMeasureTemplates = {
       {
         type: ElementType.ReportingRadio,
         label: "Is the state reporting on this measure?",
+        helperText:
+          "Warning: Changing this response will clear any data previously entered in this measure.",
         id: "measure-reporting-radio",
         value: [
           {
@@ -485,6 +457,7 @@ export const defaultMeasureTemplates = {
         type: ElementType.Radio,
         id: "measure-audited-radio",
         label: "Were the reported measure results audited or validated?",
+        conditionallyHide: true,
         value: [
           { label: "No", value: "no" },
           {
@@ -505,6 +478,7 @@ export const defaultMeasureTemplates = {
         type: ElementType.Radio,
         label: "Did you follow the [reportYear] Technical Specifications?",
         id: "measure-following-tech-specs",
+        conditionallyHide: true,
         value: [
           { label: "Yes", value: "yes" },
           {
@@ -524,6 +498,7 @@ export const defaultMeasureTemplates = {
         type: ElementType.Radio,
         id: "measure-cms-calculate",
         label: "Do you want CMS to calculate this measure on your behalf?",
+        conditionallyHide: true,
         value: [
           { label: "No", value: "no" },
           {
@@ -538,11 +513,13 @@ export const defaultMeasureTemplates = {
         helperText:
           "If applicable, add any notes or comments to provide context to the reported measure result",
         label: "Additional notes/comments (optional)",
+        conditionallyHide: true,
       },
       {
         type: ElementType.Radio,
         id: "delivery-method-radio",
         label: "Which delivery systems were used to report this measure?",
+        conditionallyHide: true,
         value: [
           { label: "Fee-For-Service (FFS)", value: DeliverySystem.FFS },
           {
@@ -610,6 +587,8 @@ export const defaultMeasureTemplates = {
       {
         type: ElementType.ReportingRadio,
         label: "Is the state reporting on this measure?",
+        helperText:
+          "Warning: Changing this response will clear any data previously entered in this measure.",
         id: "measure-reporting-radio",
         value: [
           {
@@ -626,6 +605,7 @@ export const defaultMeasureTemplates = {
         type: ElementType.Radio,
         id: "measure-audited-radio",
         label: "Were the reported measure results audited or validated?",
+        conditionallyHide: true,
         value: [
           { label: "No", value: "no" },
           {
@@ -646,6 +626,7 @@ export const defaultMeasureTemplates = {
         type: ElementType.Radio,
         label: "Did you follow the [reportYear] Technical Specifications?",
         id: "measure-following-tech-specs",
+        conditionallyHide: true,
         value: [
           { label: "Yes", value: "yes" },
           {
@@ -665,6 +646,7 @@ export const defaultMeasureTemplates = {
         type: ElementType.Radio,
         id: "measure-cms-calculate",
         label: "Do you want CMS to calculate this measure on your behalf?",
+        conditionallyHide: true,
         value: [
           { label: "No", value: "no" },
           {
@@ -679,11 +661,13 @@ export const defaultMeasureTemplates = {
         helperText:
           "If applicable, add any notes or comments to provide context to the reported measure result",
         label: "Additional notes/comments (optional)",
+        conditionallyHide: true,
       },
       {
         type: ElementType.Radio,
         id: "delivery-method-radio",
         label: "Which delivery systems were used to report this measure?",
+        conditionallyHide: true,
         value: [
           { label: "Fee-For-Service (FFS)", value: DeliverySystem.FFS },
           {
@@ -751,6 +735,8 @@ export const defaultMeasureTemplates = {
       {
         type: ElementType.ReportingRadio,
         label: "Is the state reporting on this measure?",
+        helperText:
+          "Warning: Changing this response will clear any data previously entered in this measure.",
         id: "measure-reporting-radio",
         value: [
           {
@@ -767,6 +753,7 @@ export const defaultMeasureTemplates = {
         type: ElementType.Radio,
         id: "measure-audited-radio",
         label: "Were the reported measure results audited or validated?",
+        conditionallyHide: true,
         value: [
           { label: "No", value: "no" },
           {
@@ -787,6 +774,7 @@ export const defaultMeasureTemplates = {
         type: ElementType.Radio,
         label: "Did you follow the [reportYear] Technical Specifications?",
         id: "measure-following-tech-specs",
+        conditionallyHide: true,
         value: [
           { label: "Yes", value: "yes" },
           {
@@ -806,6 +794,7 @@ export const defaultMeasureTemplates = {
         type: ElementType.Radio,
         id: "measure-cms-calculate",
         label: "Do you want CMS to calculate this measure on your behalf?",
+        conditionallyHide: true,
         value: [
           { label: "No", value: "no" },
           {
@@ -820,11 +809,13 @@ export const defaultMeasureTemplates = {
         helperText:
           "If applicable, add any notes or comments to provide context to the reported measure result",
         label: "Additional notes/comments (optional)",
+        conditionallyHide: true,
       },
       {
         type: ElementType.Radio,
         id: "delivery-method-radio",
         label: "Which delivery systems were used to report this measure?",
+        conditionallyHide: true,
         value: [
           { label: "Fee-For-Service (FFS)", value: DeliverySystem.FFS },
           {
@@ -888,21 +879,6 @@ export const defaultMeasureTemplates = {
         type: ElementType.SubHeader,
         id: "measure-information-subheader",
         text: "Measure Information",
-      },
-      {
-        type: ElementType.ReportingRadio,
-        label: "Is the state reporting on this measure?",
-        id: "measure-reporting-radio",
-        value: [
-          {
-            label: "Yes, the state is reporting on this measure",
-            value: "yes",
-          },
-          {
-            label: "No, CMS is reporting this measure on the state's behalf",
-            value: "no",
-          },
-        ],
       },
       {
         type: ElementType.Radio,
@@ -1017,21 +993,6 @@ export const defaultMeasureTemplates = {
         type: ElementType.SubHeader,
         id: "measure-information-subheader",
         text: "Measure Information",
-      },
-      {
-        type: ElementType.ReportingRadio,
-        label: "Is the state reporting on this measure?",
-        id: "measure-reporting-radio",
-        value: [
-          {
-            label: "Yes, the state is reporting on this measure",
-            value: "yes",
-          },
-          {
-            label: "No, CMS is reporting this measure on the state's behalf",
-            value: "no",
-          },
-        ],
       },
       {
         type: ElementType.Radio,
@@ -1149,21 +1110,6 @@ export const defaultMeasureTemplates = {
         text: "Measure Information",
       },
       {
-        type: ElementType.ReportingRadio,
-        label: "Is the state reporting on this measure?",
-        id: "measure-reporting-radio",
-        value: [
-          {
-            label: "Yes, the state is reporting on this measure",
-            value: "yes",
-          },
-          {
-            label: "No, CMS is reporting this measure on the state's behalf",
-            value: "no",
-          },
-        ],
-      },
-      {
         type: ElementType.Radio,
         id: "measure-audited-radio",
         label: "Were the reported measure results audited or validated?",
@@ -1260,21 +1206,6 @@ export const defaultMeasureTemplates = {
         type: ElementType.SubHeader,
         id: "measure-information-subheader",
         text: "Measure Information",
-      },
-      {
-        type: ElementType.ReportingRadio,
-        label: "Is the state reporting on this measure?",
-        id: "measure-reporting-radio",
-        value: [
-          {
-            label: "Yes, the state is reporting on this measure",
-            value: "yes",
-          },
-          {
-            label: "No, CMS is reporting this measure on the state's behalf",
-            value: "no",
-          },
-        ],
       },
       {
         type: ElementType.Radio,
@@ -1402,21 +1333,6 @@ export const defaultMeasureTemplates = {
         text: "Measure Information",
       },
       {
-        type: ElementType.ReportingRadio,
-        label: "Is the state reporting on this measure?",
-        id: "measure-reporting-radio",
-        value: [
-          {
-            label: "Yes, the state is reporting on this measure",
-            value: "yes",
-          },
-          {
-            label: "No, CMS is reporting this measure on the state's behalf",
-            value: "no",
-          },
-        ],
-      },
-      {
         type: ElementType.Radio,
         id: "measure-audited-radio",
         label: "Were the reported measure results audited or validated?",
@@ -1542,21 +1458,6 @@ export const defaultMeasureTemplates = {
         text: "Measure Information",
       },
       {
-        type: ElementType.ReportingRadio,
-        label: "Is the state reporting on this measure?",
-        id: "measure-reporting-radio",
-        value: [
-          {
-            label: "Yes, the state is reporting on this measure",
-            value: "yes",
-          },
-          {
-            label: "No, CMS is reporting this measure on the state's behalf",
-            value: "no",
-          },
-        ],
-      },
-      {
         type: ElementType.Radio,
         id: "measure-audited-radio",
         label: "Were the reported measure results audited or validated?",
@@ -1653,21 +1554,6 @@ export const defaultMeasureTemplates = {
         type: ElementType.SubHeader,
         id: "measure-information-subheader",
         text: "Measure Information",
-      },
-      {
-        type: ElementType.ReportingRadio,
-        label: "Is the state reporting on this measure?",
-        id: "measure-reporting-radio",
-        value: [
-          {
-            label: "Yes, the state is reporting on this measure",
-            value: "yes",
-          },
-          {
-            label: "No, CMS is reporting this measure on the state's behalf",
-            value: "no",
-          },
-        ],
       },
       {
         type: ElementType.Radio,

--- a/services/app-api/forms/pomMeasures.ts
+++ b/services/app-api/forms/pomMeasures.ts
@@ -94,21 +94,6 @@ export const pomMeasureTemplates = {
         text: "Measure Information",
       },
       {
-        type: ElementType.ReportingRadio,
-        label: "Is the state reporting on this measure?",
-        id: "measure-reporting-radio",
-        value: [
-          {
-            label: "Yes, the state is reporting on this measure",
-            value: "yes",
-          },
-          {
-            label: "No, CMS is reporting this measure on the state's behalf",
-            value: "no",
-          },
-        ],
-      },
-      {
         type: ElementType.Radio,
         id: "measure-audited-radio",
         label: "Did you follow the [reportYear] Technical Specifications?",
@@ -221,25 +206,6 @@ export const pomMeasureTemplates = {
         type: ElementType.SubHeader,
         id: "measure-information-subheader",
         text: "Measure Information",
-      },
-      {
-        type: ElementType.Radio,
-        id: "measure-reporting-radio",
-        label: "Did you follow the [reportYear] Technical Specifications?",
-        value: [
-          { label: "Yes", value: "yes" },
-          {
-            label: "No",
-            value: "no",
-            checkedChildren: [
-              {
-                type: ElementType.TextAreaField,
-                id: "measure-following-tech-specs-no-explain",
-                label: "Please explain the variance.",
-              },
-            ],
-          },
-        ],
       },
       {
         type: ElementType.Radio,

--- a/services/app-api/types/reports.ts
+++ b/services/app-api/types/reports.ts
@@ -249,6 +249,7 @@ export type TextboxTemplate = {
   helperText?: string;
   answer?: string;
   required?: string; //takes error message to display if not provided
+  conditionallyHide?: boolean;
 };
 
 export type TextAreaBoxTemplate = {
@@ -257,6 +258,7 @@ export type TextAreaBoxTemplate = {
   label: string;
   helperText?: string;
   answer?: string;
+  conditionallyHide?: boolean;
 };
 
 export type DateTemplate = {
@@ -306,6 +308,7 @@ export type RadioTemplate = {
   value: ChoiceTemplate[];
   answer?: string;
   required?: string; //takes error message to display if not provided
+  conditionallyHide?: boolean;
 };
 
 export type ReportingRadioTemplate = {

--- a/services/app-api/utils/reportValidation.ts
+++ b/services/app-api/utils/reportValidation.ts
@@ -45,6 +45,7 @@ const textboxTemplateSchema = object().shape({
   helperText: string().notRequired(),
   answer: string().notRequired(),
   required: string().notRequired(),
+  conditionallyHide: boolean().notRequired(),
 });
 
 const textAreaTemplateSchema = object().shape({
@@ -53,6 +54,7 @@ const textAreaTemplateSchema = object().shape({
   label: string().required(),
   helperText: string().notRequired(),
   answer: string().notRequired(),
+  conditionallyHide: boolean().notRequired(),
 });
 
 const dateTemplateSchema = object().shape({
@@ -144,6 +146,7 @@ const radioTemplateSchema = object().shape({
   id: string().required(),
   label: string().required(),
   helperText: string().notRequired(),
+  conditionallyHide: boolean().notRequired(),
   value: array().of(
     object().shape({
       label: string().required(),

--- a/services/ui-src/src/components/fields/RadioField.tsx
+++ b/services/ui-src/src/components/fields/RadioField.tsx
@@ -90,12 +90,14 @@ export const RadioField = (props: PageElementProps) => {
     form.setValue(name, value, { shouldValidate: true });
     form.setValue(`${props.formkey}.type`, radio.type);
     form.setValue(`${props.formkey}.label`, radio.label);
+    form.setValue(`${props.formkey}.id`, radio.id);
   };
 
   const onBlurHandler = async (event: React.ChangeEvent<HTMLInputElement>) => {
     form.setValue(key, event.target.value, { shouldValidate: true });
     form.setValue(`${props.formkey}.type`, radio.type);
     form.setValue(`${props.formkey}.label`, radio.label);
+    form.setValue(`${props.formkey}.id`, radio.id);
   };
 
   // prepare error message, hint, and classes

--- a/services/ui-src/src/components/fields/ReportingRadioField.tsx
+++ b/services/ui-src/src/components/fields/ReportingRadioField.tsx
@@ -11,7 +11,6 @@ import { ChoiceProps } from "@cmsgov/design-system/dist/types/ChoiceList/ChoiceL
 export const ReportingRadioField = (props: PageElementProps) => {
   const radio = props.element as ReportingRadioTemplate;
   const { clearMeasure, currentPageId } = useStore();
-
   const [displayValue, setDisplayValue] = useState<ChoiceProps[]>([]);
 
   // Need to listen to prop updates from the parent for events like a measure clear
@@ -23,10 +22,14 @@ export const ReportingRadioField = (props: PageElementProps) => {
 
   // get form context and register field
   const form = useFormContext();
+
   const key = `${props.formkey}.answer`;
   useEffect(() => {
     const options = { required: radio.required || false };
     form.register(key, options);
+    form.setValue(`${props.formkey}.type`, radio.type);
+    form.setValue(`${props.formkey}.label`, radio.label);
+    form.setValue(`${props.formkey}.id`, radio.id);
   }, []);
 
   const onChangeHandler = async (
@@ -39,6 +42,9 @@ export const ReportingRadioField = (props: PageElementProps) => {
     });
     setDisplayValue(newValues);
     form.setValue(name, value, { shouldValidate: true });
+    form.setValue(`${props.formkey}.type`, radio.type);
+    form.setValue(`${props.formkey}.label`, radio.label);
+    form.setValue(`${props.formkey}.id`, radio.id);
 
     if (value === "no") {
       clearMeasure(currentPageId ?? "", [radio.id]);
@@ -48,6 +54,9 @@ export const ReportingRadioField = (props: PageElementProps) => {
 
   const onBlurHandler = async (event: React.ChangeEvent<HTMLInputElement>) => {
     form.setValue(key, event.target.value);
+    form.setValue(`${props.formkey}.type`, radio.type);
+    form.setValue(`${props.formkey}.label`, radio.label);
+    form.setValue(`${props.formkey}.id`, radio.id);
   };
 
   // prepare error message, hint, and classes

--- a/services/ui-src/src/components/fields/TextField.test.tsx
+++ b/services/ui-src/src/components/fields/TextField.test.tsx
@@ -59,8 +59,8 @@ describe("<TextField />", () => {
 
       await userEvent.type(textField, "hello[Tab]");
 
-      // 5 keystrokes + 1 blur + 1 hydrate x 3 set value calls each = 18 calls
-      expect(mockRhfMethods.setValue).toHaveBeenCalledTimes(19);
+      // lots of set value calls + 1 hydrate + 1 blur
+      expect(mockRhfMethods.setValue).toHaveBeenCalledTimes(25);
       expect(mockRhfMethods.setValue).toHaveBeenCalledWith(
         expect.any(String),
         "hello"

--- a/services/ui-src/src/components/fields/TextField.tsx
+++ b/services/ui-src/src/components/fields/TextField.tsx
@@ -33,12 +33,14 @@ export const TextField = (props: PageElementProps) => {
     form.setValue(name, value, { shouldValidate: true });
     form.setValue(`${props.formkey}.type`, textbox.type);
     form.setValue(`${props.formkey}.label`, textbox.label);
+    form.setValue(`${props.formkey}.id`, textbox.id);
   };
 
   const onBlurHandler = async (event: React.ChangeEvent<HTMLInputElement>) => {
     form.setValue(key, event.target.value);
     form.setValue(`${props.formkey}.type`, textbox.type);
     form.setValue(`${props.formkey}.label`, textbox.label);
+    form.setValue(`${props.formkey}.id`, textbox.id);
   };
 
   // prepare error message, hint, and classes

--- a/services/ui-src/src/components/report/Page.test.tsx
+++ b/services/ui-src/src/components/report/Page.test.tsx
@@ -145,6 +145,45 @@ const elements: PageElement[] = [
   },
 ];
 
+const elementsWithConditionallyHide: PageElement[] = [
+  {
+    type: ElementType.Textbox,
+    id: "",
+    label: "textbox-hide",
+    conditionallyHide: true,
+  },
+  {
+    type: ElementType.TextAreaField,
+    id: "",
+    label: "textarea-hide",
+    conditionallyHide: true,
+  },
+  {
+    type: ElementType.Radio,
+    id: "",
+    label: "radio-hide",
+    value: [
+      { label: "radio-hide-choice-1", value: "1", checkedChildren: [] },
+      { label: "radio-hide-choice-2", value: "2" },
+    ],
+    conditionallyHide: true,
+  },
+  {
+    type: ElementType.ReportingRadio,
+    id: "",
+    label: "label",
+    value: [
+      { label: "a", value: "1", checkedChildren: [] },
+      { label: "b", value: "2" },
+    ],
+  },
+  {
+    type: ElementType.QualityMeasureTable,
+    id: "",
+    measureDisplay: "quality",
+  },
+];
+
 const textFieldElement: PageElement[] = [
   {
     type: ElementType.Textbox,
@@ -228,5 +267,30 @@ describe("Page Component with read only user", () => {
     render(<Page elements={dateFieldElement} />);
     const dateField = screen.getByRole("textbox");
     expect(dateField).toBeDisabled();
+  });
+});
+
+describe("Page Component with condtionally hidden elements", () => {
+  test("elements with 'conditionallyHide' bool should be visible if hideElements is set to false", () => {
+    render(
+      <Page elements={elementsWithConditionallyHide} hideElements={false} />
+    );
+    const textField = screen.queryByLabelText("textbox-hide");
+    const textArea = screen.queryByLabelText("textarea-hide");
+    const radio = screen.queryByLabelText("radio-hide-choice-1");
+    expect(textField).toBeVisible();
+    expect(textArea).toBeVisible();
+    expect(radio).toBeVisible();
+  });
+  test("elements with 'conditionallyHide' bool should be hidden if hideElements is set to true", () => {
+    render(
+      <Page elements={elementsWithConditionallyHide} hideElements={true} />
+    );
+    const textField = screen.queryByLabelText("textbox-hide");
+    const textArea = screen.queryByLabelText("textarea-hide");
+    const radio = screen.queryByLabelText("radio-hide-choice-1");
+    expect(textField).toBe(null);
+    expect(textArea).toBe(null);
+    expect(radio).toBe(null);
   });
 });

--- a/services/ui-src/src/components/report/Page.tsx
+++ b/services/ui-src/src/components/report/Page.tsx
@@ -24,9 +24,10 @@ import { useStore } from "utils";
 
 interface Props {
   elements: PageElement[];
+  hideElements?: boolean;
 }
 
-export const Page = ({ elements }: Props) => {
+export const Page = ({ elements, hideElements }: Props) => {
   const { userIsEndUser } = useStore().user || {};
   const renderElement = (element: PageElement) => {
     const elementType = element.type;
@@ -40,6 +41,9 @@ export const Page = ({ elements }: Props) => {
       case ElementType.Textbox:
         return TextField;
       case ElementType.TextAreaField:
+        if (element?.conditionallyHide && hideElements) {
+          return (_element: any, _key: number) => <></>;
+        }
         return TextAreaField;
       case ElementType.Date:
         return DateField;
@@ -48,6 +52,9 @@ export const Page = ({ elements }: Props) => {
       case ElementType.Accordion:
         return accordionElement;
       case ElementType.Radio:
+        if (element?.conditionallyHide && hideElements) {
+          return (_element: any, _key: number) => <></>;
+        }
         return RadioField;
       case ElementType.ReportingRadio:
         return ReportingRadioField;

--- a/services/ui-src/src/components/report/Page.tsx
+++ b/services/ui-src/src/components/report/Page.tsx
@@ -39,6 +39,9 @@ export const Page = ({ elements, hideElements }: Props) => {
       case ElementType.Paragraph:
         return paragraphElement;
       case ElementType.Textbox:
+        if (element?.conditionallyHide && hideElements) {
+          return (_element: any, _key: number) => <></>;
+        }
         return TextField;
       case ElementType.TextAreaField:
         if (element?.conditionallyHide && hideElements) {

--- a/services/ui-src/src/components/report/ReportPageWrapper.tsx
+++ b/services/ui-src/src/components/report/ReportPageWrapper.tsx
@@ -25,11 +25,27 @@ export const ReportPageWrapper = () => {
   } = useStore();
   const { reportType, state, reportId, pageId } = useParams();
   const [isLoading, setIsLoading] = useState<boolean>(true);
+  const [hideElements, setHideElements] = useState<boolean>(false);
   const methods = useForm({
     defaultValues: {},
     shouldUnregister: true,
     resolver: yupResolver(elementsValidateSchema),
   });
+
+  useEffect(() => {
+    const formValues = methods.getValues() as any;
+    if (Object.keys(formValues).length === 0) {
+      return;
+    }
+    const reportingRadio = formValues?.elements?.find((element: any) => {
+      return element?.id === "measure-reporting-radio";
+    });
+    if (reportingRadio?.answer === "no") {
+      setHideElements(true);
+    } else {
+      setHideElements(false);
+    }
+  }, [methods.getValues()]);
 
   const navigate = useNavigate();
 
@@ -99,7 +115,10 @@ export const ReportPageWrapper = () => {
               onBlur={handleSubmit(handleBlur)}
             >
               {currentPage.elements && (
-                <Page elements={currentPage.elements ?? []}></Page>
+                <Page
+                  elements={currentPage.elements ?? []}
+                  hideElements={hideElements}
+                ></Page>
               )}
             </form>
           </Box>

--- a/services/ui-src/src/types/report.ts
+++ b/services/ui-src/src/types/report.ts
@@ -182,6 +182,7 @@ export type TextboxTemplate = {
   helperText?: string;
   answer?: string;
   required?: string; //takes error message to display if not provided
+  conditionallyHide?: boolean;
 };
 
 export type TextAreaBoxTemplate = {
@@ -190,6 +191,7 @@ export type TextAreaBoxTemplate = {
   label: string;
   helperText?: string;
   answer?: string;
+  conditionallyHide?: boolean;
 };
 
 export type DateTemplate = {
@@ -242,6 +244,7 @@ export type RadioTemplate = {
   helperText?: string;
   answer?: string;
   required?: string; //takes error message to display if not provided
+  conditionallyHide?: boolean;
 };
 
 export type ReportingRadioTemplate = {

--- a/services/ui-src/src/utils/validation/reportValidation.ts
+++ b/services/ui-src/src/utils/validation/reportValidation.ts
@@ -49,6 +49,7 @@ const pageElementSchema = lazy((element: PageElement): any => {
       // TODO: make date schema
       return textboxSchema;
     case ElementType.Radio:
+    case ElementType.ReportingRadio:
       if (element.value) {
         return radioWithChildrenSchema;
       }


### PR DESCRIPTION
### Description
This particular problem was difficult to solve because of the nature of how we use react hook form and also the way we are trying to control sibling level form values with another sibling. I decided to do a little bit of hacking in the ReportPageWrapper so this might not be ideal, but this is the best and most smooth solution I've come up with thus far. 

The solution is as follows:
1. added a boolean called `conditionallyHide` (i'm open to other names) to sibling elements that should be hidden when selected "CMS is reporting measure"
2. In ReportPageWrapper, I then listen for any form value changes. If the form has changed, I find the element that has a "measure-reporting-radio" id (id of all the reporting radios) and i check the answer. If it's "no" (no, CMS is reporting), i set a state variable called `hideElements` (open to new names for that too) to true. if "yes" i set to false
3. Then, I pass that `hideElements` state to the Page component. Then in the Page component, I will not render any element that has the `conditionallyHide` boolean && `hideElements` is set to true based on the `measure-reporting-radio` selection. 


One vaguely unrelated thing I did in this PR was to remove the "Is the state reporting on this measure?" for all pages except for LTSS-6, LTSS-7 and LTSS-8 per Cam's request [here](https://stratiformworkspace.slack.com/archives/C06V6EKEL74/p1741268828891719)


### Related ticket(s)
CMDCT-4239

---
### How to test
https://d3r1jw3z8zgool.cloudfront.net/
1. Log in as any state user, create or edit a report and go to one of the following required measures: LTSS-6, LTSS-7, LTSS-8
2. Fill out the form. Notice that as you toggle between "yes" and "no" on the "Is the state reporting on this measure?" question, "no" will hide all the elements and "yes" will bring them back. Test out various configurations of the form, like fill out a bunch of stuff when "yes" is selected, toggle to "no" so the elements all go away, and then toggle "yes" to bring back and make sure all the questions come back with nothing filled out.
