### PR TITLE
[HCBS] - Substitute Measure and Sidebar - Tabable

### DIFF
--- a/services/ui-src/src/components/report/MeasureTable.tsx
+++ b/services/ui-src/src/components/report/MeasureTable.tsx
@@ -1,4 +1,4 @@
-import { useNavigate, useParams } from "react-router-dom";
+import { useParams } from "react-router-dom";
 import {
   Button,
   Table,
@@ -55,11 +55,9 @@ export const MeasureTableElement = (props: PageElementProps) => {
   };
 
   const { reportType, state, reportId } = useParams();
-  const navigate = useNavigate();
 
   const handleEditClick = (measureId: string) => {
-    const path = `/report/${reportType}/${state}/${reportId}/${measureId}`;
-    navigate(path);
+    return `/report/${reportType}/${state}/${reportId}/${measureId}`;
   };
 
   const getTableStatus = (measure: MeasurePageTemplate) => {
@@ -103,7 +101,17 @@ export const MeasureTableElement = (props: PageElementProps) => {
         </Td>
         <Td>
           {measure.substitutable && measure.required ? (
-            <Link onClick={() => buildModal(measure)}>Substitute measure</Link>
+            <Button
+              as={Link}
+              variant="link"
+              href={handleEditClick(measure.id)}
+              onClick={(e) => {
+                e.preventDefault(); // Prevent default navigation if needed
+                buildModal(measure);
+              }}
+            >
+              Substitute measure
+            </Button>
           ) : null}
         </Td>
 

--- a/services/ui-src/src/components/report/Sidebar.tsx
+++ b/services/ui-src/src/components/report/Sidebar.tsx
@@ -51,13 +51,10 @@ export const Sidebar = () => {
         <Button
           variant={"sidebar"}
           className={page.id === currentPageId ? "selected" : ""}
+          onClick={() => onNavSelect(page.id)}
         >
           <Flex justifyContent="space-between" alignItems="center">
-            <Box
-              width="100%"
-              height="100%"
-              onClick={() => onNavSelect(page.id)}
-            >
+            <Box width="100%" height="100%">
               {navItem(page.title!, index)}
             </Box>
             {childSections?.length! > 0 && (


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
This PR covers both Sidebar menu fix where previously because the onClick was being applied to the Button's child, the space or return button wouldn't click into the sidebar page. Additionally, substitute measure is updated to a Button as a Link so that UI wise it still looks like a Link but functions as a button since it's an action and does not navigate to a new page upon pressing the button.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4544

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->


### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
