### PR TITLE
Child Textfield error not preventing Completion

### DIFF
--- a/services/app-api/forms/2026/elements.ts
+++ b/services/app-api/forms/2026/elements.ts
@@ -107,6 +107,7 @@ export const wereTheResultsAudited: RadioTemplate = {
           id: "measure-audited-entity",
           label:
             "Enter the name of the entity that conducted the audit or validation.",
+          required: true,
         },
       ],
     },
@@ -142,6 +143,7 @@ export const didYouFollowSpecifications: RadioTemplate = {
           type: ElementType.TextAreaField,
           id: "measure-following-tech-specs-no-explain",
           label: "Please explain the variance.",
+          required: true,
         },
       ],
     },

--- a/services/app-api/types/reports.ts
+++ b/services/app-api/types/reports.ts
@@ -354,6 +354,7 @@ export type TextAreaBoxTemplate = {
   helperText?: string;
   answer?: string;
   hideCondition?: HideCondition;
+  required?: boolean;
 };
 
 export type DateTemplate = {

--- a/services/app-api/utils/reportValidation.ts
+++ b/services/app-api/utils/reportValidation.ts
@@ -76,6 +76,7 @@ const textAreaTemplateSchema = object().shape({
     })
     .notRequired()
     .default(undefined),
+  required: boolean().notRequired(),
 });
 
 const dateTemplateSchema = object().shape({

--- a/services/ui-src/src/components/pages/Dashboard/DashboardTable.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardTable.tsx
@@ -58,11 +58,11 @@ export const HorizontalTable = (
           {showEditNameColumn && (
             <Td fontWeight={"bold"}>
               <button onClick={() => openAddEditReportModal(report)}>
-                <Image src={editIcon} alt="Edit Report Name" />
+                <Image src={editIcon} alt="Edit Report Name" minW={"1.75rem"} />
               </button>
             </Td>
           )}
-          <Td fontWeight={"bold"}>
+          <Td fontWeight={"bold"} maxWidth={"14.25rem"}>
             {report.name ? report.name : "{Name of form}"}
           </Td>
           <Td>
@@ -133,7 +133,11 @@ export const VerticleTable = (
             <HStack>
               {showEditNameColumn && (
                 <button onClick={() => openAddEditReportModal(report)}>
-                  <Image src={editIcon} alt="Edit Report Name" />
+                  <Image
+                    src={editIcon}
+                    alt="Edit Report Name"
+                    minW={"1.75rem"}
+                  />
                 </button>
               )}
               <Text fontWeight="bold">{report.name}</Text>

--- a/services/ui-src/src/types/report.ts
+++ b/services/ui-src/src/types/report.ts
@@ -262,6 +262,7 @@ export type TextAreaBoxTemplate = {
   helperText?: string;
   answer?: string;
   hideCondition?: HideCondition;
+  required?: boolean;
 };
 
 export type DateTemplate = {


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->

This PR will tackle the issues of the complete button in a measure being enabled when the child field of a radio field is open. A simple fix, the child field needed to have the required key as part of it's template data.

https://github.com/user-attachments/assets/4109c64a-1170-46ae-8ee5-80b059965016


Also added a min and max width for the report dashboard title.

**Known Issue**
After entering the text, you can't seem to clear it from the children textbox. we're still working on what to do with that situation so you can ignore that.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4552
CMDCT-4547

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Deploy Link: https://d19uyho4lexobc.cloudfront.net/

1) Sign into HCBS, any state user
2) Create a new QMS report
3) Click [Required Measure Results] in the side navigation bar
4) Select [Edit] for LTSS-1 in the table
5) Fill out LTSS-1 
6) For the question **Did you follow the 2026 Technical Specifications?**, select [No] but do not fill out the textbox
7) Fill out the rest of the measure including completing a Delivery Method.
8) Make sure the [Complete measure] button  stays disabled until you enter text in the child textbox.

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
