### PR TITLE
Update dompurify with strict rules

### DIFF
--- a/services/app-api/utils/sanitize.ts
+++ b/services/app-api/utils/sanitize.ts
@@ -4,6 +4,22 @@ import { JSDOM } from "jsdom";
 const windowEmulator: any = new JSDOM("").window;
 const DOMPurify = createDOMPurify(windowEmulator);
 
+/*
+ * DOMPurify prevents all XSS attacks by default. With these settings, it also
+ * prevents "deception" attacks. If an attacker could put <div style="...">
+ * into the site's admin banner, they could make give the banner any appearance,
+ * overlaid anywhere on the page. For example, a fake "session expired" modal
+ * with a malicious link. Thus, this very strict DOMPurify config.
+ */
+DOMPurify.setConfig({
+  // Only these tags will be allowed through
+  ALLOWED_TAGS: ["ul", "ol", "li", "a", "#text"],
+  // On those tags, only these attributes are allowed
+  ALLOWED_ATTR: ["href", "alt"],
+  // If a tag is removed, so will all its child elements & text
+  KEEP_CONTENT: false,
+});
+
 // sanitize string
 export const sanitizeString = (string: string) => {
   if (DOMPurify.isSupported) {

--- a/services/app-api/utils/tests/sanitize.test.ts
+++ b/services/app-api/utils/tests/sanitize.test.ts
@@ -12,35 +12,13 @@ const safeUndefined = undefined;
 
 const cleanString = "test";
 
-const dirtyImgString = '<img src="foo.png" onload="alert("Hello!")"/>';
-const cleanImgString = '<img src="foo.png">';
-
-const dirtyLinkString = "<UL><li><A HREF=//google.com>click</UL>";
+const dirtyLinkString = "<ul><li><a href=//google.com>click</ul>";
 const cleanLinkString = '<ul><li><a href="//google.com">click</a></li></ul>';
-
-const dirtyScriptString =
-  "<math><mi//xlink:href='data:x,<script>alert(4)</script>'>";
-const cleanScriptString = "<math><mi></mi></math>";
-
-const dirtySvgString = "<svg><g/onload=alert(2)//<p>";
-const cleanSvgString = "<svg><g></g></svg>";
 
 // ARRAYS
 
-const dirtyStringArray = [
-  cleanString,
-  dirtyImgString,
-  dirtyLinkString,
-  dirtySvgString,
-  dirtyScriptString,
-];
-const cleanStringArray = [
-  cleanString,
-  cleanImgString,
-  cleanLinkString,
-  cleanSvgString,
-  cleanScriptString,
-];
+const dirtyStringArray = [cleanString, dirtyLinkString];
+const cleanStringArray = [cleanString, cleanLinkString];
 
 const dirtyNestedStringArray = [dirtyStringArray, dirtyStringArray];
 const cleanNestedStringArray = [cleanStringArray, cleanStringArray];
@@ -48,11 +26,11 @@ const cleanNestedStringArray = [cleanStringArray, cleanStringArray];
 // OBJECTS
 
 const dirtyObject = {
-  string: dirtyImgString,
+  string: dirtyLinkString,
   array: dirtyStringArray,
 };
 const cleanObject = {
-  string: cleanImgString,
+  string: cleanLinkString,
   array: cleanStringArray,
 };
 
@@ -61,10 +39,7 @@ const cleanObjectArray = [cleanObject, cleanObject];
 
 const dirtyComplexObject = {
   string1: cleanString,
-  string2: dirtyImgString,
-  string3: dirtyLinkString,
-  string4: dirtySvgString,
-  string5: dirtyScriptString,
+  string2: dirtyLinkString,
   array: dirtyStringArray,
   nestedStringArray: dirtyNestedStringArray,
   nestedObjectArray: dirtyObjectArray,
@@ -74,10 +49,7 @@ const dirtyComplexObject = {
 };
 const cleanComplexObject = {
   string1: cleanString,
-  string2: cleanImgString,
-  string3: cleanLinkString,
-  string4: cleanSvgString,
-  string5: cleanScriptString,
+  string2: cleanLinkString,
   array: cleanStringArray,
   nestedStringArray: cleanNestedStringArray,
   nestedObjectArray: cleanObjectArray,
@@ -93,10 +65,7 @@ describe("Test sanitizeString", () => {
   });
 
   test("Test sanitizeString cleans dirty strings", () => {
-    expect(sanitizeString(dirtyImgString)).toEqual(cleanImgString);
     expect(sanitizeString(dirtyLinkString)).toEqual(cleanLinkString);
-    expect(sanitizeString(dirtySvgString)).toEqual(cleanSvgString);
-    expect(sanitizeString(dirtyScriptString)).toEqual(cleanScriptString);
   });
 });
 


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Pull in the prior fix to MCR & MFP DOMPurify rules: https://github.com/Enterprise-CMCS/macpro-mdct-mcr/pull/12000

Copying @benmartin-coforma's and @karla-vm's work

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
N/A

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Unit tests should just about prove it, 
Otherwise, manually take the steps to inject html in the admin banner

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
