### PR TITLE
[Cmdct-4512] Refresh hidden elements + Autosave Tweaks

### DIFF
--- a/services/app-api/forms/2026/elements.ts
+++ b/services/app-api/forms/2026/elements.ts
@@ -81,6 +81,8 @@ export const managedCareMeasureResultsSubheader: SubHeaderTemplate = {
 export const isTheStateReportingThisMeasure: ReportingRadioTemplate = {
   type: ElementType.ReportingRadio,
   label: "Is the state reporting on this measure?",
+  helperText:
+    "Warning: Changing this response will clear any data previously entered in this measure.",
   id: "measure-reporting-radio",
   value: [
     { label: "Yes, the state is reporting on this measure", value: "yes" },

--- a/services/ui-src/src/components/app/AppRoutes.tsx
+++ b/services/ui-src/src/components/app/AppRoutes.tsx
@@ -14,6 +14,7 @@ import {
 import { useStore } from "utils";
 import { useEffect } from "react";
 import { useFlags } from "launchdarkly-react-client-sdk";
+import { ReportAutosaveProvider } from "components/report/ReportAutosaveProvider";
 
 export const AppRoutes = () => {
   const { userIsAdmin } = useStore().user ?? {};
@@ -30,33 +31,37 @@ export const AppRoutes = () => {
   return (
     <main id="main-content" tabIndex={-1}>
       <AdminBannerProvider>
-        <Routes>
-          {/* General Routes */}
-          <Route path="/" element={<HomePage />} />
-          <Route
-            path="/admin"
-            element={!userIsAdmin ? <Navigate to="/profile" /> : <AdminPage />}
-          />
-          <Route path="/profile" element={<ProfilePage />} />
-          <Route path="/help" element={<HelpPage />} />
-          <Route path="*" element={<NotFoundPage />} />
-          <Route
-            path="/report/:reportType/:state"
-            element={<DashboardPage />}
-          />
-          <Route path="/report/QMS" element={<CreateReportOptions />} />
-          {isPdfActive && (
+        <ReportAutosaveProvider>
+          <Routes>
+            {/* General Routes */}
+            <Route path="/" element={<HomePage />} />
             <Route
-              path="/report/:reportType/:state/:reportId/export"
-              element={<ExportedReportPage />}
+              path="/admin"
+              element={
+                !userIsAdmin ? <Navigate to="/profile" /> : <AdminPage />
+              }
             />
-          )}
-          <Route
-            path="/report/:reportType/:state/:reportId/:pageId?"
-            element={<ReportPageWrapper />}
-          />
-          {/* TO DO: Load pageId by default? */}
-        </Routes>
+            <Route path="/profile" element={<ProfilePage />} />
+            <Route path="/help" element={<HelpPage />} />
+            <Route path="*" element={<NotFoundPage />} />
+            <Route
+              path="/report/:reportType/:state"
+              element={<DashboardPage />}
+            />
+            <Route path="/report/QMS" element={<CreateReportOptions />} />
+            {isPdfActive && (
+              <Route
+                path="/report/:reportType/:state/:reportId/export"
+                element={<ExportedReportPage />}
+              />
+            )}
+            <Route
+              path="/report/:reportType/:state/:reportId/:pageId?"
+              element={<ReportPageWrapper />}
+            />
+            {/* TO DO: Load pageId by default? */}
+          </Routes>
+        </ReportAutosaveProvider>
       </AdminBannerProvider>
     </main>
   );

--- a/services/ui-src/src/components/fields/RadioField.test.tsx
+++ b/services/ui-src/src/components/fields/RadioField.test.tsx
@@ -3,6 +3,7 @@ import userEvent from "@testing-library/user-event";
 import { RadioField } from "components";
 import { useFormContext } from "react-hook-form";
 import { ElementType, PageElement } from "types";
+import { useElementIsHidden } from "utils/state/hooks/useElementIsHidden";
 import { testA11y } from "utils/testing/commonTests";
 
 const mockTrigger = jest.fn();
@@ -26,6 +27,10 @@ const mockGetValues = (returnValue: any) =>
     ...mockRhfMethods,
     getValues: jest.fn().mockReturnValueOnce([]).mockReturnValue(returnValue),
   }));
+jest.mock("utils/state/hooks/useElementIsHidden");
+const mockedUseElementIsHidden = useElementIsHidden as jest.MockedFunction<
+  typeof useElementIsHidden
+>;
 
 const mockRadioElement = {
   type: RadioField,
@@ -105,32 +110,14 @@ describe("<RadioField />", () => {
 
 describe("Radio field hide condition logic", () => {
   test("Radio field is hidden if its hide conditions' controlling element has a matching answer", async () => {
-    mockGetValues({
-      elements: [
-        {
-          answer: "yes",
-          type: "reportingRadio",
-          label: "Should we hide the other radios on this page?",
-          id: "reporting-radio",
-        },
-      ],
-    });
+    mockedUseElementIsHidden.mockReturnValue(true);
     render(RadioFieldComponent);
     const radioField = screen.queryByText("Choice 1");
     expect(radioField).not.toBeInTheDocument();
   });
 
   test("Radio field is NOT hidden if its hide conditions' controlling element has a different answer", async () => {
-    mockGetValues({
-      elements: [
-        {
-          answer: "idk",
-          type: "reportingRadio",
-          label: "Should we hide the other radios on this page?",
-          id: "reporting-radio",
-        },
-      ],
-    });
+    mockedUseElementIsHidden.mockReturnValue(false);
     render(RadioFieldComponent);
     const radioField = screen.queryByText("Choice 1");
     expect(radioField).toBeVisible();

--- a/services/ui-src/src/components/fields/RadioField.tsx
+++ b/services/ui-src/src/components/fields/RadioField.tsx
@@ -61,7 +61,7 @@ export const RadioField = (props: PageElementProps) => {
   }, []);
 
   const [displayValue, setDisplayValue] = useState<ChoiceProps[]>([]);
-  const hideElement = useElementIsHidden(radio.hideCondition);
+  const hideElement = useElementIsHidden(radio.hideCondition, key);
 
   // Need to listen to prop updates from the parent for events like a measure clear
   useEffect(() => {

--- a/services/ui-src/src/components/fields/ReportingRadioField.test.tsx
+++ b/services/ui-src/src/components/fields/ReportingRadioField.test.tsx
@@ -25,6 +25,7 @@ const mockGetValues = (returnValue: any) =>
     ...mockRhfMethods,
     getValues: jest.fn().mockReturnValueOnce([]).mockReturnValue(returnValue),
   }));
+jest.mock("utils/state/hooks/useElementIsHidden");
 
 const mockRadioElement = {
   type: ReportingRadioField,

--- a/services/ui-src/src/components/fields/ReportingRadioField.tsx
+++ b/services/ui-src/src/components/fields/ReportingRadioField.tsx
@@ -29,6 +29,7 @@ export const ReportingRadioField = (props: PageElementProps) => {
     const options = { required: radio.required ? requiredResponse : false };
     form.register(key, options);
     form.setValue(`${props.formkey}.id`, radio.id);
+    form.setValue(key, radio.answer);
   }, []);
 
   const onChangeHandler = async (
@@ -46,8 +47,9 @@ export const ReportingRadioField = (props: PageElementProps) => {
     form.setValue(`${props.formkey}.id`, radio.id);
 
     if (value === "no") {
-      clearMeasure(currentPageId ?? "", [radio.id]);
+      clearMeasure(currentPageId ?? "", { [radio.id]: value });
       saveReport();
+      event.stopPropagation(); // This action is doing its own effect outside of normal change.
       return;
     }
   };

--- a/services/ui-src/src/components/fields/ReportingRadioField.tsx
+++ b/services/ui-src/src/components/fields/ReportingRadioField.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useContext } from "react";
 import { Box } from "@chakra-ui/react";
 import { PageElementProps } from "components/report/Elements";
 import { FieldError, useFormContext } from "react-hook-form";
@@ -8,10 +8,12 @@ import { ChoiceList as CmsdsChoiceList } from "@cmsgov/design-system";
 import { formatChoices } from "./RadioField";
 import { ChoiceProps } from "@cmsgov/design-system/dist/react-components/types/ChoiceList/ChoiceList";
 import { requiredResponse } from "../../constants";
+import { ReportAutosaveContext } from "components/report/ReportAutosaveProvider";
 
 export const ReportingRadioField = (props: PageElementProps) => {
   const radio = props.element as ReportingRadioTemplate;
-  const { clearMeasure, saveReport, currentPageId } = useStore();
+  const { clearMeasure, currentPageId } = useStore();
+  const { autosave } = useContext(ReportAutosaveContext);
 
   const [displayValue, setDisplayValue] = useState<ChoiceProps[]>([]);
 
@@ -48,7 +50,7 @@ export const ReportingRadioField = (props: PageElementProps) => {
 
     if (value === "no") {
       clearMeasure(currentPageId ?? "", { [radio.id]: value });
-      saveReport();
+      autosave();
       event.stopPropagation(); // This action is doing its own effect outside of normal change.
       return;
     }

--- a/services/ui-src/src/components/fields/TextAreaField.test.tsx
+++ b/services/ui-src/src/components/fields/TextAreaField.test.tsx
@@ -6,6 +6,7 @@ import { mockStateUserStore } from "utils/testing/setupJest";
 import { useStore } from "utils";
 import { testA11y } from "utils/testing/commonTests";
 import { ElementType, TextAreaBoxTemplate } from "types/report";
+import { useElementIsHidden } from "utils/state/hooks/useElementIsHidden";
 
 const mockTrigger = jest.fn();
 const mockRhfMethods = {
@@ -26,6 +27,10 @@ const mockGetValues = (returnValue: any) =>
     ...mockRhfMethods,
     getValues: jest.fn().mockReturnValueOnce([]).mockReturnValue(returnValue),
   }));
+jest.mock("utils/state/hooks/useElementIsHidden");
+const mockedUseElementIsHidden = useElementIsHidden as jest.MockedFunction<
+  typeof useElementIsHidden
+>;
 
 jest.mock("utils/state/useStore");
 const mockedUseStore = useStore as jest.MockedFunction<typeof useStore>;
@@ -78,16 +83,7 @@ describe("<TextAreaField />", () => {
 
   describe("Text area field hide condition logic", () => {
     test("Text area field is hidden if its hide conditions' controlling element has a matching answer", async () => {
-      mockGetValues({
-        elements: [
-          {
-            answer: "yes",
-            type: "reportingRadio",
-            label: "Should we hide the other radios on this page?",
-            id: "reporting-radio",
-          },
-        ],
-      });
+      mockedUseElementIsHidden.mockReturnValueOnce(true);
       render(textAreaFieldComponent);
       const textField = screen.queryByLabelText("test label");
       expect(textField).not.toBeInTheDocument();

--- a/services/ui-src/src/components/fields/TextAreaField.tsx
+++ b/services/ui-src/src/components/fields/TextAreaField.tsx
@@ -11,11 +11,11 @@ export const TextAreaField = (props: PageElementProps) => {
   const textbox = props.element as TextAreaBoxTemplate;
   const defaultValue = textbox.answer ?? "";
   const [displayValue, setDisplayValue] = useState<string>(defaultValue);
-  const hideElement = useElementIsHidden(textbox.hideCondition);
 
   // get form context and register field
   const form = useFormContext();
   const key = `${props.formkey}.answer`;
+  const hideElement = useElementIsHidden(textbox.hideCondition, key);
   useEffect(() => {
     form.register(key);
     form.setValue(key, defaultValue);

--- a/services/ui-src/src/components/fields/TextField.test.tsx
+++ b/services/ui-src/src/components/fields/TextField.test.tsx
@@ -6,6 +6,7 @@ import { mockStateUserStore } from "utils/testing/setupJest";
 import { useStore } from "utils";
 import { testA11y } from "utils/testing/commonTests";
 import { ElementType, TextboxTemplate } from "types/report";
+import { useElementIsHidden } from "utils/state/hooks/useElementIsHidden";
 
 const mockTrigger = jest.fn();
 const mockRhfMethods = {
@@ -29,14 +30,18 @@ const mockGetValues = (returnValue: any) =>
 
 jest.mock("utils/state/useStore");
 const mockedUseStore = useStore as jest.MockedFunction<typeof useStore>;
+jest.mock("utils/state/hooks/useElementIsHidden");
+const mockedUseElementIsHidden = useElementIsHidden as jest.MockedFunction<
+  typeof useElementIsHidden
+>;
 
 const mockedTextboxElement = {
   type: ElementType.Textbox,
   label: "test label",
   helperText: "helper text",
   hideCondition: {
-    controllerElementId: "reporting-radio",
-    answer: "yes",
+    controllerElementId: "measure-reporting-radio",
+    answer: "no",
   },
 } as TextboxTemplate;
 
@@ -72,16 +77,8 @@ describe("<TextField />", () => {
 
   describe("Text field hide condition logic", () => {
     test("Text field is hidden if its hide conditions' controlling element has a matching answer", async () => {
-      mockGetValues({
-        elements: [
-          {
-            answer: "yes",
-            type: "reportingRadio",
-            label: "Should we hide the other radios on this page?",
-            id: "reporting-radio",
-          },
-        ],
-      });
+      mockedUseStore.mockReturnValue(mockStateUserStore);
+      mockedUseElementIsHidden.mockReturnValueOnce(true);
       render(textFieldComponent);
       const textField = screen.queryByLabelText("test label");
       expect(textField).not.toBeInTheDocument();

--- a/services/ui-src/src/components/fields/TextField.tsx
+++ b/services/ui-src/src/components/fields/TextField.tsx
@@ -12,11 +12,12 @@ export const TextField = (props: PageElementProps) => {
   const textbox = props.element as TextboxTemplate;
   const defaultValue = textbox.answer ?? "";
   const [displayValue, setDisplayValue] = useState<string>(defaultValue);
-  const hideElement = useElementIsHidden(textbox.hideCondition);
 
   // get form context and register field
   const form = useFormContext();
   const key = `${props.formkey}.answer`;
+  const hideElement = useElementIsHidden(textbox.hideCondition, key);
+
   useEffect(() => {
     const options = { required: textbox.required ? requiredResponse : false };
     form.register(key, options);

--- a/services/ui-src/src/components/report/MeasureFooter.tsx
+++ b/services/ui-src/src/components/report/MeasureFooter.tsx
@@ -8,6 +8,8 @@ import {
   currentPageCompletableSelector,
   currentPageSelector,
 } from "utils/state/selectors";
+import { useContext } from "react";
+import { ReportAutosaveContext } from "./ReportAutosaveProvider";
 
 export const MeasureFooterElement = (props: PageElementProps) => {
   const footer = props.element as MeasureFooterTemplate;
@@ -15,11 +17,11 @@ export const MeasureFooterElement = (props: PageElementProps) => {
   const {
     report,
     resetMeasure,
-    saveReport,
     setModalComponent,
     setModalOpen,
     completePage,
   } = useStore();
+  const { autosave } = useContext(ReportAutosaveContext);
   const currentPage = useStore(currentPageSelector);
   const completable = useStore(currentPageCompletableSelector);
   const completeEnabled =
@@ -31,7 +33,7 @@ export const MeasureFooterElement = (props: PageElementProps) => {
   const navigate = useNavigate();
   const submitClear = () => {
     resetMeasure(currentPage.id);
-    saveReport();
+    autosave();
   };
 
   const getPrevPageId = () => {
@@ -43,7 +45,7 @@ export const MeasureFooterElement = (props: PageElementProps) => {
 
   const onCompletePage = () => {
     completePage(currentPage.id);
-    saveReport();
+    autosave();
 
     //there's some interference with the scroll so we need a delay before it will work
     setTimeout(function () {

--- a/services/ui-src/src/components/report/MeasureTable.tsx
+++ b/services/ui-src/src/components/report/MeasureTable.tsx
@@ -20,11 +20,13 @@ import {
 } from "types";
 import { useStore } from "utils";
 import { PageElementProps } from "./Elements";
+import { useContext } from "react";
+import { ReportAutosaveContext } from "./ReportAutosaveProvider";
 
 export const MeasureTableElement = (props: PageElementProps) => {
   const table = props.element as MeasureTableTemplate;
-  const { report, setModalComponent, setModalOpen, setSubstitute, saveReport } =
-    useStore();
+  const { report, setModalComponent, setModalOpen, setSubstitute } = useStore();
+  const { autosave } = useContext(ReportAutosaveContext);
   const measures = report?.pages.filter((page) =>
     isMeasureTemplate(page)
   ) as MeasurePageTemplate[];
@@ -40,7 +42,7 @@ export const MeasureTableElement = (props: PageElementProps) => {
   const onSubstitute = async (selectMeasure: MeasurePageTemplate) => {
     if (report) {
       setSubstitute(report, selectMeasure);
-      saveReport();
+      autosave();
     }
     setModalOpen(false);
   };

--- a/services/ui-src/src/components/report/ReportAutosaveProvider.test.tsx
+++ b/services/ui-src/src/components/report/ReportAutosaveProvider.test.tsx
@@ -1,0 +1,59 @@
+import { useContext } from "react";
+import { render, screen, act, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+// utils
+import { RouterWrappedComponent } from "utils/testing/setupJest";
+import {
+  ReportAutosaveContext,
+  ReportAutosaveProvider,
+} from "./ReportAutosaveProvider";
+
+const mockSaveReport = jest.fn();
+
+jest.mock("utils/state/useStore", () => ({
+  ...jest.requireActual("utils/state/useStore"),
+  saveReport: () => mockSaveReport,
+}));
+
+// COMPONENTS
+
+const TestComponent = () => {
+  const { ...context } = useContext(ReportAutosaveContext);
+  return (
+    <div>
+      <button onClick={() => context.autosave()}>Save</button>
+      Save Test
+    </div>
+  );
+};
+
+const testComponent = (
+  <RouterWrappedComponent>
+    <ReportAutosaveProvider>
+      <TestComponent />
+    </ReportAutosaveProvider>
+  </RouterWrappedComponent>
+);
+
+// TESTS
+
+describe("<UserProvider />", () => {
+  beforeEach(async () => {
+    await act(async () => {
+      render(testComponent);
+    });
+  });
+
+  test("child component renders", () => {
+    expect(screen.getByText("Save Test")).toBeVisible();
+  });
+
+  test("test autosave function", async () => {
+    await act(async () => {
+      const saveButton = screen.getByRole("button", { name: "Save" });
+      await userEvent.click(saveButton);
+    });
+    jest.runAllTimers();
+    await waitFor(() => expect(mockSaveReport).toHaveBeenCalled);
+  });
+});

--- a/services/ui-src/src/components/report/ReportAutosaveProvider.tsx
+++ b/services/ui-src/src/components/report/ReportAutosaveProvider.tsx
@@ -1,0 +1,40 @@
+import { createContext, ReactNode, useState } from "react";
+import { useStore } from "utils";
+
+export const ReportAutosaveContext = createContext({
+  autosave: () => {},
+});
+
+export const ReportAutosaveProvider = ({ children }: Props) => {
+  const [timerId, setTimerId] = useState<ReturnType<typeof setTimeout>>();
+  const { report, saveReport } = useStore();
+
+  const useDebounce = (func: Function, delay: number = 2000) => {
+    if (timerId) clearTimeout(timerId);
+
+    let timer = setTimeout(() => {
+      func();
+    }, delay);
+    setTimerId(timer);
+  };
+
+  const autosave = () => {
+    useDebounce(() => {
+      if (!report) return;
+      saveReport();
+    });
+  };
+  const value = {
+    autosave,
+  };
+
+  return (
+    <ReportAutosaveContext.Provider value={value}>
+      {children}
+    </ReportAutosaveContext.Provider>
+  );
+};
+
+interface Props {
+  children?: ReactNode;
+}

--- a/services/ui-src/src/components/report/ReportPageWrapper.tsx
+++ b/services/ui-src/src/components/report/ReportPageWrapper.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useContext, useEffect, useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import { FormProvider, useForm } from "react-hook-form";
 import {
@@ -20,6 +20,7 @@ import { currentPageSelector } from "utils/state/selectors";
 import nextArrowIcon from "assets/icons/arrows/icon_arrow_next_white.svg";
 import prevArrowIcon from "assets/icons/arrows/icon_arrow_prev_primary.svg";
 import { isReviewSubmitPage, ReportStatus } from "types";
+import { ReportAutosaveContext } from "./ReportAutosaveProvider";
 
 export const ReportPageWrapper = () => {
   const {
@@ -29,13 +30,12 @@ export const ReportPageWrapper = () => {
     loadReport: setReport,
     setAnswers,
     setCurrentPageId,
-    saveReport,
   } = useStore();
   const currentPage = useStore(currentPageSelector);
 
   const { reportType, state, reportId, pageId } = useParams();
   const [isLoading, setIsLoading] = useState<boolean>(true);
-  const [timerId, setTimerId] = useState<ReturnType<typeof setTimeout>>();
+  const { autosave } = useContext(ReportAutosaveContext);
 
   const methods = useForm({
     defaultValues: {},
@@ -54,28 +54,16 @@ export const ReportPageWrapper = () => {
     }
   }, [pageId]);
 
-  const useDebounce = (func: Function, delay: number = 2000) => {
-    if (timerId) clearTimeout(timerId);
-
-    let timer = setTimeout(() => {
-      func();
-    }, delay);
-    setTimerId(timer);
-  };
-
   const handleChange = async (data: any) => {
     setAnswers(data);
-    useDebounce(() => {
-      if (!report) return;
-      saveReport();
-    });
+    autosave();
   };
 
   const handleError = async (errors: any) => {
     const data = methods.getValues();
     if (!report) return;
     setAnswers(data, errors);
-    saveReport();
+    autosave();
   };
 
   const fetchReport = async () => {

--- a/services/ui-src/src/types/states.ts
+++ b/services/ui-src/src/types/states.ts
@@ -54,7 +54,10 @@ export interface HcbsReportState {
   setModalOpen: (modalOpen: boolean) => void;
   setModalComponent: (modalComponent: ReactNode, modalHeader: string) => void;
   setAnswers: (answers: any, errors?: any) => void;
-  clearMeasure: (measureId: string, ignoreList: string[]) => void;
+  clearMeasure: (
+    measureId: string,
+    ignoreList: { [key: string]: string }
+  ) => void;
   completePage: (measureId: string) => void;
   resetMeasure: (measureId: string) => void;
   setSubstitute: (report: Report, selectMeasure: MeasurePageTemplate) => void;

--- a/services/ui-src/src/utils/state/hooks/useElementIsHidden.ts
+++ b/services/ui-src/src/utils/state/hooks/useElementIsHidden.ts
@@ -15,21 +15,14 @@ export const useElementIsHidden = (
 
   useEffect(() => {
     if (!hideCondition || !currentPage?.elements) {
-      setHideElement(false);
       return;
     }
 
-    const newHideState = elementIsHidden(hideCondition, currentPage.elements);
-    if (!hideElement && newHideState && answerKey) {
-      // Hiding - unbind so future updates don't continue overwriting
-      form.unregister(answerKey);
-      setHideElement(newHideState);
-    } else if (hideElement && !newHideState && answerKey) {
-      // Unhiding
-
-      // form.clearErrors(answerKey); // continue to investigate
-      setHideElement(newHideState);
+    const hidden = elementIsHidden(hideCondition, currentPage.elements);
+    if (hidden && answerKey) {
+      form.unregister(answerKey); // unbind so future updates don't continue overwriting
     }
+    setHideElement(hidden);
   }, [currentPage]);
   return hideElement;
 };

--- a/services/ui-src/src/utils/state/reportLogic/completeness.ts
+++ b/services/ui-src/src/utils/state/reportLogic/completeness.ts
@@ -218,7 +218,7 @@ export const elementIsHidden = (
     return target?.id === hideCondition?.controllerElementId;
   });
   return (
-    controlElement &&
+    !!controlElement &&
     "answer" in controlElement &&
     controlElement.answer === hideCondition?.answer
   );

--- a/services/ui-src/src/utils/state/reportLogic/reportActions.test.ts
+++ b/services/ui-src/src/utils/state/reportLogic/reportActions.test.ts
@@ -614,7 +614,9 @@ describe("state/management/reportState: clearMeasure", () => {
     };
 
     const state = buildState(testReport, false) as unknown as HcbsReportState;
-    const response = clearMeasure("LTSS-1", state, ["measure-reporting-radio"]);
+    const response = clearMeasure("LTSS-1", state, {
+      ["measure-reporting-radio"]: "no",
+    });
     const measure = response!.report!.pages[3] as MeasurePageTemplate;
     const reportingRadio = measure.elements[0] as ReportingRadioTemplate;
     const question = measure.elements[1] as TextboxTemplate;

--- a/services/ui-src/src/utils/state/reportLogic/reportActions.ts
+++ b/services/ui-src/src/utils/state/reportLogic/reportActions.ts
@@ -182,7 +182,7 @@ export const markPageComplete = (pageId: string, state: HcbsReportState) => {
 export const clearMeasure = (
   measureId: string,
   state: HcbsReportState,
-  ignoreList: string[]
+  ignoreList: { [key: string]: string }
 ) => {
   if (!state.report) return;
   const report = structuredClone(state.report);

--- a/services/ui-src/src/utils/state/reportLogic/reset.ts
+++ b/services/ui-src/src/utils/state/reportLogic/reset.ts
@@ -18,7 +18,7 @@ import {
 export const performClearMeasure = (
   measureId: string,
   report: Report,
-  ignoreList: string[]
+  ignoreList: { [key: string]: string }
 ) => {
   const page = report.pages.find((page) => page.id === measureId);
   if (!page) {
@@ -29,16 +29,17 @@ export const performClearMeasure = (
   }
   // Clean measure
   page.elements?.forEach((element) => {
-    if (ignoreList.includes(element.id)) {
+    if (element.id in ignoreList && "answer" in element) {
+      element.answer = ignoreList[element.id];
       return;
     }
     performResetPageElement(element);
   });
 
-  // Clear children of measures
+  // Clear children of measures - hard reset
   if (page.type === PageType.Measure) {
     (page as MeasurePageTemplate).dependentPages?.forEach((child) => {
-      performClearMeasure(child.template, report, ignoreList);
+      performResetMeasure(child.template, report);
     });
   }
 

--- a/services/ui-src/src/utils/state/reportLogic/reset.ts
+++ b/services/ui-src/src/utils/state/reportLogic/reset.ts
@@ -29,8 +29,10 @@ export const performClearMeasure = (
   }
   // Clean measure
   page.elements?.forEach((element) => {
-    if (element.id in ignoreList && "answer" in element) {
-      element.answer = ignoreList[element.id];
+    if (element.id in ignoreList) {
+      // Answer may not be set yet, typeguard can derail
+      const elementWithAnswer = element as Partial<{ answer: any }>;
+      elementWithAnswer.answer = ignoreList[element.id];
       return;
     }
     performResetPageElement(element);

--- a/services/ui-src/src/utils/state/useStore.ts
+++ b/services/ui-src/src/utils/state/useStore.ts
@@ -121,7 +121,7 @@ const reportStore = (set: Function, get: Function): HcbsReportState => ({
     set((state: HcbsReportState) => resetMeasure(measureId, state), false, {
       type: "resetMeasure",
     }),
-  clearMeasure: (measureId: string, ignoreList: string[]) =>
+  clearMeasure: (measureId: string, ignoreList: { [key: string]: string }) =>
     set(
       (state: HcbsReportState) => clearMeasure(measureId, state, ignoreList),
       false,

--- a/services/ui-src/src/utils/testing/setupJest.tsx
+++ b/services/ui-src/src/utils/testing/setupJest.tsx
@@ -206,7 +206,24 @@ export const mockMeasureTemplate: MeasurePageTemplate = {
   type: PageType.Measure,
   required: true,
   substitutable: "FASI-1",
-  elements: [],
+  elements: [
+    {
+      type: ElementType.ReportingRadio,
+      label: "Is the state reporting on this measure?",
+      id: "measure-reporting-radio",
+      value: [
+        {
+          label: "Yes, the state is reporting on this measure",
+          value: "yes",
+        },
+        {
+          label: "No, CMS is reporting this measure on the state's behalf",
+          value: "no",
+        },
+      ],
+      answer: "yes",
+    },
+  ],
   dependentPages: [
     {
       key: "FFS",


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Addresses a few behaviors around the reporting radio button
1. When refreshing the page, hidden elements continue to be hidden
2. When toggling the yes/no, data in the measure is properly cleared
3. Other edge cases where saveReport was being managed were folded into the autosave provider, so they would never go rogue and overwrite each other.

Points 2 and 3 above were addresed by introducing an Autosave Provider, which moves the recent debounce in ReportPageWrapper up a level to a shared function. Now any time an action gets taken, that can be called and after 3 seconds of debounciness, the most recent version of any of these changes gets sent to be saved, whether it be text field changes, clearing measures, or completing them.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4512

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
https://d1m5rzw7wglmjj.cloudfront.net/
- Create a report
- Navigate to LTSS-6
- Fill out the form
- Flip to no, flip to yes, the content should be removed
- Flip to no, refresh, the form should stay hidden
- Try some permutations of the above

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
