### PR TITLE
[CMDCT-4617] Radio Tab Fix

### DIFF
--- a/services/ui-src/src/components/fields/DateField.test.tsx
+++ b/services/ui-src/src/components/fields/DateField.test.tsx
@@ -64,18 +64,12 @@ describe("<DateField />", () => {
       render(dateFieldComponent);
       const dateFieldInput = screen.getByRole("textbox");
 
-      await userEvent.type(dateFieldInput, "10162024[Tab]");
-
-      /*
-       *   1 onChange (which passed validation) (value: 10162024)
-       * + 1 onChange (performed automatically by masking) (value: 10/16/2024)
-       * + 1 onBlur
-       * = 3 calls
-       */
-      expect(mockRhfMethods.setValue).toHaveBeenCalledTimes(3);
+      await userEvent.type(dateFieldInput, "10162024");
+      expect(mockRhfMethods.setValue).toHaveBeenCalledTimes(1);
       expect(mockRhfMethods.setValue).toHaveBeenCalledWith(
         `${testKey}.answer`,
-        "10/16/2024"
+        "10/16/2024",
+        expect.any(Object)
       );
     });
   });

--- a/services/ui-src/src/components/fields/DateField.tsx
+++ b/services/ui-src/src/components/fields/DateField.tsx
@@ -31,10 +31,6 @@ export const DateField = (props: PageElementProps) => {
     }
   };
 
-  const onBlurHandler = async (event: React.ChangeEvent<HTMLInputElement>) => {
-    form.setValue(key, event.target.value);
-  };
-
   // prepare error message, hint, and classes
   const formErrors = form?.formState?.errors;
   const errorMessage: string | undefined = get(formErrors, key)?.message;
@@ -50,7 +46,6 @@ export const DateField = (props: PageElementProps) => {
         name={key}
         label={labelText || ""}
         onChange={onChangeHandler}
-        onBlur={onBlurHandler}
         value={displayValue}
         hint={parsedHint}
         errorMessage={errorMessage}

--- a/services/ui-src/src/components/fields/RadioField.tsx
+++ b/services/ui-src/src/components/fields/RadioField.tsx
@@ -126,12 +126,6 @@ export const RadioField = (props: PageElementProps) => {
     }
   };
 
-  const onBlurHandler = async (event: React.ChangeEvent<HTMLInputElement>) => {
-    form.setValue(key, event.target.value, { shouldValidate: true });
-    form.setValue(`${props.formkey}.type`, radio.type);
-    form.setValue(`${props.formkey}.label`, radio.label);
-  };
-
   // prepare error message, hint, and classes
   const formErrors = form?.formState?.errors;
   const errorMessage: string | undefined = get(formErrors, key)?.message;
@@ -156,7 +150,6 @@ export const RadioField = (props: PageElementProps) => {
         hint={parsedHint}
         errorMessage={errorMessage}
         onChange={onChangeHandler}
-        onComponentBlur={onBlurHandler}
         {...props}
       />
     </Box>

--- a/services/ui-src/src/components/fields/TextAreaField.test.tsx
+++ b/services/ui-src/src/components/fields/TextAreaField.test.tsx
@@ -71,13 +71,15 @@ describe("<TextAreaField />", () => {
       render(textAreaFieldComponent);
       const textAreaField = screen.getByRole("textbox");
 
-      await act(async () => await userEvent.type(textAreaField, "hello[Tab]"));
+      await act(async () => await userEvent.type(textAreaField, "h"));
 
-      // 5 keystrokes + 1 blur + 1 hydrate = 7 calls
-      expect(mockRhfMethods.setValue).toHaveBeenCalledTimes(7);
-      expect(mockRhfMethods.setValue).toHaveBeenCalledWith(
+      // hydrate + interact
+      expect(mockRhfMethods.setValue).toHaveBeenCalledTimes(2);
+      expect(mockRhfMethods.setValue).toHaveBeenNthCalledWith(
+        2,
         expect.any(String),
-        "hello"
+        "h",
+        expect.any(Object)
       );
     });
   });

