### PR TITLE
[HCBS] - QMS - LTSS-1 - Measure Details Page

### DIFF
--- a/services/app-api/forms/2026/measureOptions.ts
+++ b/services/app-api/forms/2026/measureOptions.ts
@@ -9,7 +9,7 @@ export const defaultMeasures: MeasureOptions[] = [
     measureTemplate: [
       MeasureTemplateName["LTSS-1"],
       MeasureTemplateName["FFS-1"],
-      MeasureTemplateName["MLTSS"],
+      MeasureTemplateName["MLTSS-1"],
     ],
   },
   {

--- a/services/app-api/forms/2026/measureTemplates.ts
+++ b/services/app-api/forms/2026/measureTemplates.ts
@@ -218,7 +218,7 @@ export const measureTemplates: Record<
         label: "Are you reporting stratification for this measure?",
         value: [
           { label: "Yes", value: "yes" },
-          { label: "Yes", value: "no" },
+          { label: "No", value: "no" },
         ],
       },
       {
@@ -404,7 +404,7 @@ export const measureTemplates: Record<
         label: "Are you reporting stratification for this measure?",
         value: [
           { label: "Yes", value: "yes" },
-          { label: "Yes", value: "no" },
+          { label: "No", value: "no" },
         ],
       },
       {

--- a/services/app-api/forms/2026/measureTemplates.ts
+++ b/services/app-api/forms/2026/measureTemplates.ts
@@ -79,11 +79,333 @@ export const measureTemplates: Record<
         helperText:
           "Please provide waiver, SPA or 1115 demonstration names and associated control numbers.",
       },
