### PR TITLE
Store sync: Round 2

### DIFF
--- a/services/ui-src/src/components/fields/ReportingRadioField.tsx
+++ b/services/ui-src/src/components/fields/ReportingRadioField.tsx
@@ -10,7 +10,7 @@ import { ChoiceProps } from "@cmsgov/design-system/dist/react-components/types/C
 
 export const ReportingRadioField = (props: PageElementProps) => {
   const radio = props.element as ReportingRadioTemplate;
-  const { clearMeasure, currentPageId } = useStore();
+  const { clearMeasure, saveReport, currentPageId } = useStore();
 
   const [displayValue, setDisplayValue] = useState<ChoiceProps[]>([]);
 
@@ -48,6 +48,7 @@ export const ReportingRadioField = (props: PageElementProps) => {
 
     if (value === "no") {
       clearMeasure(currentPageId ?? "", [radio.id]);
+      saveReport();
       return;
     }
   };

--- a/services/ui-src/src/components/report/MeasureClearModal.tsx
+++ b/services/ui-src/src/components/report/MeasureClearModal.tsx
@@ -8,7 +8,7 @@ export const MeasureClearModal = (
   onSubmit: Function
 ): ReactNode => {
   const submitReset = () => {
-    onSubmit(measure.id);
+    onSubmit();
     onClose();
   };
   const body = `This action cannot be undone. It will clear all data that has been entered into the measure ${measure.id} and reset this measure's status to 'Not started'`;

--- a/services/ui-src/src/components/report/MeasureDetails.test.tsx
+++ b/services/ui-src/src/components/report/MeasureDetails.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from "@testing-library/react";
+import { mockUseStore } from "utils/testing/setupJest";
+import { MeasureDetailsElement } from "./MeasureDetails";
+
+jest.mock("utils/state/useStore", () => ({
+  useStore: jest.fn().mockImplementation((selector: Function | undefined) => {
+    if (selector) {
+      return selector(mockUseStore);
+    }
+    return mockUseStore;
+  }),
+}));
+
+describe("Measure Footer", () => {
+  it("Test Measure Footer component", async () => {
+    render(<MeasureDetailsElement />);
+
+    expect(screen.getByText(/LTSS-1/)).toBeInTheDocument(); // name from store
+    expect(screen.getByText(/960/)).toBeInTheDocument(); // CMIT from store
+    expect(screen.getByText(/Hybrid/)).toBeInTheDocument(); // Collection method from store
+  });
+});

--- a/services/ui-src/src/components/report/MeasureDetails.tsx
+++ b/services/ui-src/src/components/report/MeasureDetails.tsx
@@ -1,16 +1,15 @@
 import { Box, Divider, Flex, Text } from "@chakra-ui/react";
 import { useStore } from "utils";
-import { DataSource, MeasurePageTemplate } from "types";
+import { DataSource, MeasurePageTemplate, PageType } from "types";
+import { currentPageSelector } from "utils/state/selectors";
 
 export const MeasureDetailsElement = () => {
-  const { report, pageMap, currentPageId } = useStore();
+  const currentPage = useStore(currentPageSelector);
 
-  if (!currentPageId) return null;
-  const currentPage = report?.pages[
-    pageMap?.get(currentPageId)!
-  ] as MeasurePageTemplate;
+  if (!currentPage || currentPage.type !== PageType.Measure) return null;
+  const measurePage = currentPage as MeasurePageTemplate;
 
-  const cmitInfo = currentPage.cmitInfo;
+  const cmitInfo = measurePage.cmitInfo;
   const title = cmitInfo!.name;
   const cmit = cmitInfo?.cmit;
   const steward = cmitInfo?.measureSteward;

--- a/services/ui-src/src/components/report/MeasureFooter.test.tsx
+++ b/services/ui-src/src/components/report/MeasureFooter.test.tsx
@@ -3,13 +3,17 @@ import { ElementType, MeasureFooterTemplate } from "types";
 import { MeasureFooterElement } from "./MeasureFooter";
 import userEvent from "@testing-library/user-event";
 import { mockUseStore } from "utils/testing/setupJest";
-import { useStore } from "utils";
 
 const mockUseNavigate = jest.fn();
 
-jest.mock("utils/state/useStore");
-const mockedUseStore = useStore as jest.MockedFunction<typeof useStore>;
-mockedUseStore.mockReturnValue(mockUseStore);
+jest.mock("utils/state/useStore", () => ({
+  useStore: jest.fn().mockImplementation((selector: Function | undefined) => {
+    if (selector) {
+      return selector(mockUseStore);
+    }
+    return mockUseStore;
+  }),
+}));
 
 jest.mock("react-router-dom", () => ({
   ...jest.requireActual("react-router-dom"),

--- a/services/ui-src/src/components/report/MeasureFooter.tsx
+++ b/services/ui-src/src/components/report/MeasureFooter.tsx
@@ -1,9 +1,10 @@
 import { Box, Button, Divider, Flex } from "@chakra-ui/react";
 import { PageElementProps } from "../report/Elements";
-import { MeasureFooterTemplate, MeasurePageTemplate } from "types";
+import { MeasureFooterTemplate, MeasurePageTemplate, PageType } from "types";
 import { useNavigate, useParams } from "react-router-dom";
 import { useStore } from "utils";
 import { MeasureClearModal } from "./MeasureClearModal";
+import { currentPageSelector } from "utils/state/selectors";
 
 const onCompleteMeasure = () => {};
 
@@ -12,19 +13,11 @@ const onCompleteSection = () => {};
 export const MeasureFooterElement = (props: PageElementProps) => {
   const footer = props.element as MeasureFooterTemplate;
   const { reportType, state, reportId } = useParams();
-  const {
-    currentPageId,
-    report,
-    pageMap,
-    resetMeasure,
-    setModalComponent,
-    setModalOpen,
-  } = useStore();
+  const { resetMeasure, setModalComponent, setModalOpen } = useStore();
+  const currentPage = useStore(currentPageSelector);
 
-  if (!report || !pageMap || !currentPageId) return null;
-  const measure = report.pages[
-    pageMap.get(currentPageId)!
-  ] as MeasurePageTemplate;
+  if (!currentPage || currentPage.type !== PageType.Measure) return null;
+  const measure = currentPage as MeasurePageTemplate;
   const navigate = useNavigate();
 
   const onClear = () => {

--- a/services/ui-src/src/components/report/MeasureFooter.tsx
+++ b/services/ui-src/src/components/report/MeasureFooter.tsx
@@ -13,19 +13,24 @@ const onCompleteSection = () => {};
 export const MeasureFooterElement = (props: PageElementProps) => {
   const footer = props.element as MeasureFooterTemplate;
   const { reportType, state, reportId } = useParams();
-  const { resetMeasure, setModalComponent, setModalOpen } = useStore();
+  const { resetMeasure, saveReport, setModalComponent, setModalOpen } =
+    useStore();
   const currentPage = useStore(currentPageSelector);
 
   if (!currentPage || currentPage.type !== PageType.Measure) return null;
   const measure = currentPage as MeasurePageTemplate;
   const navigate = useNavigate();
+  const submitClear = () => {
+    resetMeasure(measure.id);
+    saveReport();
+  };
 
-  const onClear = () => {
+  const onClearButton = () => {
     // Open Modal
     const modal = MeasureClearModal(
       measure,
       () => setModalOpen(false), // Close Action
-      resetMeasure // Submit
+      submitClear // Submit
     ); // This will need the whole measure eventually
     setModalComponent(
       modal,
@@ -61,7 +66,11 @@ export const MeasureFooterElement = (props: PageElementProps) => {
 
         <Box>
           {footer.clear && (
-            <Button variant="link" marginRight="2rem" onClick={() => onClear()}>
+            <Button
+              variant="link"
+              marginRight="2rem"
+              onClick={() => onClearButton()}
+            >
               Clear measure data
             </Button>
           )}

--- a/services/ui-src/src/components/report/MeasureTable.tsx
+++ b/services/ui-src/src/components/report/MeasureTable.tsx
@@ -22,7 +22,8 @@ import { PageElementProps } from "./Elements";
 
 export const MeasureTableElement = (props: PageElementProps) => {
   const table = props.element as MeasureTableTemplate;
-  const { report, setModalComponent, setModalOpen, setSubstitute } = useStore();
+  const { report, setModalComponent, setModalOpen, setSubstitute, saveReport } =
+    useStore();
   const measures = report?.pages.filter((page) =>
     isMeasureTemplate(page)
   ) as MeasurePageTemplate[];
@@ -36,8 +37,10 @@ export const MeasureTableElement = (props: PageElementProps) => {
   );
 
   const onSubstitute = async (selectMeasure: MeasurePageTemplate) => {
-    if (report) setSubstitute(report, selectMeasure);
-
+    if (report) {
+      setSubstitute(report, selectMeasure);
+      saveReport();
+    }
     setModalOpen(false);
   };
 

--- a/services/ui-src/src/components/report/QualityMeasureTable.test.tsx
+++ b/services/ui-src/src/components/report/QualityMeasureTable.test.tsx
@@ -1,14 +1,18 @@
 import { QualityMeasureTableElement } from "./QualityMeasureTable";
 import { render, screen } from "@testing-library/react";
-import { useStore } from "utils";
 import { mockUseStore } from "utils/testing/setupJest";
 import userEvent from "@testing-library/user-event";
 import { useLiveElement } from "utils/state/hooks/useLiveElement";
 import { ElementType } from "types/report";
 
-jest.mock("utils/state/useStore");
-const mockedUseStore = useStore as jest.MockedFunction<typeof useStore>;
-mockedUseStore.mockReturnValue({ ...mockUseStore });
+jest.mock("utils/state/useStore", () => ({
+  useStore: jest.fn().mockImplementation((selector: Function | undefined) => {
+    if (selector) {
+      return selector(mockUseStore);
+    }
+    return mockUseStore;
+  }),
+}));
 
 jest.mock("utils/state/hooks/useLiveElement");
 const mockedUseLiveElement = useLiveElement as jest.MockedFunction<

--- a/services/ui-src/src/components/report/QualityMeasureTable.tsx
+++ b/services/ui-src/src/components/report/QualityMeasureTable.tsx
@@ -22,7 +22,7 @@ export const QualityMeasureTableElement = () => {
   const { reportType, state, reportId } = useParams();
   const navigate = useNavigate();
 
-  if (!currentPage || currentPage.type !== PageType.Measure) return;
+  if (!currentPage || currentPage.type !== PageType.Measure) return null;
   const measurePage = currentPage as MeasurePageTemplate;
   const deliveryMethodRadio = useLiveElement(
     "delivery-method-radio"

--- a/services/ui-src/src/components/report/QualityMeasureTable.tsx
+++ b/services/ui-src/src/components/report/QualityMeasureTable.tsx
@@ -10,21 +10,20 @@ import {
 } from "@chakra-ui/react";
 import { useStore } from "utils";
 import { TableStatusIcon } from "components/tables/TableStatusIcon";
-import { MeasurePageTemplate, RadioTemplate } from "types";
+import { MeasurePageTemplate, PageType, RadioTemplate } from "types";
 import { useParams, useNavigate } from "react-router-dom";
 import { useLiveElement } from "utils/state/hooks/useLiveElement";
+import { currentPageSelector } from "utils/state/selectors";
 
 export const QualityMeasureTableElement = () => {
-  const { report, pageMap, currentPageId } = useStore();
+  const { report } = useStore();
+  const currentPage = useStore(currentPageSelector);
+
   const { reportType, state, reportId } = useParams();
   const navigate = useNavigate();
 
-  if (!currentPageId) return null;
-  const currentPage = report?.pages[
-    pageMap?.get(currentPageId)!
-  ] as MeasurePageTemplate;
-  if (!currentPage.cmitInfo) return null;
-
+  if (!currentPage || currentPage.type !== PageType.Measure) return;
+  const measurePage = currentPage as MeasurePageTemplate;
   const deliveryMethodRadio = useLiveElement(
     "delivery-method-radio"
   ) as RadioTemplate;
@@ -32,7 +31,7 @@ export const QualityMeasureTableElement = () => {
   const handleEditClick = (deliverySystem: string) => {
     if (report && report.measureLookup) {
       const measure = report?.measureLookup.defaultMeasures.find(
-        (measure) => measure.cmit === currentPage.cmit
+        (measure) => measure.cmit === measurePage.cmit
       );
       const deliveryId = measure?.deliverySystemTemplates.find((item) =>
         item.toString().includes(deliverySystem)
@@ -41,10 +40,10 @@ export const QualityMeasureTableElement = () => {
       navigate(path);
     }
   };
-  const singleOption = currentPage.cmitInfo?.deliverySystem.length == 1;
+  const singleOption = measurePage.cmitInfo?.deliverySystem.length == 1;
 
   // Build Rows
-  const rows = currentPage.cmitInfo?.deliverySystem.map((system, index) => {
+  const rows = measurePage.cmitInfo?.deliverySystem.map((system, index) => {
     const selections = deliveryMethodRadio?.answer ?? "";
     const deliverySystemIsSelected = selections.split(",").includes(system);
     return (
@@ -54,7 +53,7 @@ export const QualityMeasureTableElement = () => {
         </Td>
         <Td width="100%">
           <Text fontWeight="bold">Delivery Method: {system}</Text>
-          <Text>CMIT# {currentPage.cmit}</Text>
+          <Text>CMIT# {measurePage.cmit}</Text>
         </Td>
         <Td>
           <Button

--- a/services/ui-src/src/components/report/ReportPageWrapper.test.tsx
+++ b/services/ui-src/src/components/report/ReportPageWrapper.test.tsx
@@ -271,7 +271,11 @@ describe("Page validation", () => {
       reportId: "QMSNJ123",
     });
   });
-  test("form should display error when text field is blurred with no input", async () => {
+  test.skip("form should display error when text field is blurred with no input", async () => {
+    global.structuredClone = (val: unknown) => {
+      return JSON.parse(JSON.stringify(val));
+    };
+
     await act(async () => {
       render(<ReportPageWrapper />);
     });

--- a/services/ui-src/src/components/report/ReportPageWrapper.tsx
+++ b/services/ui-src/src/components/report/ReportPageWrapper.tsx
@@ -10,8 +10,10 @@ import {
   Page,
   PraDisclosure,
 } from "components";
-import { yupResolver } from "@hookform/resolvers/yup";
-import { elementsValidateSchema } from "utils/validation/reportValidation";
+/*
+ * import { yupResolver } from "@hookform/resolvers/yup";
+ * import { elementsValidateSchema } from "utils/validation/reportValidation";
+ */
 import { currentPageSelector } from "utils/state/selectors";
 
 export const ReportPageWrapper = () => {
@@ -22,6 +24,7 @@ export const ReportPageWrapper = () => {
     setReport,
     setAnswers,
     setCurrentPageId,
+    saveReport,
   } = useStore();
   const currentPage = useStore(currentPageSelector);
 
@@ -30,7 +33,7 @@ export const ReportPageWrapper = () => {
   const methods = useForm({
     defaultValues: {},
     shouldUnregister: true,
-    resolver: yupResolver(elementsValidateSchema),
+    // resolver: yupResolver(elementsValidateSchema),
   });
 
   const navigate = useNavigate();
@@ -44,9 +47,10 @@ export const ReportPageWrapper = () => {
     }
   }, [report, pageMap, pageId]);
 
-  const handleBlur = (data: any) => {
+  const handleBlur = async (data: any) => {
     if (!report) return;
     setAnswers(data);
+    saveReport();
   };
 
   const fetchReport = async () => {

--- a/services/ui-src/src/components/report/ReportPageWrapper.tsx
+++ b/services/ui-src/src/components/report/ReportPageWrapper.tsx
@@ -12,17 +12,19 @@ import {
 } from "components";
 import { yupResolver } from "@hookform/resolvers/yup";
 import { elementsValidateSchema } from "utils/validation/reportValidation";
+import { currentPageSelector } from "utils/state/selectors";
 
 export const ReportPageWrapper = () => {
   const {
     report,
     pageMap,
     parentPage,
-    currentPageId,
     setReport,
     setAnswers,
     setCurrentPageId,
   } = useStore();
+  const currentPage = useStore(currentPageSelector);
+
   const { reportType, state, reportId, pageId } = useParams();
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const methods = useForm({
@@ -69,11 +71,10 @@ export const ReportPageWrapper = () => {
     return <div>bad params</div>; // TODO: error page
   }
 
-  if (isLoading || !report || !pageMap || !currentPageId) {
+  if (isLoading || !currentPage) {
     return <p>Loading</p>;
   }
 
-  const currentPage = report.pages[pageMap.get(currentPageId)!];
   const SetPageIndex = (newPageIndex: number) => {
     if (!parentPage) return; // Pages can exist outside of the direct parentage structure
     const sectionId = parentPage.childPageIds[newPageIndex];

--- a/services/ui-src/src/types/states.ts
+++ b/services/ui-src/src/types/states.ts
@@ -56,7 +56,5 @@ export interface HcbsReportState {
   clearMeasure: (measureId: string, ignoreList: string[]) => void;
   resetMeasure: (measureId: string) => void;
   setSubstitute: (report: Report, selectMeasure: MeasurePageTemplate) => void;
-  setErrorMessage: (error: string) => void;
-  setLastSavedTime: () => void;
   saveReport: () => void;
 }

--- a/services/ui-src/src/types/states.ts
+++ b/services/ui-src/src/types/states.ts
@@ -45,6 +45,7 @@ export interface HcbsReportState {
   modalHeader?: string;
   modalComponent?: ReactNode;
   lastSavedTime?: string;
+  errorMessage?: string;
 
   // ACTIONS
   setReport: (report?: Report) => void;
@@ -55,4 +56,7 @@ export interface HcbsReportState {
   clearMeasure: (measureId: string, ignoreList: string[]) => void;
   resetMeasure: (measureId: string) => void;
   setSubstitute: (report: Report, selectMeasure: MeasurePageTemplate) => void;
+  setErrorMessage: (error: string) => void;
+  setLastSavedTime: () => void;
+  saveReport: () => void;
 }

--- a/services/ui-src/src/utils/state/management/reportState.test.ts
+++ b/services/ui-src/src/utils/state/management/reportState.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import { HcbsReportState } from "types";
 import {
   ElementType,

--- a/services/ui-src/src/utils/state/management/reportState.test.ts
+++ b/services/ui-src/src/utils/state/management/reportState.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unused-vars */
 import { HcbsReportState } from "types";
 import {
   ElementType,

--- a/services/ui-src/src/utils/state/management/reportState.ts
+++ b/services/ui-src/src/utils/state/management/reportState.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import { HcbsReportState } from "types";
 import {
   isMeasureTemplate,

--- a/services/ui-src/src/utils/state/management/reportState.ts
+++ b/services/ui-src/src/utils/state/management/reportState.ts
@@ -80,15 +80,11 @@ export const substitute = (
     isMeasureTemplate(page)
   ) as MeasurePageTemplate[];
 
-  if (selectMeasure) {
-    const substitute = selectMeasure.substitutable?.toString();
-    const measure = measures.find((measure) =>
-      measure.id.includes(substitute!)
-    );
-    if (report && measure) {
-      measure.required = true;
-      selectMeasure.required = false;
-    }
+  const substitute = selectMeasure.substitutable?.toString();
+  const measure = measures.find((measure) => measure.id.includes(substitute!));
+  if (measure) {
+    measure.required = true;
+    selectMeasure.required = false;
   }
 
   return { report };
@@ -124,9 +120,8 @@ export const resetMeasure = (measureId: string, state: HcbsReportState) => {
  */
 export const saveReport = async (state: HcbsReportState) => {
   if (!state.report) return;
-  const report = structuredClone(state.report);
   try {
-    await putReport(report); // Submit to API
+    await putReport(state.report); // Submit to API
   } catch (_) {
     return { errorMessage: "Something went wrong, try again." };
   }

--- a/services/ui-src/src/utils/state/management/reportState.ts
+++ b/services/ui-src/src/utils/state/management/reportState.ts
@@ -69,8 +69,7 @@ export const mergeAnswers = (answers: any, state: HcbsReportState) => {
   );
   report.pages[pageIndex] = deepMerge(report.pages[pageIndex], answers);
 
-  putReport(report); // Submit to API
-  return { report, lastSavedTime: getLocalHourMinuteTime() };
+  return { report };
 };
 
 export const substitute = (
@@ -89,12 +88,10 @@ export const substitute = (
     if (report && measure) {
       measure.required = true;
       selectMeasure.required = false;
-
-      putReport(report);
     }
   }
 
-  return { report, lastSavedTime: getLocalHourMinuteTime() };
+  return { report };
 };
 /**
  * Clear all nested content in the measure, preserving an In Progress state,
@@ -108,7 +105,6 @@ export const clearMeasure = (
   if (!state.report) return;
   const report = structuredClone(state.report);
   performClearMeasure(measureId, report, ignoreList);
-  putReport(report); // Submit to API
   return { report };
 };
 
@@ -120,6 +116,19 @@ export const resetMeasure = (measureId: string, state: HcbsReportState) => {
   const report = structuredClone(state.report);
 
   performResetMeasure(measureId, report);
-  putReport(report); // Submit to API
   return { report };
+};
+
+/**
+ * Action saving a report to the api, updates errors or saved status
+ */
+export const saveReport = async (state: HcbsReportState) => {
+  if (!state.report) return;
+  const report = structuredClone(state.report);
+  try {
+    await putReport(report); // Submit to API
+  } catch (_) {
+    return { errorMessage: "Something went wrong, try again." };
+  }
+  return { lastSavedTime: getLocalHourMinuteTime() };
 };

--- a/services/ui-src/src/utils/state/selectors.ts
+++ b/services/ui-src/src/utils/state/selectors.ts
@@ -1,0 +1,11 @@
+import { HcbsReportState } from "types";
+
+export const currentPageSelector = (state: HcbsReportState) => {
+  const { report, pageMap, currentPageId } = state;
+  if (!report || !pageMap || !currentPageId) {
+    return null;
+  }
+
+  const currentPage = report.pages[pageMap.get(currentPageId)!];
+  return currentPage;
+};

--- a/services/ui-src/src/utils/state/useStore.ts
+++ b/services/ui-src/src/utils/state/useStore.ts
@@ -19,7 +19,6 @@ import {
   setPage,
   substitute,
 } from "./management/reportState";
-import { getLocalHourMinuteTime } from "utils";
 
 // USER STORE
 const userStore = (set: Function) => ({
@@ -121,12 +120,6 @@ const reportStore = (set: Function, get: Function): HcbsReportState => ({
     const result = await saveReport(state);
     set(result, false, { type: "saveReport" });
   },
-  setErrorMessage: (errorMessage: string) =>
-    set(() => ({ errorMessage }), false, { type: "setErrorMessage" }),
-  setLastSavedTime: () =>
-    set(() => ({ lastSavedTime: getLocalHourMinuteTime() }), false, {
-      type: "setLastSavedTime",
-    }),
 });
 
 export const useStore = create(

--- a/services/ui-src/src/utils/testing/setupJest.tsx
+++ b/services/ui-src/src/utils/testing/setupJest.tsx
@@ -18,6 +18,7 @@ import {
   DataSource,
   DeliverySystem,
   MeasureSpecification,
+  ElementType,
 } from "types";
 import { mockBannerData } from "./mockBanner";
 // GLOBALS
@@ -238,6 +239,42 @@ export const mock2MeasureTemplate: MeasurePageTemplate = {
   elements: [],
 };
 
+export const mockMeasureTemplateNotReporting: MeasurePageTemplate = {
+  id: "LTSS-1",
+  cmitId: "960",
+  status: MeasureStatus.IN_PROGRESS,
+  title: "mock-title-2",
+  type: PageType.Measure,
+  required: true,
+  substitutable: "FASI-1",
+  elements: [
+    {
+      type: ElementType.ReportingRadio,
+      label: "Is the state reporting on this measure?",
+      id: "measure-reporting-radio",
+      value: [
+        {
+          label: "Yes, the state is reporting on this measure",
+          value: "yes",
+        },
+        {
+          label: "No, CMS is reporting this measure on the state's behalf",
+          value: "no",
+        },
+      ],
+      answer: "no",
+    },
+    {
+      type: ElementType.TextAreaField,
+      id: "additional-notes-field",
+      helperText:
+        "If applicable, add any notes or comments to provide context to the reported measure result",
+      label: "Additional notes/comments (optional)",
+      answer: "yes",
+    },
+  ],
+};
+
 export const mockReportStore: HcbsReportState = {
   modalOpen: false,
   currentPageId: "mock-template-id",
@@ -302,6 +339,7 @@ export const mockReportStore: HcbsReportState = {
   resetMeasure: () => {},
   clearMeasure: () => {},
   setSubstitute: () => {},
+  saveReport: async () => {},
 };
 
 // BOUND STORE


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Second attempt at running this through.
- Adds a selector for getting the current page, removes the repeated querying against selected pages
- Splits the save report action to its own action. This allows the synchronous part of the ui changes to run through just fine, then handle any api requests and errors. This unblocks any rendering nonsense where an action overwrites the state of the report after the api call goes through. If we do that, it should be deliberate.
- Threads errors from api calls into the state. There will be a future story to deal with the rendering, I have tested it local by rendering the error message into the action bar as a proof of concept, but no real behavior for now.
- *Disables UI Validation that is currently broken in main*. It is preventing autosave.
- *Disables a unit test in ReportPageWrapper supporting that UI validation*

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
N/A
---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
https://d11b41cs5p226h.cloudfront.net/
Measure Footer, and Measure page keep working, but the code looks less painful.
Save/Substitute/Clear/Reset all keep working (but now they add errors to the state that we'll eventually use).

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
