### PR TITLE
[HCBS] State Performance Target Question Required

### DIFF
--- a/services/app-api/forms/2026/elements.ts
+++ b/services/app-api/forms/2026/elements.ts
@@ -387,8 +387,8 @@ export const performanceRateFacilityTransitions: PerformanceRateTemplate = {
       autoCalc: true,
     },
   ],
-  rateType: PerformanceRateType.FIELDS,
   required: true,
+  rateType: PerformanceRateType.FIELDS,
   rateCalc: RateCalc.FacilityLengthOfStayCalc,
 };
 

--- a/services/ui-src/src/components/rates/types/Fields.tsx
+++ b/services/ui-src/src/components/rates/types/Fields.tsx
@@ -29,6 +29,8 @@ export const Fields = (
   const key = `${props.formkey}.answer`;
   useEffect(() => {
     form.register(key, { required: true });
+    // Register the specific field because it's separate from key fields
+    form.register(`${key}.rates.0.performanceTarget`, { required: true });
     form.setValue(key, defaultValue);
   }, []);
 

--- a/services/ui-src/src/components/rates/types/Fields.tsx
+++ b/services/ui-src/src/components/rates/types/Fields.tsx
@@ -29,8 +29,6 @@ export const Fields = (
   const key = `${props.formkey}.answer`;
   useEffect(() => {
     form.register(key, { required: true });
-    // Register the specific field because it's separate from key fields
-    form.register(`${key}.rates.0.performanceTarget`, { required: true });
     form.setValue(key, defaultValue);
   }, []);
 

--- a/services/ui-src/src/utils/state/reportLogic/completeness.ts
+++ b/services/ui-src/src/utils/state/reportLogic/completeness.ts
@@ -186,7 +186,12 @@ const rateIsComplete = (element: PerformanceRateTemplate) => {
     } else {
       // PerformanceData
       for (const uniqueRate of element.answer.rates) {
-        if (uniqueRate.rate === undefined || uniqueRate.rate === "")
+        if (
+          uniqueRate.rate === undefined ||
+          uniqueRate.rate === "" ||
+          uniqueRate.performanceTarget === undefined ||
+          uniqueRate.performanceTarget === ""
+        )
           return false;
       }
     }


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
This PR fixes the bug where complete section was showing up even though the answer for the "required" performance Target question was left blank.

Alternate option for the logic is: 
Looks cleaner but not sure if as readable. Curious what thoughts are:
```
if (
  [uniqueRate.rate, uniqueRate.performanceTarget].some(
    (uniqueRateValue) => uniqueRateValue === undefined || uniqueRateValue === ""
  )
) {
  return false;
}
```

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4554

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
**Deploy link:** https://d13wce1kd9m1xw.cloudfront.net/

1. Sign into HCBS, any state user.
2. Create a new QMS report, say yes to the POM measures to check those too.
3. Go to any measure and confirm that if you leave the answer blank for the question: "What is the 2028 state performance target for this assessment?", that the complete button stays disabled. To test this accurately, make sure to click anywhere on the page due to onblur behavior.
4. <img width="400" alt="" src="https://github.com/user-attachments/assets/63b4b766-9cd8-47c9-81b3-b0bd8555fb35">

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
