### PR TITLE
Substitute Measure Cancel Button Stalls

### DIFF
--- a/services/ui-src/src/utils/state/reportLogic/reportActions.ts
+++ b/services/ui-src/src/utils/state/reportLogic/reportActions.ts
@@ -153,7 +153,7 @@ export const substitute = (
     isMeasureTemplate(page)
   ) as MeasurePageTemplate[];
 
-  const substitute = selectMeasure.substitutable?.toString();
+  const substitute = selectMeasure?.substitutable?.toString();
   const measure = measures.find((measure) => measure.id.includes(substitute!));
   if (measure) {
     measure.required = true;


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
There was a bug in the substitute modal where if you select no and click the buttons, the modal wouldn't do anything. This fixes it.

![Screenshot 2025-04-18 at 4 06 56 PM](https://github.com/user-attachments/assets/7f76ac85-6aa7-46ad-a971-13e970f39a9a)


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4548

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Deploy Link: https://d22bne4hrcvfls.cloudfront.net/

1) Sign into HCBS, any state user
2) Create a QMS report
3) Go to required measure results
4) Open the substitute modal. Click around to make sure all the buttons and options work

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
