### PR TITLE
Previous buttons sometimes go to the wrong page

### DIFF
--- a/services/app-api/forms/2026/elements.ts
+++ b/services/app-api/forms/2026/elements.ts
@@ -206,7 +206,6 @@ export const measureResultsNavigationTable: MeasureResultsNavigationTableTemplat
 export const measureFooter: MeasureFooterTemplate = {
   type: ElementType.MeasureFooter,
   id: "measure-footer",
-  prevTo: "req-measure-result",
   completeMeasure: true,
   clear: true,
 };

--- a/services/app-api/types/reports.ts
+++ b/services/app-api/types/reports.ts
@@ -439,7 +439,7 @@ export type MeasureDetailsTemplate = {
 export type MeasureFooterTemplate = {
   type: ElementType.MeasureFooter;
   id: string;
-  prevTo: string;
+  prevTo?: string;
   nextTo?: string;
   completeMeasure?: boolean;
   completeSection?: boolean;

--- a/services/app-api/utils/reportValidation.ts
+++ b/services/app-api/utils/reportValidation.ts
@@ -258,7 +258,7 @@ const measureDetailsTemplateSchema = object().shape({
 const measureFooterSchema = object().shape({
   type: string().required(ElementType.MeasureFooter),
   id: string().required(),
-  prevTo: string().required(),
+  prevTo: string().notRequired(),
   nextTo: string().notRequired(),
   completeMeasure: boolean().notRequired(),
   completeSection: boolean().notRequired(),

--- a/services/ui-src/src/components/report/Elements.tsx
+++ b/services/ui-src/src/components/report/Elements.tsx
@@ -22,7 +22,7 @@ import {
 } from "types";
 import { AccordionItem } from "components";
 import arrowLeftIcon from "assets/icons/arrows/icon_arrow_left_blue.png";
-import { parseCustomHtml, useStore } from "utils";
+import { measurePrevPage, parseCustomHtml, useStore } from "utils";
 import successIcon from "assets/icons/status/icon_status_check.svg";
 export interface PageElementProps {
   element: PageElement;
@@ -131,15 +131,7 @@ export const buttonLinkElement = (props: PageElementProps) => {
 
   const navigate = useNavigate();
   const button = props.element as ButtonLinkTemplate;
-
-  const findPrevPage = () => {
-    const measure = report?.pages.find(
-      (measure) => measure.id === pageId
-    ) as MeasurePageTemplate;
-    return measure?.required ? "req-measure-result" : "optional-measure-result";
-  };
-
-  const page = button.to ?? findPrevPage();
+  const page = button.to ?? measurePrevPage(report!, pageId!);
 
   //auto generate the label for measures that are substitutable
   const setLabel =

--- a/services/ui-src/src/components/report/Elements.tsx
+++ b/services/ui-src/src/components/report/Elements.tsx
@@ -16,7 +16,6 @@ import {
   AccordionTemplate,
   ButtonLinkTemplate,
   PageElement,
-  MeasurePageTemplate,
   NestedHeadingTemplate,
   HeaderIcon,
 } from "types";

--- a/services/ui-src/src/components/report/MeasureFooter.test.tsx
+++ b/services/ui-src/src/components/report/MeasureFooter.test.tsx
@@ -27,16 +27,20 @@ jest.mock("react-router-dom", () => ({
 
 const mockedMeasureFooterElement = {
   type: ElementType.MeasureFooter,
-  prevTo: "mock-prev-link",
   nextTo: "mock-next-link",
   completeMeasure: true,
-  completeSection: true,
   clear: true,
 } as MeasureFooterTemplate;
 
 const mockedMeasureFooterEmpty = {
   type: ElementType.MeasureFooter,
   prevTo: "mock-prev-link",
+} as MeasureFooterTemplate;
+
+const mockedMeasureSectionFooterElement = {
+  type: ElementType.MeasureFooter,
+  prevTo: "mock-prev-link",
+  completeSection: true,
 } as MeasureFooterTemplate;
 
 describe("Measure Footer", () => {
@@ -54,7 +58,7 @@ describe("Measure Footer", () => {
       name: "Previous",
     });
     await userEvent.click(previousLink);
-    const prevRoute = "/report/QMS/CO/mock-id/mock-prev-link";
+    const prevRoute = "/report/QMS/CO/mock-id/req-measure-result";
     expect(mockUseNavigate).toHaveBeenCalledWith(prevRoute);
 
     //click next
@@ -76,6 +80,24 @@ describe("Measure Footer", () => {
       name: "Complete measure",
     });
     await userEvent.click(completeMeasureBtn);
+  });
+
+  it("Test Measure Footer component as a measure section", async () => {
+    render(
+      <MeasureFooterElement
+        element={mockedMeasureSectionFooterElement}
+        index={0}
+        formkey="elements.0"
+      />
+    );
+
+    //click previous
+    const previousLink = screen.getByRole("button", {
+      name: "Previous",
+    });
+    await userEvent.click(previousLink);
+    const prevRoute = "/report/QMS/CO/mock-id/mock-prev-link";
+    expect(mockUseNavigate).toHaveBeenCalledWith(prevRoute);
 
     //click complete section
     const completeSectionBtn = screen.getByRole("button", {

--- a/services/ui-src/src/components/report/MeasureFooter.tsx
+++ b/services/ui-src/src/components/report/MeasureFooter.tsx
@@ -1,6 +1,11 @@
 import { Box, Button, Flex } from "@chakra-ui/react";
 import { PageElementProps } from "../report/Elements";
-import { isFormPageTemplate, MeasureFooterTemplate, PageStatus } from "types";
+import {
+  isFormPageTemplate,
+  MeasureFooterTemplate,
+  MeasurePageTemplate,
+  PageStatus,
+} from "types";
 import { useNavigate, useParams } from "react-router-dom";
 import { useStore } from "utils";
 import { MeasureClearModal } from "./MeasureClearModal";
@@ -13,6 +18,7 @@ export const MeasureFooterElement = (props: PageElementProps) => {
   const footer = props.element as MeasureFooterTemplate;
   const { reportType, state, reportId } = useParams();
   const {
+    report,
     resetMeasure,
     saveReport,
     setModalComponent,
@@ -31,6 +37,19 @@ export const MeasureFooterElement = (props: PageElementProps) => {
   const submitClear = () => {
     resetMeasure(currentPage.id);
     saveReport();
+  };
+
+  const getPrevPageId = () => {
+    //this indicates it's a parent measure page
+    if (footer.completeMeasure) {
+      const measure = report?.pages.find(
+        (measure) => measure.id === currentPage.id
+      ) as MeasurePageTemplate;
+      return measure?.required
+        ? "req-measure-result"
+        : "optional-measure-result";
+    }
+    return footer.prevTo;
   };
 
   const onCompletePage = () => {
@@ -59,7 +78,7 @@ export const MeasureFooterElement = (props: PageElementProps) => {
           variant="outline"
           onClick={() =>
             navigate(
-              `/report/${reportType}/${state}/${reportId}/${footer.prevTo}`
+              `/report/${reportType}/${state}/${reportId}/${getPrevPageId()}`
             )
           }
         >

--- a/services/ui-src/src/components/report/MeasureFooter.tsx
+++ b/services/ui-src/src/components/report/MeasureFooter.tsx
@@ -1,11 +1,6 @@
 import { Box, Button, Flex } from "@chakra-ui/react";
 import { PageElementProps } from "../report/Elements";
-import {
-  isFormPageTemplate,
-  MeasureFooterTemplate,
-  MeasurePageTemplate,
-  PageStatus,
-} from "types";
+import { isFormPageTemplate, MeasureFooterTemplate, PageStatus } from "types";
 import { useNavigate, useParams } from "react-router-dom";
 import { measurePrevPage, useStore } from "utils";
 import { MeasureClearModal } from "./MeasureClearModal";

--- a/services/ui-src/src/components/report/MeasureFooter.tsx
+++ b/services/ui-src/src/components/report/MeasureFooter.tsx
@@ -7,7 +7,7 @@ import {
   PageStatus,
 } from "types";
 import { useNavigate, useParams } from "react-router-dom";
-import { useStore } from "utils";
+import { measurePrevPage, useStore } from "utils";
 import { MeasureClearModal } from "./MeasureClearModal";
 import {
   currentPageCompletableSelector,
@@ -40,16 +40,10 @@ export const MeasureFooterElement = (props: PageElementProps) => {
   };
 
   const getPrevPageId = () => {
-    //this indicates it's a parent measure page
-    if (footer.completeMeasure) {
-      const measure = report?.pages.find(
-        (measure) => measure.id === currentPage.id
-      ) as MeasurePageTemplate;
-      return measure?.required
-        ? "req-measure-result"
-        : "optional-measure-result";
-    }
-    return footer.prevTo;
+    //if a measure parent, search for the id, else use the one being passed in
+    return footer.completeMeasure
+      ? measurePrevPage(report!, currentPage.id)
+      : footer.prevTo;
   };
 
   const onCompletePage = () => {

--- a/services/ui-src/src/types/report.ts
+++ b/services/ui-src/src/types/report.ts
@@ -352,7 +352,7 @@ export type MeasureDetailsTemplate = {
 export type MeasureFooterTemplate = {
   type: ElementType.MeasureFooter;
   id: string;
-  prevTo: string;
+  prevTo?: string;
   nextTo?: string;
   completeMeasure?: boolean;
   completeSection?: boolean;

--- a/services/ui-src/src/utils/other/routing.ts
+++ b/services/ui-src/src/utils/other/routing.ts
@@ -1,5 +1,13 @@
-import { Report } from "types";
+import { MeasurePageTemplate, Report } from "types";
 
 export const reportBasePath = (report: Report) => {
   return `/report/${report.type}/${report.state}/${report.id}`;
+};
+
+//utilized for finding the previous page in a measure. also, handles the routing when a measure is substituted.
+export const measurePrevPage = (report: Report, pageId: string) => {
+  const measure = report?.pages.find(
+    (measure) => measure.id === pageId
+  ) as MeasurePageTemplate;
+  return measure?.required ? "req-measure-result" : "optional-measure-result";
 };

--- a/services/ui-src/src/utils/validation/reportValidation.test.ts
+++ b/services/ui-src/src/utils/validation/reportValidation.test.ts
@@ -181,7 +181,6 @@ describe("Ignores validation for elements that are not editable", () => {
         {
           type: ElementType.MeasureFooter,
           id: "measure-footer",
-          prevTo: "req-measure-result",
           completeMeasure: true,
           clear: true,
         },


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
This PR changes the action of the [Previous] button in the measure footer. If the measure is the parent, the code will figure out the return. if it's a measure section, it was use the data entered in measureTemplates.ts.

https://github.com/user-attachments/assets/b0dabffa-cafa-4d42-a0c5-083c89d77336

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4514

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Deploy Link: https://d36ma4f5kxbyc2.cloudfront.net/

1) Sign into HCBS, any state user
2) Create a QMS report
3) In Required Measures Results section, click [Substitute measure] link on LTSS-1. Change it to FASI-1.
4) Enter FASI-1, and scroll down, press the [Previous] button it should take you back to the Require Measures Results page
5) Go to the Optional Measure Results section
6) Find LTSS-1, and repeat the same action as FASI-1
7) When you click the [Previous] button, it should take you back to the Optional Measure Results section.

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