--- a/services/ui-src/src/components/fields/TextAreaField.tsx
+++ b/services/ui-src/src/components/fields/TextAreaField.tsx
@@ -34,10 +34,6 @@ export const TextAreaField = (props: PageElementProps) => {
     form.setValue(name, value, { shouldValidate: true });
   };
 
-  const onBlurHandler = async (event: React.ChangeEvent<HTMLInputElement>) => {
-    form.setValue(key, event.target.value);
-  };
-
   // prepare error message, hint, and classes
   const formErrorState = form?.formState?.errors;
   const errorMessage: string | undefined = get(formErrorState, key)?.message;
@@ -60,7 +56,6 @@ export const TextAreaField = (props: PageElementProps) => {
         label={labelText || ""}
         hint={parsedHint}
         onChange={onChangeHandler}
-        onBlur={onBlurHandler}
         value={displayValue}
         errorMessage={errorMessage}
         multiline

--- a/services/ui-src/src/components/fields/TextField.test.tsx
+++ b/services/ui-src/src/components/fields/TextField.test.tsx
@@ -66,11 +66,15 @@ describe("<TextField />", () => {
       render(textFieldComponent);
       const textField = screen.getByRole("textbox");
 
-      await act(async () => await userEvent.type(textField, "hello[Tab]"));
+      await act(async () => await userEvent.type(textField, "h"));
 
-      expect(mockRhfMethods.setValue).toHaveBeenCalledWith(
+      // hydrate + enter letter + type + label + id
+      expect(mockRhfMethods.setValue).toHaveBeenCalledTimes(5);
+      expect(mockRhfMethods.setValue).toHaveBeenNthCalledWith(
+        2,
         expect.any(String),
-        "hello"
+        "h",
+        expect.any(Object)
       );
     });
   });

--- a/services/ui-src/src/components/fields/TextField.tsx
+++ b/services/ui-src/src/components/fields/TextField.tsx
@@ -40,10 +40,6 @@ export const TextField = (props: PageElementProps) => {
     form.setValue(`${props.formkey}.id`, textbox.id);
   };
 
-  const onBlurHandler = async (event: React.ChangeEvent<HTMLInputElement>) => {
-    form.setValue(key, event.target.value);
-  };
-
   // prepare error message, hint, and classes
   const formErrors = form?.formState?.errors;
   const errorMessage: string | undefined = get(formErrors, key)?.message;
