### PR TITLE
Hide the "Substitute Measure" button in submitted reports

### DIFF
--- a/services/ui-src/src/components/report/MeasureTable.test.tsx
+++ b/services/ui-src/src/components/report/MeasureTable.test.tsx
@@ -1,53 +1,161 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { MeasureTableElement } from "./MeasureTable";
-import { mockMeasureTemplate, mockUseStore } from "utils/testing/setupJest";
+import { mockUseStore } from "utils/testing/setupJest";
 import { useStore } from "utils/state/useStore";
-import { ElementType, MeasurePageTemplate, PageElement } from "types";
-import { MemoryRouter } from "react-router-dom";
+import {
+  ElementType,
+  MeasurePageTemplate,
+  MeasureTableTemplate,
+  PageType,
+  Report,
+  ReportStatus,
+} from "types";
+import { MemoryRouter, useNavigate } from "react-router-dom";
+
+const mockReport = {
+  status: ReportStatus.IN_PROGRESS,
+  pages: [
+    {
+      type: PageType.Measure,
+      id: "mock-measure-1",
+      title: "Mock Measure Req",
+      cmit: 42,
+      substitutable: "mock-measure-3",
+      required: true,
+    } as MeasurePageTemplate,
+    {
+      type: PageType.Measure,
+      id: "mock-measure-2",
+      title: "Mock Measure Strat",
+      cmit: 43,
+      required: true,
+      stratified: true,
+    } as MeasurePageTemplate,
+    {
+      type: PageType.Measure,
+      id: "mock-measure-3",
+      title: "Mock Measure Opt",
+      cmit: 44,
+      substitutable: "mock-measure-1",
+      required: false,
+    } as MeasurePageTemplate,
+  ],
+} as Report;
 
 jest.mock("utils/state/useStore");
 const mockedUseStore = useStore as jest.MockedFunction<typeof useStore>;
-mockedUseStore.mockReturnValue(mockUseStore);
+mockedUseStore.mockReturnValue({
+  ...mockUseStore,
+  report: mockReport,
+});
 
-const mockedMeasureTableElement = {
+jest.mock("react-router-dom", () => ({
+  ...jest.requireActual("react-router-dom"),
+  useParams: jest.fn().mockReturnValue({
+    reportType: "QMS",
+    state: "CO",
+    reportId: "123",
+  }),
+  useNavigate: jest.fn().mockReturnValue(jest.fn()),
+}));
+const mockedNavigate = useNavigate() as jest.Mock;
+
+const mockTemplate: MeasureTableTemplate = {
   type: ElementType.MeasureTable,
+  id: "mock-table-id",
   measureDisplay: "required",
 };
 
 jest.mock("./MeasureReplacementModal", () => ({
   MeasureReplacementModal: (
-    _measure: MeasurePageTemplate,
+    measure: MeasurePageTemplate,
     _onClose: Function,
     onSubmit: Function
   ) => {
-    onSubmit(mockMeasureTemplate);
+    onSubmit(measure);
   },
 }));
 
 const MeasureTableComponent = (
-  <MemoryRouter>
-    <MeasureTableElement
-      element={mockedMeasureTableElement as unknown as PageElement}
-      formkey={""}
-    ></MeasureTableElement>
-  </MemoryRouter>
-);
+  measureDisplay: MeasureTableTemplate["measureDisplay"]
+) => {
+  const template = { ...mockTemplate, measureDisplay };
+  return (
+    <MemoryRouter>
+      <MeasureTableElement element={template} formkey={""} />
+    </MemoryRouter>
+  );
+};
 
