### PR TITLE
a11y: allow leave form button to be keyboard accessible

### DIFF
--- a/services/ui-src/src/components/report/SubnavBar.tsx
+++ b/services/ui-src/src/components/report/SubnavBar.tsx
@@ -32,7 +32,6 @@ export const SubnavBar = () => {
               to={`/report/${report?.type}/${report?.state}` || "/"}
               sx={sx.leaveFormLink}
               variant="outlineButton"
-              tabIndex={-1}
             >
               Leave form
             </Link>


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
- Remove tabindex such that "Leave form" link is accessible with keyboard

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4440

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Create and open any report
- Tab through the page and verify you can access the "Leave form" button
- Verify you can activate the button by hitting the return key
- Verify it returns you to the dashboard


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---