### PR TITLE
Hot fix: dupe property

### DIFF
--- a/services/app-api/forms/2026/elements.ts
+++ b/services/app-api/forms/2026/elements.ts
@@ -390,7 +390,6 @@ export const performanceRateFacilityTransitions: PerformanceRateTemplate = {
   rateType: PerformanceRateType.FIELDS,
   required: true,
   rateCalc: RateCalc.FacilityLengthOfStayCalc,
-  required: true,
 };
 
 // Rates for LTSS-6


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Code climate and tools don't detect anomalies like duplicate properties until it's pushed to main and it see both from different PR's. This PR removes the additional `required: true,` from elements.ts

### Related ticket(s)
N/A

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Tests pass