-/* To do: add real test */
 describe("Test MeasureTable", () => {
   beforeEach(() => {
-    render(MeasureTableComponent);
+    jest.clearAllMocks();
   });
-  it("Test MeasureTable render", () => {
-    expect(screen.getByText("mock-title")).toBeInTheDocument();
+
+  it("should display required measures when in required mode", () => {
+    render(MeasureTableComponent("required"));
+
+    expect(screen.getByText("Mock Measure Req")).toBeInTheDocument();
+    // Note that our mock Stratified measure is required, so it will show here.
+    expect(screen.getByText("Mock Measure Strat")).toBeInTheDocument();
+    expect(screen.queryByText("Mock Measure Opt")).not.toBeInTheDocument();
   });
-  it("Test Sustitute button", async () => {
-    const substituteBtn = screen.getByText("Substitute measure");
-    await userEvent.click(substituteBtn);
+
+  it("should display stratified measures when in stratified mode", () => {
+    render(MeasureTableComponent("stratified"));
+
+    expect(screen.queryByText("Mock Measure Req")).not.toBeInTheDocument();
+    expect(screen.getByText("Mock Measure Strat")).toBeInTheDocument();
+    expect(screen.queryByText("Mock Measure Opt")).not.toBeInTheDocument();
   });
-  it("Test Edit button", async () => {
-    const editBtn = screen.getAllByText("Edit")[0];
-    await userEvent.click(editBtn);
+
+  it("should display optional measures when in optional mode", () => {
+    render(MeasureTableComponent("optional"));
+
+    expect(screen.queryByText("Mock Measure Req")).not.toBeInTheDocument();
+    expect(screen.queryByText("Mock Measure Strat")).not.toBeInTheDocument();
+    expect(screen.getByText("Mock Measure Opt")).toBeInTheDocument();
+
+    // Also, the substitute button should not be visible for non-required measures
+    expect(screen.queryByText("Substitute measure")).not.toBeInTheDocument();
+  });
+
+  it("should perform substitution when the button is clicked", async () => {
+    const mockSubstitute = jest.fn();
+    const requiredMeasure = mockReport.pages.find((p: any) => p.required);
+    mockedUseStore.mockReturnValue({
+      ...mockUseStore,
+      report: mockReport,
+      setSubstitute: mockSubstitute,
+    });
+
+    render(MeasureTableComponent("required"));
+
+    const substituteButton = screen.getByText("Substitute measure");
+    await userEvent.click(substituteButton);
+    expect(mockSubstitute).toHaveBeenCalledWith(mockReport, requiredMeasure);
+  });
+
+  it("should not show the substitute button for submitted reports", () => {
+    mockedUseStore.mockReturnValueOnce({
+      ...mockUseStore,
+      report: {
+        ...mockReport,
+        status: ReportStatus.SUBMITTED,
+      },
+    });
+    render(MeasureTableComponent("required"));
+    const substituteButton = screen.queryByText("Substitute measure");
+    expect(substituteButton).not.toBeInTheDocument();
+  });
+
+  it("should navigate to the measure when the edit button is clicked", async () => {
+    render(MeasureTableComponent("required"));
+    const editButton = screen.getAllByText("Edit")[0];
+    await userEvent.click(editButton);
+    expect(mockedNavigate).toHaveBeenCalledWith(
+      "/report/QMS/CO/123/mock-measure-1"
+    );
   });
 });

--- a/services/ui-src/src/components/report/MeasureTable.tsx
+++ b/services/ui-src/src/components/report/MeasureTable.tsx
@@ -17,6 +17,7 @@ import {
   PageStatus,
   MeasureTableTemplate,
   PageType,
+  ReportStatus,
 } from "types";
 import { useStore } from "utils";
 import { PageElementProps } from "./Elements";
@@ -103,7 +104,9 @@ export const MeasureTableElement = (props: PageElementProps) => {
           {errorMessage(measure)}
         </Td>
         <Td>
-          {measure.substitutable && measure.required ? (
+          {measure.substitutable &&
+          measure.required &&
+          report?.status !== ReportStatus.SUBMITTED ? (
             <Button
               variant="link"
               sx={{ fontSize: "14px" }}


### PR DESCRIPTION
### Description
After a report is submitted, it cannot be changed. One type of change that should be disallowed is the substitution of Optional Measures for Required ones. And now, with this PR, that _is_ disallowed! :tada:

Here is a screenshot showcasing the lack of "Substitute measure" buttons, within a submitted report:
![image](https://github.com/user-attachments/assets/7f194cf8-6536-458f-ab48-81a9b02251f8)

### Related ticket(s)
CMDCT-4601

---
### How to test
https://dgftiobu9dks4.cloudfront.net/

1. Create a report and fill it out
2. Observe that, when viewing the Required Measures page, each measure has a Substitute button
3. Submit the report
4. Observe that the Substitute button is gone
5. Unlock the report
6. Observe that the Substitute button is back

### Important updates
n/a

---
### Author checklist

- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- ~[ ] I have updated relevant documentation, if necessary~
