### PR TITLE
NDR Field Bug Fix

### DIFF
--- a/services/ui-src/src/components/cards/ReportIntroCardActions.tsx
+++ b/services/ui-src/src/components/cards/ReportIntroCardActions.tsx
@@ -40,7 +40,7 @@ const sx = {
   actionsFlex: {
     flexFlow: "no-wrap",
     gridGap: "1rem",
-    justifyContent: "space-between",
+    justifyContent: "end",
     margin: "1rem 0 0 1rem",
     ".mobile &": {
       flexDirection: "column",

--- a/services/ui-src/src/utils/state/reportLogic/completeness.test.ts
+++ b/services/ui-src/src/utils/state/reportLogic/completeness.test.ts
@@ -5,6 +5,7 @@ import {
   PerformanceRateTemplate,
   PerformanceRateType,
   RadioTemplate,
+  RateSetData,
 } from "types";
 import {
   elementSatisfiesRequired,
@@ -284,10 +285,30 @@ describe("elementSatisfiesRequired", () => {
       required: true,
       rateType: PerformanceRateType.NDR,
     } as PerformanceRateTemplate;
+    const badNDRFieldRate = {
+      id: "bad-ndr-field-rate",
+      type: ElementType.PerformanceRate,
+      required: true,
+      rateType: PerformanceRateType.NDR_FIELDS,
+      fields: [{ label: "abc", id: "abc" }],
+      answer: [
+        {
+          id: "mock-id",
+          label: "abc",
+          rates: [
+            {
+              label: "abc",
+              performanceTarget: undefined,
+            },
+          ],
+        },
+      ] as RateSetData[],
+    } as PerformanceRateTemplate;
     const elements = [goodRateA, goodRateB, badRate];
     expect(elementSatisfiesRequired(goodRateA, elements)).toBeTruthy();
     expect(elementSatisfiesRequired(goodRateB, elements)).toBeTruthy();
     expect(elementSatisfiesRequired(fieldsRate, elements)).toBeTruthy();
     expect(elementSatisfiesRequired(badRate, elements)).toBeFalsy();
+    expect(elementSatisfiesRequired(badNDRFieldRate, elements)).toBeFalsy();
   });
 });

--- a/services/ui-src/src/utils/state/reportLogic/completeness.ts
+++ b/services/ui-src/src/utils/state/reportLogic/completeness.ts
@@ -200,8 +200,16 @@ const rateIsComplete = (element: PerformanceRateTemplate) => {
     for (const rateAnswer of element.answer) {
       if (!rateAnswer.rates) return false;
       for (const uniqueRate of rateAnswer.rates) {
-        if (uniqueRate.performanceTarget === undefined) return false;
-        if (uniqueRate.rate === undefined) return false;
+        if (
+          uniqueRate.performanceTarget === undefined ||
+          (uniqueRate.performanceTarget as number | string) === ""
+        )
+          return false;
+        if (
+          uniqueRate.rate === undefined ||
+          (uniqueRate.rate as number | string) === ""
+        )
+          return false;
       }
     }
   }

--- a/services/ui-src/src/utils/state/reportLogic/completeness.ts
+++ b/services/ui-src/src/utils/state/reportLogic/completeness.ts
@@ -174,6 +174,8 @@ export const elementSatisfiesRequired = (
 };
 
 const rateIsComplete = (element: PerformanceRateTemplate) => {
+  const emptyAnswers = ["", undefined];
+
   if (!element.answer) return false;
   if ("rates" in element.answer) {
     // Fields
@@ -187,10 +189,8 @@ const rateIsComplete = (element: PerformanceRateTemplate) => {
       // PerformanceData
       for (const uniqueRate of element.answer.rates) {
         if (
-          uniqueRate.rate === undefined ||
-          uniqueRate.rate === "" ||
-          uniqueRate.performanceTarget === undefined ||
-          uniqueRate.performanceTarget === ""
+          emptyAnswers.includes(uniqueRate.performanceTarget) ||
+          emptyAnswers.includes(uniqueRate.rate)
         )
           return false;
       }
@@ -201,10 +201,10 @@ const rateIsComplete = (element: PerformanceRateTemplate) => {
       if (!rateAnswer.rates) return false;
       for (const uniqueRate of rateAnswer.rates) {
         if (
-          uniqueRate.performanceTarget === undefined ||
-          (uniqueRate.performanceTarget as number | string) === "" ||
-          uniqueRate.rate === undefined ||
-          (uniqueRate.rate as number | string) === ""
+          emptyAnswers.includes(
+            uniqueRate.performanceTarget as string | undefined
+          ) ||
+          emptyAnswers.includes(uniqueRate.rate as string | undefined)
         )
           return false;
       }

--- a/services/ui-src/src/utils/state/reportLogic/completeness.ts
+++ b/services/ui-src/src/utils/state/reportLogic/completeness.ts
@@ -202,10 +202,7 @@ const rateIsComplete = (element: PerformanceRateTemplate) => {
       for (const uniqueRate of rateAnswer.rates) {
         if (
           uniqueRate.performanceTarget === undefined ||
-          (uniqueRate.performanceTarget as number | string) === ""
-        )
-          return false;
-        if (
+          (uniqueRate.performanceTarget as number | string) === "" ||
           uniqueRate.rate === undefined ||
           (uniqueRate.rate as number | string) === ""
         )


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
[Same issue as this PR](https://github.com/Enterprise-CMCS/macpro-mdct-hcbs/pull/212) but with NDR Field rate calcs. The solution is to also see if performanceTarget or rates is "".

https://github.com/user-attachments/assets/014e5493-fbc3-413a-b908-7339546653ad

Also in this pr is a styling fix, I moved the button back to the right:
![Screenshot 2025-04-30 at 2 42 56 PM](https://github.com/user-attachments/assets/3c2a5ffb-eaf8-4fb2-b1d7-d14406cdf4ed)

**Why does the solution require a cast?**
`(uniqueRate.rate as number | string) === ""`

So typescript is working correctly, as we have set rate to be a number and a number only. The issue is that for user experience, we have to be able to have an empty textbox and an undefined was not enough. An undefined causes the input to not fire our onchange/onblur correctly but we didn't want to allow it to take strings as we only wanted numbers to be save so we have this weird amalgamation. This is why we have to case before checking.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
1) Sign into HCBS, any state user
2) Create a new QMS report, no POM measures needed
3) Go to Optional Measure Results page
4) Edit "HCBS-10: Self-direction of Services and Supports Among Medicaid Beneficiaries Receiving LTSS through Managed Care Organizations" 
5) Fill out a performance measure and make sure that the [Complete section] button is enabling/disabling correctly.

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