-      additionalNotesField,
       {
-        ...measureFooter,
+        type: ElementType.SubHeader,
+        id: "measure-subheader-performance-rates",
+        text: "Performance Rates",
+        helperText:
+          "The performance rate is based on a review of this measures participant case management records, selected via a systematic sample drawn from the eligible population.",
+      },
+      {
+        type: ElementType.Textbox,
+        id: "performance-rates-denom",
+        label: "Performance Rates Denominator",
+      },
+      {
+        type: ElementType.NestedHeading,
+        id: "measure-subheader",
+        text: "Performance Rate: Assessment of Core Elements",
+      },
+
+      {
+        type: ElementType.Textbox,
+        id: "performance-rate-target",
+        label:
+          "What is the [templateYear+2] state performance target for this assessment?",
+      },
+      {
+        type: ElementType.Textbox,
+        id: "performance-rate-num",
+        label: "Numerator",
+      },
+      {
+        type: ElementType.Textbox,
+        id: "performance-rate-denom",
+        helperText: "Auto-calculates",
+        label: "Denominator",
+      },
+      {
+        type: ElementType.Textbox,
+        id: "performance-rate",
+        helperText: "Auto-calculates",
+        label: "Rate",
+      },
+      {
+        type: ElementType.NestedHeading,
+        id: "measure-subheader",
+        text: "Performance Rate: Assessment of Supplemental Elements",
+      },
+      {
+        type: ElementType.Textbox,
+        id: "performance-rate-target",
+        label:
+          "What is the [templateYear+2] state performance target for this assessment?",
+      },
+      {
+        type: ElementType.Textbox,
+        id: "performance-rate-num",
+        label: "Numerator",
+      },
+      {
+        type: ElementType.Textbox,
+        id: "performance-rate-denom",
+        helperText: "Auto-calculates",
+        label: "Denominator",
+      },
+      {
+        type: ElementType.Textbox,
+        id: "performance-rate",
+        helperText: "Auto-calculates",
+        label: "Rate",
+      },
+      {
+        type: ElementType.SubHeader,
+        id: "measure-subheader-exclusion-rates",
+        text: "Exclusion Rates",
+      },
+      {
+        type: ElementType.Textbox,
+        id: "performance-rates-denom",
+        label: "Exclusion Rates Denominator",
+      },
+      {
+        type: ElementType.NestedHeading,
+        id: "measure-nested-heading",
+        text: "Exclusion Rate: Participant Count Not Be Contacted",
+      },
+      {
+        type: ElementType.Textbox,
+        id: "exclusion-rate-num",
+        label: "Numerator",
+      },
+      {
+        type: ElementType.Textbox,
+        id: "exclusion-rate-denom",
+        helperText: "Auto-calculates",
+        label: "Denominator",
+      },
+      {
+        type: ElementType.Textbox,
+        id: "performance-rate",
+        helperText: "Auto-calculates",
+        label: "Rate",
+      },
+      {
+        type: ElementType.NestedHeading,
+        id: "measure-subheader",
+        text: "Exclusion Rate: Participant Refused Assessment",
+      },
+      {
+        type: ElementType.Textbox,
+        id: "exclusion-rate-num",
+        label: "Numerator",
+      },
+      {
+        type: ElementType.Textbox,
+        id: "exclusion-rate-denom",
+        helperText: "Auto-calculates",
+        label: "Denominator",
+      },
+      {
+        type: ElementType.Textbox,
+        id: "performance-rate",
+        helperText: "Auto-calculates",
+        label: "Rate",
+      },
+      {
+        type: ElementType.SubHeader,
+        id: "measure-subheader-stratification",
+        text: "Measure Stratification",
+      },
+      {
+        type: ElementType.Paragraph,
+        id: "measure-strat-paragraph",
+        text: "If the stratification factor applies to this measure, select it and enter the stratified measure results specific to the demographic group. Do not select categories and sub-classifications for which you will not be reporting any data",
+      },
+      {
+        type: ElementType.Radio,
+        id: "reporting-strat-radio",
+        label: "Are you reporting stratification for this measure?",
+        value: [
+          { label: "Yes", value: "yes" },
+          { label: "Yes", value: "no" },
+        ],
+      },
+      {
+        type: ElementType.MeasureFooter,
+        id: "measure-footer",
         prevTo: "LTSS-1",
-        clear: undefined,
+        completeSection: true,
+      },
+    ],
+  },
+  [MeasureTemplateName["MLTSS-1"]]: {
+    id: "MLTSS-1",
+    title: "LTSS-1: Managed Care (MLTSS)",
+    type: PageType.MeasureResults,
+    sidebar: false,
+    elements: [
+      {
+        type: ElementType.ButtonLink,
+        id: "return-button",
+        label: "Return to Measure Information",
+        to: "LTSS-1",
+      },
+      {
+        type: ElementType.Header,
+        id: "measure-header",
+        text: "LTSS-1: Managed Care (MLTSS)",
+      },
+      {
+        type: ElementType.Accordion,
+        id: "measure-instructions",
+        label: "Instructions",
+        value:
+          "[Optional instructional content that could support the user in completing this page]",
+      },
+      {
+        type: ElementType.SubHeader,
+        id: "measure-subheader",
+        text: "Managed Care Measure Results",
+      },
+      {
+        type: ElementType.TextAreaField,
+        id: "measure-programs-text",
+        label: "Which Medicaid HCBS programs are being reported? (optional)",
+        helperText:
+          "Please provide waiver, SPA or 1115 demonstration names and associated control numbers.",
+      },
+      {
+        type: ElementType.SubHeader,
+        id: "measure-subheader-performance-rates",
+        text: "Performance Rates",
+        helperText:
+          "The performance rate is based on a review of this measures participant case management records, selected via a systematic sample drawn from the eligible population.",
+      },
+      {
+        type: ElementType.Textbox,
+        id: "performance-rates-denom",
+        label: "Performance Rates Denominator",
+      },
+      {
+        type: ElementType.NestedHeading,
+        id: "measure-subheader",
+        text: "Performance Rate: Assessment of Core Elements",
+      },
+
+      {
+        type: ElementType.Textbox,
+        id: "performance-rate-target",
+        label:
+          "What is the [templateYear+2] state performance target for this assessment?",
+      },
+      {
+        type: ElementType.Textbox,
+        id: "performance-rate-num",
+        label: "Numerator",
+      },
+      {
+        type: ElementType.Textbox,
+        id: "performance-rate-denom",
+        helperText: "Auto-calculates",
+        label: "Denominator",
+      },
+      {
+        type: ElementType.Textbox,
+        id: "performance-rate",
+        helperText: "Auto-calculates",
+        label: "Rate",
+      },
+      {
+        type: ElementType.NestedHeading,
+        id: "measure-subheader",
+        text: "Performance Rate: Assessment of Supplemental Elements",
+      },
+      {
+        type: ElementType.Textbox,
+        id: "performance-rate-target",
+        label:
+          "What is the [templateYear+2] state performance target for this assessment?",
+      },
+      {
+        type: ElementType.Textbox,
+        id: "performance-rate-num",
+        label: "Numerator",
+      },
+      {
+        type: ElementType.Textbox,
+        id: "performance-rate-denom",
+        helperText: "Auto-calculates",
+        label: "Denominator",
+      },
+      {
+        type: ElementType.Textbox,
+        id: "performance-rate",
+        helperText: "Auto-calculates",
+        label: "Rate",
+      },
+      {
+        type: ElementType.SubHeader,
+        id: "measure-subheader-exclusion-rates",
+        text: "Exclusion Rates",
+      },
+      {
+        type: ElementType.Textbox,
+        id: "performance-rates-denom",
+        label: "Exclusion Rates Denominator",
+      },
+      {
+        type: ElementType.NestedHeading,
+        id: "measure-nested-heading",
+        text: "Exclusion Rate: Participant Count Not Be Contacted",
+      },
+      {
+        type: ElementType.Textbox,
+        id: "exclusion-rate-num",
+        label: "Numerator",
+      },
+      {
+        type: ElementType.Textbox,
+        id: "exclusion-rate-denom",
+        helperText: "Auto-calculates",
+        label: "Denominator",
+      },
+      {
+        type: ElementType.Textbox,
+        id: "performance-rate",
+        helperText: "Auto-calculates",
+        label: "Rate",
+      },
+      {
+        type: ElementType.NestedHeading,
+        id: "measure-subheader",
+        text: "Exclusion Rate: Participant Refused Assessment",
+      },
+      {
+        type: ElementType.Textbox,
+        id: "exclusion-rate-num",
+        label: "Numerator",
+      },
+      {
+        type: ElementType.Textbox,
+        id: "exclusion-rate-denom",
+        helperText: "Auto-calculates",
+        label: "Denominator",
+      },
+      {
+        type: ElementType.Textbox,
+        id: "performance-rate",
+        helperText: "Auto-calculates",
+        label: "Rate",
+      },
+      {
+        type: ElementType.SubHeader,
+        id: "measure-subheader-stratification",
+        text: "Measure Stratification",
+      },
+      {
+        type: ElementType.Paragraph,
+        id: "measure-strat-paragraph",
+        text: "If the stratification factor applies to this measure, select it and enter the stratified measure results specific to the demographic group. Do not select categories and sub-classifications for which you will not be reporting any data",
+      },
+      {
+        type: ElementType.Radio,
+        id: "reporting-strat-radio",
+        label: "Are you reporting stratification for this measure?",
+        value: [
+          { label: "Yes", value: "yes" },
+          { label: "Yes", value: "no" },
+        ],
       },
     ],
   },