@@ -62,7 +58,6 @@ export const TextField = (props: PageElementProps) => {
         label={labelText || ""}
         hint={parsedHint}
         onChange={onChangeHandler}
-        onBlur={onBlurHandler}
         value={displayValue}
         errorMessage={errorMessage}
         {...props}

--- a/services/ui-src/src/components/rates/types/Fields.tsx
+++ b/services/ui-src/src/components/rates/types/Fields.tsx
@@ -48,13 +48,6 @@ export const Fields = (
     form.setValue(`${key}`, displayValue, { shouldValidate: true });
     form.setValue(`${key}.type`, props.type);
   };
-  const onBlurHandler = (event: React.ChangeEvent<HTMLInputElement>) => {
-    if (!isNumber(event.target.value)) return;
-
-    const { name, value } = event.target;
-    form.setValue(`${key}.rates.${name}`, value, { shouldValidate: true });
-    form.setValue(`${key}.type`, props.type);
-  };
 
   return (
     <Stack gap="2rem">
@@ -64,7 +57,6 @@ export const Fields = (
         } state performance target for this assessment?`}
         name={`0.performanceTarget`}
         onChange={onChangeHandler}
-        onBlur={onBlurHandler}
         value={displayValue.rates[0].performanceTarget ?? ""}
         disabled={disabled}
       ></CmsdsTextField>
@@ -74,7 +66,6 @@ export const Fields = (
             label={field.label}
             name={`0.${field.id}`}
             onChange={onChangeHandler}
-            onBlur={onBlurHandler}
             value={displayValue.rates[0][field.id] ?? ""}
             disabled={field.autoCalc || disabled}
           ></CmsdsTextField>

--- a/services/ui-src/src/components/rates/types/NDR.tsx
+++ b/services/ui-src/src/components/rates/types/NDR.tsx
@@ -55,13 +55,6 @@ export const NDR = (
     form.setValue(`${key}`, displayValue, { shouldValidate: true });
     form.setValue(`${key}.type`, props.type);
   };
-  const onBlurHandler = async (event: React.ChangeEvent<HTMLInputElement>) => {
-    if (!isNumber(event.target.value)) return;
-
-    const { name, value } = event.target;
-    form.setValue(`${key}.rates.${name}`, value, { shouldValidate: true });
-    form.setValue(`${key}.type`, props.type);
-  };
 
   return (
     <Stack gap="2rem">
@@ -82,7 +75,6 @@ export const NDR = (
               } state performance target for this assessment?`}
               name={`${index}.performanceTarget`}
               onChange={onChangeHandler}
-              onBlur={onBlurHandler}
               value={value.performanceTarget ?? ""}
               disabled={disabled}
             ></CmsdsTextField>
@@ -90,7 +82,6 @@ export const NDR = (
               label="Numerator"
               name={`${index}.numerator`}
               onChange={onChangeHandler}
-              onBlur={onBlurHandler}
               value={value.numerator ?? ""}
               disabled={disabled}
             ></CmsdsTextField>
@@ -98,7 +89,6 @@ export const NDR = (
               label="Denominator"
               name={`${index}.denominator`}
               onChange={onChangeHandler}
-              onBlur={onBlurHandler}
               value={value.denominator ?? ""}
               disabled={disabled}
             ></CmsdsTextField>

--- a/services/ui-src/src/components/rates/types/NDREnhanced.tsx
+++ b/services/ui-src/src/components/rates/types/NDREnhanced.tsx
@@ -70,16 +70,6 @@ export const NDREnhanced = (
     form.setValue(`${key}`, newDisplayValue, { shouldValidate: true });
     form.setValue(`${key}.type`, props.type);
   };
-  const onBlurHandler = async (event: React.ChangeEvent<HTMLInputElement>) => {
-    if (!isNumber(event.target.value)) return;
-
-    const { name, value } = event.target;
-    let adjustedName = name === "denominator" ? "" : ".rates";
-    form.setValue(`${key}${adjustedName}.${name}`, value, {
-      shouldValidate: true,
-    });
-    form.setValue(`${key}.type`, props.type);
-  };
 
   return (
     <Stack gap="2rem">
@@ -87,7 +77,6 @@ export const NDREnhanced = (
         label="Performance Rates Denominator"
         name="denominator"
         onChange={onChangeHandler}
-        onBlur={onBlurHandler}
         value={displayValue?.denominator ?? ""}
         disabled={disabled}
       ></CmsdsTextField>
@@ -108,7 +97,6 @@ export const NDREnhanced = (
               } state performance target for this assessment?`}
               name={`${index}.performanceTarget`}
               onChange={onChangeHandler}
-              onBlur={onBlurHandler}
               value={value.performanceTarget ?? ""}
               disabled={disabled}
             ></CmsdsTextField>
@@ -116,7 +104,6 @@ export const NDREnhanced = (
               label="Numerator"
               name={`${index}.numerator`}
               onChange={onChangeHandler}
-              onBlur={onBlurHandler}
               value={value.numerator ?? ""}
               disabled={disabled}
             ></CmsdsTextField>
@@ -124,7 +111,6 @@ export const NDREnhanced = (
               label="Denominator"
               name={`${index}.denominator`}
               onChange={onChangeHandler}
-              onBlur={onBlurHandler}
               value={value.denominator ?? ""}
               hint="Auto-calculates"
               disabled

--- a/services/ui-src/src/components/rates/types/NDRFields.tsx
+++ b/services/ui-src/src/components/rates/types/NDRFields.tsx
@@ -84,13 +84,6 @@ export const NDRFields = (
     form.setValue(`${key}`, newValues, { shouldValidate: true });
     form.setValue(`${key}.type`, props.type);
   };
-  const onBlurHandler = async (event: React.ChangeEvent<HTMLInputElement>) => {
-    if (!isNumber(event.target.value)) return;
-
-    const { name, value } = event.target;
-    form.setValue(`${key}.${name}`, value, { shouldValidate: true });
-    form.setValue(`${key}.type`, props.type);
-  };
 
   return (
     <Stack gap="2rem">
@@ -109,7 +102,6 @@ export const NDRFields = (
               label={`Denominator (${assess.label})`}
               name={`${assessIndex}.denominator`}
               onChange={onChangeHandler}
-              onBlur={onBlurHandler}
               value={rateSet?.denominator ?? ""}
               disabled={disabled}
             ></CmsdsTextField>
@@ -130,7 +122,6 @@ export const NDRFields = (
                     })?`}
                     name={`${assessIndex}.rates.${fieldIndex}.performanceTarget`}
                     onChange={onChangeHandler}
-                    onBlur={onBlurHandler}
                     value={value?.performanceTarget ?? ""}
                     disabled={disabled}
                   ></CmsdsTextField>
@@ -138,7 +129,6 @@ export const NDRFields = (
                     label={`Numerator: ${field.label} (${assess.label})`}
                     name={`${assessIndex}.rates.${fieldIndex}.numerator`}
                     onChange={onChangeHandler}
-                    onBlur={onBlurHandler}
                     value={value?.numerator ?? ""}
                     disabled={disabled}
                   ></CmsdsTextField>
@@ -146,7 +136,6 @@ export const NDRFields = (
                     label={`Denominator (${assess.label})`}
                     name={`${assessIndex}.rates.${fieldIndex}.denominator`}
                     onChange={onChangeHandler}
-                    onBlur={onBlurHandler}
                     value={value?.denominator ?? ""}
                     disabled
                   ></CmsdsTextField>

--- a/services/ui-src/src/components/report/MeasureFooter.tsx
+++ b/services/ui-src/src/components/report/MeasureFooter.tsx
@@ -104,9 +104,6 @@ export const MeasureFooterElement = (props: PageElementProps) => {
             <Button
               variant="link"
               marginRight="2rem"
-              onBlur={(event) => {
-                event.stopPropagation();
-              }}
               onClick={() => onClearButton()}
             >
               Clear measure data
@@ -115,9 +112,6 @@ export const MeasureFooterElement = (props: PageElementProps) => {
           {footer.completeMeasure && (
             <Button
               disabled={!completeEnabled}
-              onBlur={(event) => {
-                event.stopPropagation();
-              }}
               onClick={() => onCompletePage()}
             >
               Complete measure
@@ -126,9 +120,6 @@ export const MeasureFooterElement = (props: PageElementProps) => {
           {footer.completeSection && (
             <Button
               disabled={!completeEnabled}
-              onBlur={(event) => {
-                event.stopPropagation();
-              }}
               onClick={() => onCompletePage()}
             >
               Complete section

--- a/services/ui-src/src/components/report/StatusTable.tsx
+++ b/services/ui-src/src/components/report/StatusTable.tsx
@@ -113,9 +113,6 @@ export const StatusTableElement = () => {
           <Button
             alignSelf="flex-end"
             onClick={async () => displayModal()}
-            onBlur={(event) => {
-              event.stopPropagation();
-            }}
             disabled={!submittableMetrics?.submittable || submitting}
           >
             {submitting && <Spinner size="sm" marginRight="1rem" />}


### PR DESCRIPTION
Tabbing through radios was having a weird effect when you skipped right past. This was due to removing the onBlur handling in favor of onchange, but KEEPING the onBlur handlers in the component.

The component would write the radio value of the previewed item into the hook form on tab, whatever we had in place at the wrapper level before prevented this for empty values.

This removes the vestigial traces of the blur handling, and assumes we're using change for everything.

I tested most odd interactions I could think of, but please poke around, give it a shot. 
### Description
<!-- Detailed description of changes and related context -->


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4617

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Report Creation Modal, 
- Enter name
- Tab through to submit without filling anything out
- You shouldn't be able to submit, good job us.

Measure Details
- Tab through the delivery method question to complete
- the table should not have lit up an edit link unexpectedly

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
