### PR TITLE
CMDCT-4382 Add WCAG 2.1 AA and 2.2 AA rules

### DIFF
--- a/services/ui-src/src/utils/testing/commonTests.tsx
+++ b/services/ui-src/src/utils/testing/commonTests.tsx
@@ -22,7 +22,16 @@ export const testA11y = (
 
     test("should not have basic accessibility issues", async () => {
       const { container } = render(component);
-      const results = await axe(container);
+      const results = await axe(container, {
+        runOnly: [
+          "wcag2a",
+          "wcag2aa",
+          "wcag21a",
+          "wcag21aa",
+          "wcag22aa",
+          "best-practice",
+        ],
+      });
       expect(results).toHaveNoViolations();
     });
   });


### PR DESCRIPTION
### Description
Add WCAG 2.1 AA and WCAG 2.2 AA [rules to axe-core](https://www.deque.com/axe/core-documentation/api-documentation/#:~:text=the%20analysis%20again.-,axe-core%20tags,-Each%20rule%20in).


### Related ticket(s)
CMDCT-4382

---
### How to test
Run UI Jest tests. They all should pass.

You can check which rules are being run if you place this console log close to where violation `results` are checked:
```JavaScript
console.log(results.toolOptions.runOnly?.values || "no rules");
```

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
