### PR TITLE
[CMDCT-4418] Dropdown not working all the time

### DIFF
--- a/services/ui-src/src/components/fields/DropdownField.tsx
+++ b/services/ui-src/src/components/fields/DropdownField.tsx
@@ -34,7 +34,8 @@ export const DropdownField = (props: PageElementProps) => {
   };
 
   const onBlurHandler = async (event: React.ChangeEvent<HTMLInputElement>) => {
-    form.setValue(key, event.target.value);
+    // CMSDS Dropdown not using event.target.value onBlur, innertext or outertext appear to contain the current value
+    form.setValue(key, event.target.innerText);
   };
 
   // prepare error message, hint, and classes


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
The dropdown within the create modal page worked sometimes. This sometimes was enough to block my other work.
The CMSDS dropdown component is wired up to emit its output onBlur and onChange. OnChange appears to behave, but the onBlur behavior for the event.target.value never contains the content of the update. InnerText or OuterText appear to behave correctly based on experimentation -- I couldn't find discussion around this.

Updated the call and added a comment for the future confused souls affected by design library changes.

The empty value was then cast to a Number(), which resulted in 0. Api requests were being sent for year 0.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4418

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Go to the create report model and try to mess around in a couple ways.
- Clicking through the dropdown should allow a submission.
- Creating a second report with the keyboard tab navigation, and blurring should create a report.

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
