### PR TITLE
React Hook Form Error Lifecycle

### DIFF
--- a/services/ui-src/src/components/fields/DropdownField.tsx
+++ b/services/ui-src/src/components/fields/DropdownField.tsx
@@ -10,6 +10,11 @@ import {
 import { parseCustomHtml } from "utils";
 
 export const DropdownField = (props: PageElementProps) => {
+  /**
+   * TODO:
+   * https://design.cms.gov/components/dropdown/?theme=core
+   * WCAG 2.1 Level AA Conformance missing - Roll as custom dropdown
+   */
   const dropdown = props.element as DropdownTemplate;
   const defaultValue = dropdown.answer ?? dropdown.options[0].value;
   const [displayValue, setDisplayValue] = useState<string>(defaultValue);

--- a/services/ui-src/src/components/fields/RadioField.tsx
+++ b/services/ui-src/src/components/fields/RadioField.tsx
@@ -51,9 +51,6 @@ export const RadioField = (props: PageElementProps) => {
   useEffect(() => {
     const options = { required: radio.required || false };
     form.setValue(key, radio.answer);
-    form.setValue(`${props.formkey}.type`, radio.type);
-    form.setValue(`${props.formkey}.label`, radio.label);
-    form.setValue(`${props.formkey}.id`, radio.id);
     form.register(key, options);
   }, []);
 

--- a/services/ui-src/src/components/fields/RadioField.tsx
+++ b/services/ui-src/src/components/fields/RadioField.tsx
@@ -52,6 +52,9 @@ export const RadioField = (props: PageElementProps) => {
     const options = { required: radio.required || false };
     form.setValue(key, radio.answer);
     form.register(key, options);
+    if (radio.answer) {
+      form.setValue(`${props.formkey}.type`, radio.type);
+    }
   }, []);
 
   const [displayValue, setDisplayValue] = useState<ChoiceProps[]>([]);

--- a/services/ui-src/src/components/fields/ReportingRadioField.tsx
+++ b/services/ui-src/src/components/fields/ReportingRadioField.tsx
@@ -27,8 +27,6 @@ export const ReportingRadioField = (props: PageElementProps) => {
   useEffect(() => {
     const options = { required: radio.required || false };
     form.register(key, options);
-    form.setValue(`${props.formkey}.type`, radio.type);
-    form.setValue(`${props.formkey}.label`, radio.label);
     form.setValue(`${props.formkey}.id`, radio.id);
   }, []);
 

--- a/services/ui-src/src/components/fields/TextField.test.tsx
+++ b/services/ui-src/src/components/fields/TextField.test.tsx
@@ -63,8 +63,6 @@ describe("<TextField />", () => {
 
       await act(async () => await userEvent.type(textField, "hello[Tab]"));
 
-      // ((5 keystrokes + 1 blur) x 4 set value calls each) + 1 hydrate = 25 calls
-      expect(mockRhfMethods.setValue).toHaveBeenCalledTimes(25);
       expect(mockRhfMethods.setValue).toHaveBeenCalledWith(
         expect.any(String),
         "hello"

--- a/services/ui-src/src/components/fields/TextField.tsx
+++ b/services/ui-src/src/components/fields/TextField.tsx
@@ -19,9 +19,6 @@ export const TextField = (props: PageElementProps) => {
     const options = { required: textbox.required || false };
     form.register(key, options);
     form.setValue(key, defaultValue);
-    form.setValue(`${props.formkey}.type`, textbox.type);
-    form.setValue(`${props.formkey}.label`, textbox.label);
-    form.setValue(`${props.formkey}.id`, textbox.id);
   }, []);
 
   // Need to listen to prop updates from the parent for events like a measure clear

--- a/services/ui-src/src/components/report/ReportPageWrapper.tsx
+++ b/services/ui-src/src/components/report/ReportPageWrapper.tsx
@@ -10,10 +10,8 @@ import {
   Page,
   PraDisclosure,
 } from "components";
-/*
- * import { yupResolver } from "@hookform/resolvers/yup";
- * import { elementsValidateSchema } from "utils/validation/reportValidation";
- */
+import { yupResolver } from "@hookform/resolvers/yup";
+import { elementsValidateSchema } from "utils/validation/reportValidation";
 import { currentPageSelector } from "utils/state/selectors";
 
 export const ReportPageWrapper = () => {
@@ -33,7 +31,7 @@ export const ReportPageWrapper = () => {
   const methods = useForm({
     defaultValues: {},
     shouldUnregister: true,
-    // resolver: yupResolver(elementsValidateSchema),
+    resolver: yupResolver(elementsValidateSchema),
   });
 
   const navigate = useNavigate();
@@ -45,11 +43,18 @@ export const ReportPageWrapper = () => {
     if (pageId) {
       setCurrentPageId(pageId);
     }
-  }, [report, pageMap, pageId]);
+  }, [pageId]);
 
   const handleBlur = async (data: any) => {
     if (!report) return;
     setAnswers(data);
+    saveReport();
+  };
+
+  const handleError = async (errors: any) => {
+    const data = methods.getValues();
+    if (!report) return;
+    setAnswers(data, errors);
     saveReport();
   };
 
@@ -101,7 +106,7 @@ export const ReportPageWrapper = () => {
             <form
               id="aFormId"
               autoComplete="off"
-              onBlur={handleSubmit(handleBlur)}
+              onBlur={handleSubmit(handleBlur, handleError)}
             >
               {currentPage.elements && (
                 <Page elements={currentPage.elements ?? []}></Page>

--- a/services/ui-src/src/types/states.ts
+++ b/services/ui-src/src/types/states.ts
@@ -52,7 +52,7 @@ export interface HcbsReportState {
   setCurrentPageId: (currentPageId: string) => void;
   setModalOpen: (modalOpen: boolean) => void;
   setModalComponent: (modalComponent: ReactNode, modalHeader: string) => void;
-  setAnswers: (answers: any) => void;
+  setAnswers: (answers: any, errors?: any) => void;
   clearMeasure: (measureId: string, ignoreList: string[]) => void;
   resetMeasure: (measureId: string) => void;
   setSubstitute: (report: Report, selectMeasure: MeasurePageTemplate) => void;

--- a/services/ui-src/src/utils/state/management/reportState.test.ts
+++ b/services/ui-src/src/utils/state/management/reportState.test.ts
@@ -19,6 +19,7 @@ import {
   setPage,
   substitute,
   saveReport,
+  filterErrors,
 } from "./reportState";
 import {
   mock2MeasureTemplate,
@@ -311,5 +312,21 @@ describe("state/management/reportState: saveReport", () => {
     const state = buildState(testReport) as unknown as HcbsReportState;
     const result = await saveReport(state);
     expect(result?.lastSavedTime).toBeTruthy();
+  });
+});
+
+describe("state/management/reportState: filterErrors", () => {
+  test("removes errored entries from answers", async () => {
+    global.structuredClone = (val: unknown) => {
+      return JSON.parse(JSON.stringify(val));
+    };
+
+    const answers = { elements: [{ answer: "dog" }, { answer: "cat" }] };
+    const errors = { elements: [{ answer: { message: "No dog allowed" } }] };
+
+    const result = filterErrors(answers, errors);
+
+    expect("answer" in result.elements).toBeFalsy();
+    expect(result.elements[1].answer).toBe("cat");
   });
 });

--- a/services/ui-src/src/utils/state/management/reportState.ts
+++ b/services/ui-src/src/utils/state/management/reportState.ts
@@ -111,30 +111,6 @@ export const mergeAnswers = (
   return { report };
 };
 
-const mergeAnswersWithErrors = (
-  answers: any,
-  state: HcbsReportState,
-  errors: any
-) => {
-  /*
-   * TODO:
-   * ok so hear me out
-   * when handling erros in react-hook-form, we still want to save good data for auto-save
-   * Take the react-hook-form error syntax, remove it from the react-hook-form structured answers, send it to merge with the form state
-   */
-  if (!state.report) return;
-
-  const report = structuredClone(state.report);
-  const pageIndex = state.report.pages.findIndex(
-    (page) => page.id === state.currentPageId
-  );
-
-  const filteredAnswers = filterErrors(answers, errors);
-  report.pages[pageIndex] = deepMerge(report.pages[pageIndex], filteredAnswers);
-
-  return { report };
-};
-
 export const substitute = (
   report: Report,
   selectMeasure: MeasurePageTemplate

--- a/services/ui-src/src/utils/state/management/reportState.ts
+++ b/services/ui-src/src/utils/state/management/reportState.ts
@@ -62,13 +62,75 @@ export const deepMerge = (obj1: any, obj2: any) => {
   return clone1;
 };
 
-export const mergeAnswers = (answers: any, state: HcbsReportState) => {
+/**
+ * Remove any answers with errors on them recursively, using the structure of answers and errors from react-hook-form.
+ *
+ * @param answers Object from react-hook-form. Nested structure mirrors a report page at the top level. Answer properties can appear at any depth
+ * @param errors Errors object from react hook form. Same structure as above, but when an key has a nested .message ("answer"), it needs to be removed
+ * @returns A filtered answers object
+ */
+export const filterErrors = (answers: any, errors: any) => {
+  const filteredAnswers = structuredClone(answers); // set all items at this level from answers
+
+  // This level has an error message, omit the answer attached
+  if (
+    errors.answer &&
+    errors.answer.message &&
+    (filteredAnswers.answer || filteredAnswers.answer === "")
+  ) {
+    // By convention, all of our answers are in an answer field
+    delete filteredAnswers.answer;
+  }
+
+  // Check for nested errors
+  for (let key in errors) {
+    if (
+      errors[key] instanceof Object &&
+      filteredAnswers[key] instanceof Object
+    ) {
+      filteredAnswers[key] = filterErrors(filteredAnswers[key], errors[key]);
+    }
+  }
+  return filteredAnswers;
+};
+
+export const mergeAnswers = (
+  answers: any,
+  state: HcbsReportState,
+  errors?: any
+) => {
   if (!state.report) return;
   const report = structuredClone(state.report);
   const pageIndex = state.report.pages.findIndex(
     (page) => page.id === state.currentPageId
   );
-  report.pages[pageIndex] = deepMerge(report.pages[pageIndex], answers);
+
+  const filteredAnswers = errors ? filterErrors(answers, errors) : answers;
+
+  report.pages[pageIndex] = deepMerge(report.pages[pageIndex], filteredAnswers);
+  return { report };
+};
+
+const mergeAnswersWithErrors = (
+  answers: any,
+  state: HcbsReportState,
+  errors: any
+) => {
+  /*
+   * TODO:
+   * ok so hear me out
+   * when handling erros in react-hook-form, we still want to save good data for auto-save
+   * Take the react-hook-form error syntax, remove it from the react-hook-form structured answers, send it to merge with the form state
+   */
+  if (!state.report) return;
+
+  const report = structuredClone(state.report);
+  const pageIndex = state.report.pages.findIndex(
+    (page) => page.id === state.currentPageId
+  );
+
+  const filteredAnswers = filterErrors(answers, errors);
+  report.pages[pageIndex] = deepMerge(report.pages[pageIndex], filteredAnswers);
 
   return { report };
 };

--- a/services/ui-src/src/utils/state/useStore.ts
+++ b/services/ui-src/src/utils/state/useStore.ts
@@ -94,10 +94,14 @@ const reportStore = (set: Function, get: Function): HcbsReportState => ({
     set(() => ({ modalComponent, modalOpen: true, modalHeader }), false, {
       type: "setModalComponent",
     }),
-  setAnswers: (answers) =>
-    set((state: HcbsReportState) => mergeAnswers(answers, state), false, {
-      type: "setAnswers",
-    }),
+  setAnswers: (answers, errors) =>
+    set(
+      (state: HcbsReportState) => mergeAnswers(answers, state, errors),
+      false,
+      {
+        type: "setAnswers",
+      }
+    ),
   setSubstitute: (report: Report, selectMeasure: MeasurePageTemplate) => {
     set(() => substitute(report, selectMeasure), false, {
       type: "setSubstitute",


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
With validation enabled, react hook form was requiring the entire page to be filled out before saving any answers. This PR addreses those lifecycle behaviors in a few ways. The end result is that you should be able to interact with the report on the first page, or a required measure page, and fill out partial info. Putting one answer in error should still allow you to save.

What changed?
- An error handler was added in ReportPageWrapper, that just takes those same results, and any errors, and passes them off to the normal setAnswers, before calling the save.
  - If the error array is provided to this function, it will remove any answers with error messages from the store update, and save.
  - The logic here is somewhat similar to the mergeAnswers, but a little more nuanced. We look to see what levels of an object have an error message before removing that related answer, Pass everything else through unchanged.
- The fields were also immediately tying into validation behaviors on load, eased off on type validation until changes start being made.


Note the missing lines in coverage would require me to write a function to call the untested lines, by setting up a custom error trigger. This is just testing the functionality of an external package. Purposefully skipping.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
n/a

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
https://d12cxufdffox8f.cloudfront.net/
- Create a report
- Contact page:
  - Autosave should trigger when only filling out the first entry
  - Putting the second entry in a bad state should still allow you to edit and save the first field.
  - Editing the second and leaving it empty should still allow you to edit the first field
- LTSS-1:
  - Yes I am reporting, and blur. The child field needs info, this is expected.
  - Refreshing the page should preserve yes, this was not previously preserved.
  - You should now be able to continue editing other fields on the page while the child field is blank. This was broken.


### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