--- a/services/app-api/forms/2026/measureTemplates.ts
+++ b/services/app-api/forms/2026/measureTemplates.ts
@@ -407,6 +407,12 @@ export const measureTemplates: Record<
           { label: "Yes", value: "no" },
         ],
       },
+      {
+        type: ElementType.MeasureFooter,
+        id: "measure-footer",
+        prevTo: "LTSS-1",
+        completeSection: true,
+      },
     ],
   },
   [MeasureTemplateName["LTSS-2"]]: {

--- a/services/app-api/types/reports.ts
+++ b/services/app-api/types/reports.ts
@@ -47,6 +47,7 @@ export enum MeasureTemplateName {
   // required measures
   "LTSS-1" = "LTSS-1",
   "FFS-1" = "FFS-1",
+  "MLTSS-1" = "MLTSS-1",
   "LTSS-2" = "LTSS-2",
   "LTSS-6" = "LTSS-6",
   "LTSS-7" = "LTSS-7",
@@ -187,6 +188,7 @@ export enum PageType {
 export enum ElementType {
   Header = "header",
   SubHeader = "subHeader",
+  NestedHeading = "nestedHeading",
   Textbox = "textbox",
   TextAreaField = "textAreaField",
   Date = "date",
@@ -207,6 +209,7 @@ export enum ElementType {
 export type PageElement =
   | HeaderTemplate
   | SubHeaderTemplate
+  | NestedHeadingTemplate
   | TextboxTemplate
   | TextAreaBoxTemplate
   | DateTemplate
@@ -236,6 +239,13 @@ export const isHeaderTemplate = (
 
 export type SubHeaderTemplate = {
   type: ElementType.SubHeader;
+  id: string;
+  text: string;
+  helperText?: string;
+};
+
+export type NestedHeadingTemplate = {
+  type: ElementType.NestedHeading;
   id: string;
   text: string;
 };

--- a/services/app-api/utils/reportValidation.ts
+++ b/services/app-api/utils/reportValidation.ts
@@ -29,6 +29,13 @@ const subHeaderTemplateSchema = object().shape({
   type: string().required(ElementType.SubHeader),
   id: string().required(),
   text: string().required(),
+  helperText: string().notRequired(),
+});
+
+const nestedHeadingTemplateSchema = object().shape({
+  type: string().required(ElementType.NestedHeading),
+  id: string().required(),
+  text: string().required(),
 });
 
 const paragraphTemplateSchema = object().shape({
@@ -104,6 +111,8 @@ const pageElementSchema = lazy((value: PageElement): Schema<any> => {
       return headerTemplateSchema;
     case ElementType.SubHeader:
       return subHeaderTemplateSchema;
+    case ElementType.NestedHeading:
+      return nestedHeadingTemplateSchema;
     case ElementType.Paragraph:
       return paragraphTemplateSchema;
     case ElementType.Textbox:

--- a/services/ui-src/src/components/report/Elements.tsx
+++ b/services/ui-src/src/components/report/Elements.tsx
@@ -15,6 +15,7 @@ import {
   ButtonLinkTemplate,
   PageElement,
   MeasurePageTemplate,
+  NestedHeadingTemplate,
 } from "types";
 import { AccordionItem } from "components";
 import arrowLeftIcon from "assets/icons/arrows/icon_arrow_left_blue.png";
@@ -36,9 +37,26 @@ export const headerElement = (props: PageElementProps) => {
 };
 
 export const subHeaderElement = (props: PageElementProps) => {
+  const element = props.element as SubHeaderTemplate;
+
   return (
-    <Heading as="h2" variant="subHeader">
-      {(props.element as SubHeaderTemplate).text}
+    <Stack>
+      <Heading as="h2" variant="subHeader">
+        {(props.element as SubHeaderTemplate).text}
+      </Heading>
+      {element?.helperText && (
+        <Text variant="helperText">
+          {(props.element as SubHeaderTemplate).helperText}
+        </Text>
+      )}
+    </Stack>
+  );
+};
+
+export const nestedHeadingElement = (props: PageElementProps) => {
+  return (
+    <Heading as="h3" variant="nestedHeading">
+      {(props.element as NestedHeadingTemplate).text}
     </Heading>
   );
 };

--- a/services/ui-src/src/components/report/Page.test.tsx
+++ b/services/ui-src/src/components/report/Page.test.tsx
@@ -53,6 +53,11 @@ const elements: PageElement[] = [
     text: "My subheader",
   },
   {
+    type: ElementType.NestedHeading,
+    id: "",
+    text: "My nested subheading",
+  },
+  {
     type: ElementType.MeasureDetails,
     id: "",
   },

--- a/services/ui-src/src/components/report/Page.test.tsx
+++ b/services/ui-src/src/components/report/Page.test.tsx
@@ -55,7 +55,7 @@ const elements: PageElement[] = [
   {
     type: ElementType.NestedHeading,
     id: "",
-    text: "My nested subheading",
+    text: "My nested heading",
   },
   {
     type: ElementType.MeasureDetails,

--- a/services/ui-src/src/components/report/Page.tsx
+++ b/services/ui-src/src/components/report/Page.tsx
@@ -5,6 +5,7 @@ import {
   paragraphElement,
   accordionElement,
   buttonLinkElement,
+  nestedHeadingElement,
 } from "./Elements";
 import { assertExhaustive, ElementType, PageElement } from "../../types/report";
 import {
@@ -35,6 +36,8 @@ export const Page = ({ elements }: Props) => {
         return headerElement;
       case ElementType.SubHeader:
         return subHeaderElement;
+      case ElementType.NestedHeading:
+        return nestedHeadingElement;
       case ElementType.Paragraph:
         return paragraphElement;
       case ElementType.Textbox:

--- a/services/ui-src/src/components/report/ReportPageWrapper.test.tsx
+++ b/services/ui-src/src/components/report/ReportPageWrapper.test.tsx
@@ -131,6 +131,14 @@ const testReport: Report = {
       type: PageType.Measure,
       elements: [],
     },
+    [MeasureTemplateName["MLTSS-1"]]: {
+      id: "",
+      title: "",
+      cmitId: "",
+      status: MeasureStatus.IN_PROGRESS,
+      type: PageType.Measure,
+      elements: [],
+    },
     [MeasureTemplateName["POM-1"]]: {
       id: "",
       title: "",

--- a/services/ui-src/src/styles/theme.ts
+++ b/services/ui-src/src/styles/theme.ts
@@ -344,6 +344,16 @@ export const theme = extendTheme({
             fontSize: "lg",
           },
         },
+        nestedHeading: {
+          fontSize: "18px",
+          fontWeight: "700",
+          p: {
+            margin: "0",
+          },
+          ".mobile &": {
+            fontSize: "lg",
+          },
+        },
         sidebar: {
           fontSize: "21px",
           fontWeight: "700",
@@ -574,6 +584,9 @@ export const theme = extendTheme({
           maxWidth: "75%",
           margin: "0 auto",
           textAlign: "center",
+        },
+        helperText: {
+          color: "palette.gray_medium_dark",
         },
       },
     },

--- a/services/ui-src/src/types/report.ts
+++ b/services/ui-src/src/types/report.ts
@@ -121,6 +121,7 @@ export enum PageType {
 export enum ElementType {
   Header = "header",
   SubHeader = "subHeader",
+  NestedHeading = "nestedHeading",
   Textbox = "textbox",
   TextAreaField = "textAreaField",
   Date = "date",
@@ -141,6 +142,7 @@ export enum ElementType {
 export type PageElement =
   | HeaderTemplate
   | SubHeaderTemplate
+  | NestedHeadingTemplate
   | TextboxTemplate
   | TextAreaBoxTemplate
   | DateTemplate
@@ -164,6 +166,13 @@ export type HeaderTemplate = {
 
 export type SubHeaderTemplate = {
   type: ElementType.SubHeader;
+  id: string;
+  text: string;
+  helperText?: string;
+};
+
+export type NestedHeadingTemplate = {
+  type: ElementType.NestedHeading;
   id: string;
   text: string;
 };
@@ -344,6 +353,7 @@ export enum MeasureTemplateName {
   "LTSS-7" = "LTSS-7",
   "LTSS-8" = "LTSS-8",
   "FFS-1" = "FFS-1",
+  "MLTSS-1" = "MLTSS-1",
   "POM-1" = "POM-1",
   "POM-2" = "POM-2",
   "POM-3" = "POM-3",

--- a/services/ui-src/src/utils/state/management/reportState.test.ts
+++ b/services/ui-src/src/utils/state/management/reportState.test.ts
@@ -127,6 +127,14 @@ const testReport: Report = {
       type: PageType.Measure,
       elements: [],
     },
+    [MeasureTemplateName["MLTSS-1"]]: {
+      id: "",
+      title: "",
+      cmitId: "",
+      status: MeasureStatus.IN_PROGRESS,
+      type: PageType.Measure,
+      elements: [],
+    },
     [MeasureTemplateName["POM-1"]]: {
       id: "",
       cmitId: "",

--- a/services/ui-src/src/utils/testing/setupJest.tsx
+++ b/services/ui-src/src/utils/testing/setupJest.tsx
@@ -255,6 +255,7 @@ export const mockReportStore: HcbsReportState = {
       [MeasureTemplateName["LTSS-7"]]: mockMeasureTemplate,
       [MeasureTemplateName["LTSS-8"]]: mockMeasureTemplate,
       [MeasureTemplateName["FFS-1"]]: mockMeasureTemplate,
+      [MeasureTemplateName["MLTSS-1"]]: mockMeasureTemplate,
       [MeasureTemplateName["POM-1"]]: mockMeasureTemplate,
       [MeasureTemplateName["POM-2"]]: mockMeasureTemplate,
       [MeasureTemplateName["POM-3"]]: mockMeasureTemplate,


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4140

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->

cloudfront: https://d3p0xu9i7j4ko8.cloudfront.net/

This page shows up when we choose to edit a delivery method. Navigate to page, and ensure that the UI looks correct (some caveats, see below).

<img width="865" alt="Screenshot 2025-03-12 at 11 29 43 AM" src="https://github.com/user-attachments/assets/85bbe9bd-fe3a-41d2-bdad-aa17c27285fc" />

Depending on whether you choose FFS or MLTSS, you should see the correct corresponding headers (Fee for Service Measure results or Managed Care Measure Results)

There's a few sections to make sure are visible: 
- Performance Rate: Assessment of Core Elements
- Performance Rate: Assessment of Supplemental Elements
- Exclusion Rate: Participant Count Not Be Contacted
- Exclusion Rate: Participant Refused Assessment

There should be a numerator, denominator, and rate field for each section. 

There should also be a Measure Stratification section with a radio button

UI caveats:
1. We are currently working to add number fields to this page, so for right now the fields are standard text fields and anything can be entered. Once we add number fields we'll add a property to disable those fields.
2. Currently there is no divider on this page, we will add that in a future UI cleanup.
3. The spacing between elements is a little off, we will also add that in a future UI cleanup.

https://www.figma.com/design/B8IEoYKQ7DuQyx5nStls8F/HCBS?node-id=1-2&p=f&t=3UWMyauT1FRuKHyH-0

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
