### PR TITLE
Performance Rate Input Behaviors

### DIFF
--- a/services/ui-src/src/components/rates/calculations.tsx
+++ b/services/ui-src/src/components/rates/calculations.tsx
@@ -24,8 +24,8 @@ export const FacilityLengthOfStayCalc = (
 
   //Observed Performance Rate for the Minimizing Length of Facility Stay
   if (isFilled(rate["count-of-success"]) && isFilled(rate["fac-count"]))
-    roundTo(
-      (rate["opr-min-stay"] = rate["count-of-success"] / rate["fac-count"]),
+    rate["opr-min-stay"] = roundTo(
+      rate["count-of-success"] / rate["fac-count"],
       2
     );
 

--- a/services/ui-src/src/components/rates/calculations.tsx
+++ b/services/ui-src/src/components/rates/calculations.tsx
@@ -4,6 +4,11 @@ const isFilled = (item: string) => {
   return item !== "" && item !== undefined;
 };
 
+const roundTo = (value: number, decimal: number) => {
+  const shift = Math.pow(10, decimal);
+  return Math.round(value * shift) / shift;
+};
+
 export const isNumber = (value: string) => {
   const allNumbers = /^-?\d*\.?\d*$/i;
   return allNumbers.test(value);
@@ -19,15 +24,20 @@ export const FacilityLengthOfStayCalc = (
 
   //Observed Performance Rate for the Minimizing Length of Facility Stay
   if (isFilled(rate["count-of-success"]) && isFilled(rate["fac-count"]))
-    rate["opr-min-stay"] = rate["count-of-success"] / rate["fac-count"];
+    roundTo(
+      (rate["opr-min-stay"] = rate["count-of-success"] / rate["fac-count"]),
+      2
+    );
 
   //Expected Performance Rate for the Minimizing Length of Facility Stay
   if (
     isFilled(rate["expected-count-of-success"]) &&
     isFilled(rate["fac-count"])
   )
-    rate["epr-min-stay"] =
-      rate["expected-count-of-success"] / rate["fac-count"];
+    rate["epr-min-stay"] = roundTo(
+      rate["expected-count-of-success"] / rate["fac-count"],
+      2
+    );
 
   //Risk Adjusted Rate for the Minimizing Length of Facility Stay
   if (
@@ -35,8 +45,10 @@ export const FacilityLengthOfStayCalc = (
     isFilled(rate["epr-min-stay"]) &&
     isFilled(rate["multi-plan"])
   )
-    rate["rar-min-stay"] =
-      (rate["opr-min-stay"] / rate["epr-min-stay"]) * rate["multi-plan"];
+    rate["rar-min-stay"] = roundTo(
+      (rate["opr-min-stay"] / rate["epr-min-stay"]) * rate["multi-plan"],
+      2
+    );
 
   return rate;
 };
@@ -46,5 +58,5 @@ export const NDRCalc = (rate: AnyObject, multiplier: number) => {
 
   if (!isFilled(numerator) || !isFilled(denominator)) return "";
 
-  return (Math.round((numerator / denominator) * 1000) / 10) * multiplier;
+  return roundTo(numerator / denominator, 1) * multiplier;
 };

--- a/services/ui-src/src/components/rates/types/Fields.test.tsx
+++ b/services/ui-src/src/components/rates/types/Fields.test.tsx
@@ -71,6 +71,7 @@ const fieldsComponent = (
     formkey={"mock-key"}
     calculation={FacilityLengthOfStayCalc}
     year={2026}
+    disabled={false}
     {...mockedPerformanceElement}
   />
 );

--- a/services/ui-src/src/components/rates/types/Fields.tsx
+++ b/services/ui-src/src/components/rates/types/Fields.tsx
@@ -10,9 +10,10 @@ export const Fields = (
     formkey: string;
     year: number;
     calculation: Function;
+    disabled: boolean;
   }
 ) => {
-  const { answer, fields, calculation, multiplier } = props;
+  const { answer, fields, calculation, multiplier, disabled } = props;
   const arr =
     fields?.map((field) => {
       return { [field.id]: "" };
@@ -74,7 +75,7 @@ export const Fields = (
             onChange={onChangeHandler}
             onBlur={onBlurHandler}
             value={displayValue.rates[0][field.id]}
-            disabled={field.autoCalc}
+            disabled={field.autoCalc || disabled}
           ></CmsdsTextField>
         );
       })}

--- a/services/ui-src/src/components/rates/types/Fields.tsx
+++ b/services/ui-src/src/components/rates/types/Fields.tsx
@@ -65,7 +65,7 @@ export const Fields = (
         name={`0.performanceTarget`}
         onChange={onChangeHandler}
         onBlur={onBlurHandler}
-        value={displayValue.rates[0].performanceTarget}
+        value={displayValue.rates[0].performanceTarget ?? ""}
       ></CmsdsTextField>
       {fields?.map((field) => {
         return (
@@ -74,7 +74,7 @@ export const Fields = (
             name={`0.${field.id}`}
             onChange={onChangeHandler}
             onBlur={onBlurHandler}
-            value={displayValue.rates[0][field.id]}
+            value={displayValue.rates[0][field.id] ?? ""}
             disabled={field.autoCalc || disabled}
           ></CmsdsTextField>
         );

--- a/services/ui-src/src/components/rates/types/Fields.tsx
+++ b/services/ui-src/src/components/rates/types/Fields.tsx
@@ -66,6 +66,7 @@ export const Fields = (
         onChange={onChangeHandler}
         onBlur={onBlurHandler}
         value={displayValue.rates[0].performanceTarget ?? ""}
+        disabled={disabled}
       ></CmsdsTextField>
       {fields?.map((field) => {
         return (

--- a/services/ui-src/src/components/rates/types/NDR.test.tsx
+++ b/services/ui-src/src/components/rates/types/NDR.test.tsx
@@ -43,6 +43,7 @@ const ndrComponent = (
     formkey={"mock-key"}
     calculation={NDRCalc}
     year={2026}
+    disabled={false}
     {...mockedPerformanceElement}
   />
 );
@@ -77,7 +78,7 @@ describe("<NDR />", () => {
       expect(denominator).toHaveValue("2");
 
       const rate = screen.getByRole("textbox", { name: "Rate" });
-      expect(rate).toHaveValue("50");
+      expect(rate).toHaveValue("0.5");
     });
   });
 

--- a/services/ui-src/src/components/rates/types/NDR.tsx
+++ b/services/ui-src/src/components/rates/types/NDR.tsx
@@ -83,7 +83,7 @@ export const NDR = (
               name={`${index}.performanceTarget`}
               onChange={onChangeHandler}
               onBlur={onBlurHandler}
-              value={value.performanceTarget}
+              value={value.performanceTarget ?? ""}
               disabled={disabled}
             ></CmsdsTextField>
             <CmsdsTextField
@@ -91,20 +91,20 @@ export const NDR = (
               name={`${index}.numerator`}
               onChange={onChangeHandler}
               onBlur={onBlurHandler}
-              value={value.numerator}
+              value={value.numerator ?? ""}
             ></CmsdsTextField>
             <CmsdsTextField
               label="Denominator"
               name={`${index}.denominator`}
               onChange={onChangeHandler}
               onBlur={onBlurHandler}
-              value={value.denominator}
+              value={value.denominator ?? ""}
             ></CmsdsTextField>
             <CmsdsTextField
               label="Rate"
               name={`${index}.rate`}
               hint="Auto-calculates"
-              value={value.rate}
+              value={value.rate ?? ""}
               disabled
             ></CmsdsTextField>
             <Divider></Divider>

--- a/services/ui-src/src/components/rates/types/NDR.tsx
+++ b/services/ui-src/src/components/rates/types/NDR.tsx
@@ -92,6 +92,7 @@ export const NDR = (
               onChange={onChangeHandler}
               onBlur={onBlurHandler}
               value={value.numerator ?? ""}
+              disabled={disabled}
             ></CmsdsTextField>
             <CmsdsTextField
               label="Denominator"
@@ -99,6 +100,7 @@ export const NDR = (
               onChange={onChangeHandler}
               onBlur={onBlurHandler}
               value={value.denominator ?? ""}
+              disabled={disabled}
             ></CmsdsTextField>
             <CmsdsTextField
               label="Rate"

--- a/services/ui-src/src/components/rates/types/NDR.tsx
+++ b/services/ui-src/src/components/rates/types/NDR.tsx
@@ -10,9 +10,11 @@ export const NDR = (
     formkey: string;
     year: number;
     calculation: Function;
+    disabled: boolean;
   }
 ) => {
-  const { label, assessments, answer, multiplier, calculation } = props;
+  const { label, assessments, answer, multiplier, calculation, disabled } =
+    props;
   const initialValues =
     assessments?.map((assess) => {
       return {
@@ -82,6 +84,7 @@ export const NDR = (
               onChange={onChangeHandler}
               onBlur={onBlurHandler}
               value={value.performanceTarget}
+              disabled={disabled}
             ></CmsdsTextField>
             <CmsdsTextField
               label="Numerator"

--- a/services/ui-src/src/components/rates/types/NDREnhanced.test.tsx
+++ b/services/ui-src/src/components/rates/types/NDREnhanced.test.tsx
@@ -43,6 +43,7 @@ const ndrEnhancedComponent = (
     formkey={"mock-key"}
     calculation={NDRCalc}
     year={2026}
+    disabled={false}
     {...mockedPerformanceElement}
   />
 );
@@ -88,7 +89,7 @@ describe("<NDREnhanced />", () => {
       expect(denominator).toHaveValue("2");
 
       const rate = screen.getByRole("textbox", { name: "Rate" });
-      expect(rate).toHaveValue("50");
+      expect(rate).toHaveValue("0.5");
     });
   });
 

--- a/services/ui-src/src/components/rates/types/NDREnhanced.tsx
+++ b/services/ui-src/src/components/rates/types/NDREnhanced.tsx
@@ -89,6 +89,7 @@ export const NDREnhanced = (
         onChange={onChangeHandler}
         onBlur={onBlurHandler}
         value={displayValue?.denominator ?? ""}
+        disabled={disabled}
       ></CmsdsTextField>
       {assessments?.map((assess, index) => {
         const value =

--- a/services/ui-src/src/components/rates/types/NDREnhanced.tsx
+++ b/services/ui-src/src/components/rates/types/NDREnhanced.tsx
@@ -10,9 +10,11 @@ export const NDREnhanced = (
     formkey: string;
     year: number;
     calculation: Function;
+    disabled: boolean;
   }
 ) => {
-  const { label, assessments, answer, multiplier, calculation } = props;
+  const { label, assessments, answer, multiplier, calculation, disabled } =
+    props;
   const initialValues =
     assessments?.map((assess) => {
       return {
@@ -107,6 +109,7 @@ export const NDREnhanced = (
               onChange={onChangeHandler}
               onBlur={onBlurHandler}
               value={value.performanceTarget}
+              disabled={disabled}
             ></CmsdsTextField>
             <CmsdsTextField
               label="Numerator"
@@ -114,6 +117,7 @@ export const NDREnhanced = (
               onChange={onChangeHandler}
               onBlur={onBlurHandler}
               value={value.numerator}
+              disabled={disabled}
             ></CmsdsTextField>
             <CmsdsTextField
               label="Denominator"

--- a/services/ui-src/src/components/rates/types/NDREnhanced.tsx
+++ b/services/ui-src/src/components/rates/types/NDREnhanced.tsx
@@ -88,7 +88,7 @@ export const NDREnhanced = (
         name="denominator"
         onChange={onChangeHandler}
         onBlur={onBlurHandler}
-        value={displayValue?.denominator}
+        value={displayValue?.denominator ?? ""}
       ></CmsdsTextField>
       {assessments?.map((assess, index) => {
         const value =
@@ -108,7 +108,7 @@ export const NDREnhanced = (
               name={`${index}.performanceTarget`}
               onChange={onChangeHandler}
               onBlur={onBlurHandler}
-              value={value.performanceTarget}
+              value={value.performanceTarget ?? ""}
               disabled={disabled}
             ></CmsdsTextField>
             <CmsdsTextField
@@ -116,7 +116,7 @@ export const NDREnhanced = (
               name={`${index}.numerator`}
               onChange={onChangeHandler}
               onBlur={onBlurHandler}
-              value={value.numerator}
+              value={value.numerator ?? ""}
               disabled={disabled}
             ></CmsdsTextField>
             <CmsdsTextField
@@ -124,7 +124,7 @@ export const NDREnhanced = (
               name={`${index}.denominator`}
               onChange={onChangeHandler}
               onBlur={onBlurHandler}
-              value={value.denominator}
+              value={value.denominator ?? ""}
               hint="Auto-calculates"
               disabled
             ></CmsdsTextField>
@@ -132,7 +132,7 @@ export const NDREnhanced = (
               label="Rate"
               name={`${index}.rate`}
               hint="Auto-calculates"
-              value={value.rate}
+              value={value.rate ?? ""}
               disabled
             ></CmsdsTextField>
           </Stack>

--- a/services/ui-src/src/components/rates/types/NDRFields.test.tsx
+++ b/services/ui-src/src/components/rates/types/NDRFields.test.tsx
@@ -58,6 +58,7 @@ const ndrNDRFieldsComponent = (
     formkey={"mock-key"}
     calculation={FacilityLengthOfStayCalc}
     year={2026}
+    disabled={false}
     {...mockedPerformanceElement}
   />
 );

--- a/services/ui-src/src/components/rates/types/NDRFields.tsx
+++ b/services/ui-src/src/components/rates/types/NDRFields.tsx
@@ -110,7 +110,7 @@ export const NDRFields = (
               name={`${assessIndex}.denominator`}
               onChange={onChangeHandler}
               onBlur={onBlurHandler}
-              value={rateSet?.denominator}
+              value={rateSet?.denominator ?? ""}
               disabled={disabled}
             ></CmsdsTextField>
 
@@ -131,7 +131,7 @@ export const NDRFields = (
                     name={`${assessIndex}.rates.${fieldIndex}.performanceTarget`}
                     onChange={onChangeHandler}
                     onBlur={onBlurHandler}
-                    value={value?.performanceTarget}
+                    value={value?.performanceTarget ?? ""}
                     disabled={disabled}
                   ></CmsdsTextField>
                   <CmsdsTextField
@@ -139,7 +139,7 @@ export const NDRFields = (
                     name={`${assessIndex}.rates.${fieldIndex}.numerator`}
                     onChange={onChangeHandler}
                     onBlur={onBlurHandler}
-                    value={value?.numerator}
+                    value={value?.numerator ?? ""}
                     disabled={disabled}
                   ></CmsdsTextField>
                   <CmsdsTextField
@@ -147,14 +147,14 @@ export const NDRFields = (
                     name={`${assessIndex}.rates.${fieldIndex}.denominator`}
                     onChange={onChangeHandler}
                     onBlur={onBlurHandler}
-                    value={value?.denominator}
+                    value={value?.denominator ?? ""}
                     disabled
                   ></CmsdsTextField>
                   <CmsdsTextField
                     label={`${field.label} Rate (${assess.label})`}
                     name={`${assessIndex}.rates.${fieldIndex}.rate`}
                     hint="Auto-calculates"
-                    value={value?.rate}
+                    value={value?.rate ?? ""}
                     disabled
                   ></CmsdsTextField>
                 </Stack>

--- a/services/ui-src/src/components/rates/types/NDRFields.tsx
+++ b/services/ui-src/src/components/rates/types/NDRFields.tsx
@@ -10,9 +10,18 @@ export const NDRFields = (
     formkey: string;
     year: number;
     calculation: Function;
+    disabled: boolean;
   }
 ) => {
-  const { label, assessments, answer, multiplier, calculation, fields } = props;
+  const {
+    label,
+    assessments,
+    answer,
+    multiplier,
+    calculation,
+    fields,
+    disabled,
+  } = props;
 
   const defaultRates: RateSetData[] =
     assessments?.map((assess) => {
@@ -102,6 +111,7 @@ export const NDRFields = (
               onChange={onChangeHandler}
               onBlur={onBlurHandler}
               value={rateSet?.denominator}
+              disabled={disabled}
             ></CmsdsTextField>
 
             {fields?.map((field, fieldIndex) => {
@@ -122,6 +132,7 @@ export const NDRFields = (
                     onChange={onChangeHandler}
                     onBlur={onBlurHandler}
                     value={value?.performanceTarget}
+                    disabled={disabled}
                   ></CmsdsTextField>
                   <CmsdsTextField
                     label={`Numerator: ${field.label} (${assess.label})`}
@@ -129,6 +140,7 @@ export const NDRFields = (
                     onChange={onChangeHandler}
                     onBlur={onBlurHandler}
                     value={value?.numerator}
+                    disabled={disabled}
                   ></CmsdsTextField>
                   <CmsdsTextField
                     label={`Denominator (${assess.label})`}

--- a/services/ui-src/src/components/report/PerformanceRate.tsx
+++ b/services/ui-src/src/components/report/PerformanceRate.tsx
@@ -29,6 +29,7 @@ export const PerformanceRateElement = (props: PageElementProps) => {
           year: report.year,
           ...performanceRateProp,
           calculation: Calculation,
+          disabled: disabled,
         }}
       ></PerformanceRate>
     </Stack>

--- a/services/ui-src/src/components/report/PerformanceRate.tsx
+++ b/services/ui-src/src/components/report/PerformanceRate.tsx
@@ -1,5 +1,5 @@
 import { PageElementProps } from "components/report/Elements";
-import { PerformanceRateTemplate } from "types";
+import { PerformanceRateTemplate, ReportStatus } from "types";
 import * as PerformanceType from "./../rates/types";
 import { Heading, Stack, Text } from "@chakra-ui/react";
 import { useStore } from "utils";
@@ -9,12 +9,15 @@ export const PerformanceRateElement = (props: PageElementProps) => {
   const performanceRateProp = props.element as PerformanceRateTemplate;
   const { rateType, rateCalc, helperText, label } = performanceRateProp;
   const { report } = useStore();
+  const { userIsEndUser } = useStore().user || {};
 
   if (!report?.year) return null;
 
   const PerformanceRate = PerformanceType[rateType];
   const Calculation = Calculations[rateCalc ?? "NDRCalc"];
   performanceRateProp.multiplier = performanceRateProp.multiplier ?? 1;
+
+  const disabled = !userIsEndUser || report?.status === ReportStatus.SUBMITTED;
 
   return (
     <Stack gap={4} sx={sx.performance}>


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
**Task**
1. Denominator field should not allow for alpha characters
- We actually do have a check for the values being inputted into the fields, the issue was due to the default value being `undefined`. Because there was no value, the input would take any value and display it, so all we needed was to add a check that if it's undefined, default to an empty string. i.e.`value={value?.denominator ?? ""}`

2. After Submission, should be read only
- The rates textfields are not using the same textfields as the rest of the forms so they needed to have the code manually added for view only mode. It should now have a check like the rest of the application.

3. Updated Precision to reflect products limit for precision
- I changed the precision of the field back to decimals as we don't indicate them as %. I'll work closely with Cam when he gets back and do another PR for any specific ones that needs more/less precision.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4546

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->

Deploy Link: https://d3bei97ytbquq1.cloudfront.net/

1) Sign into HCBS, any state user.
2) Create a new QMS report, say no to the POM measures to lessen the amount of forms to fill out.
3) Fill out the report and submit.
    - When filling out the form, check to make sure you can't enter a letter into the performance rate textfield.
4) Go to any performance measure rate and see that the fields are now uneditable.

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
