### PR TITLE
Create New Report Modal read only

### DIFF
--- a/services/ui-src/src/components/modals/AddEditReportModal.tsx
+++ b/services/ui-src/src/components/modals/AddEditReportModal.tsx
@@ -4,7 +4,7 @@ import { Spinner, Flex, Text } from "@chakra-ui/react";
 import { ElementType, Report } from "types";
 import { createReport, putReport } from "utils/api/requestMethods/report";
 import { FormProvider, useForm } from "react-hook-form";
-import { ReportOptions } from "types/report";
+import { ReportOptions, ReportStatus } from "types/report";
 
 export const AddEditReportModal = ({
   activeState,
@@ -14,7 +14,7 @@ export const AddEditReportModal = ({
   reportHandler,
 }: Props) => {
   const [submitting, setSubmitting] = useState<boolean>(false);
-
+  const readOnly = selectedReport?.status === ReportStatus.SUBMITTED;
   // TO-DO to update when we add template versioning by year
   const dropdownYears = [{ label: "2026", value: "2026" }];
 
@@ -76,6 +76,7 @@ export const AddEditReportModal = ({
         ),
         closeButtonText: "Cancel",
       }}
+      disableConfirm={readOnly}
     >
       <FormProvider {...form}>
         <form id="addEditReportModal" onSubmit={form.handleSubmit(onSubmit)}>
@@ -96,6 +97,7 @@ export const AddEditReportModal = ({
                 answer: selectedReport?.name,
                 required: true,
               }}
+              disabled={readOnly}
               formkey={"reportTitle"}
             />
             <DropdownField

--- a/services/ui-src/src/components/modals/Modal.test.tsx
+++ b/services/ui-src/src/components/modals/Modal.test.tsx
@@ -28,23 +28,43 @@ const modalComponent = (
 );
 
 describe("Test Modal", () => {
-  beforeEach(() => {
-    render(modalComponent);
-  });
+  beforeEach(() => {});
 
   test("Modal shows the contents", () => {
+    render(modalComponent);
     expect(screen.getByText(content.heading)).toBeTruthy();
     expect(screen.getByText(content.body)).toBeTruthy();
   });
 
   test("Modals action button can be clicked", () => {
+    render(modalComponent);
     fireEvent.click(screen.getByText(/Dialog Action/i));
     expect(mockConfirmationHandler).toHaveBeenCalledTimes(1);
   });
 
   test("Modals close button can be clicked", () => {
+    render(modalComponent);
     fireEvent.click(screen.getByText(/Cancel/i));
     expect(mockCloseHandler).toHaveBeenCalledTimes(1);
+  });
+  test("Modals disable submit when prompted", () => {
+    const disabledModal = (
+      <Modal
+        onConfirmHandler={mockConfirmationHandler}
+        modalDisclosure={{
+          isOpen: true,
+          onClose: mockCloseHandler,
+        }}
+        content={content}
+        disableConfirm={true}
+      >
+        <Text>{content.body}</Text>
+      </Modal>
+    );
+    render(disabledModal);
+
+    const button = screen.getByRole("button", { name: "Dialog Action" });
+    expect(button).toBeDisabled();
   });
 });
 

--- a/services/ui-src/src/components/modals/Modal.tsx
+++ b/services/ui-src/src/components/modals/Modal.tsx
@@ -22,6 +22,7 @@ export const Modal = ({
   submitting,
   formId,
   children,
+  disableConfirm,
 }: Props) => {
   return (
     <ChakraModal
@@ -58,6 +59,7 @@ export const Modal = ({
               form={formId}
               type="submit"
               data-testid="modal-submit-button"
+              disabled={disableConfirm}
             >
               {submitting ? <Spinner size="md" /> : content.actionButtonText}
             </Button>
@@ -67,6 +69,7 @@ export const Modal = ({
               sx={sx.action}
               onClick={() => onConfirmHandler()}
               data-testid="modal-submit-button"
+              disabled={disableConfirm}
             >
               {submitting ? <Spinner size="md" /> : content.actionButtonText}
             </Button>
@@ -100,6 +103,7 @@ interface Props {
   };
   submitting?: boolean;
   onConfirmHandler?: Function;
+  disableConfirm?: boolean;
   formId?: string;
   children?: ReactNode;
   [key: string]: any;

--- a/services/ui-src/src/components/pages/Dashboard/DashboardTable.test.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardTable.test.tsx
@@ -71,8 +71,7 @@ describe("Dashboard table with state user", () => {
   it("should render report name and edit button in table", async () => {
     render(dashboardTableComponent);
     expect(screen.getByText("report 1")).toBeInTheDocument();
-    // one report is submitted so there will 3 reports in the table but only two edit buttons
-    expect(screen.getAllByAltText("Edit Report Name").length).toBe(2);
+    expect(screen.getAllByAltText("Edit Report Name").length).toBe(3);
   });
 });
 

--- a/services/ui-src/src/components/pages/Dashboard/DashboardTable.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardTable.tsx
@@ -65,15 +65,9 @@ export const HorizontalTable = (props: TableProps) => {
         <Tr key={report.id}>
           {props.showEditNameColumn && (
             <Td fontWeight={"bold"}>
-              {report.status !== ReportStatus.SUBMITTED ? (
-                <button onClick={() => props.openAddEditReportModal(report)}>
-                  <Image
-                    src={editIcon}
-                    alt="Edit Report Name"
-                    minW={"1.75rem"}
-                  />
-                </button>
-              ) : null}
+              <button onClick={() => props.openAddEditReportModal(report)}>
+                <Image src={editIcon} alt="Edit Report Name" minW={"1.75rem"} />
+              </button>
             </Td>
           )}
           <Td
@@ -152,19 +146,13 @@ export const VerticalTable = (props: TableProps) => {
             <Text variant="grey">Submission name</Text>
             <HStack>
               {props.showEditNameColumn && (
-                <>
-                  {report.status !== ReportStatus.SUBMITTED ? (
-                    <button
-                      onClick={() => props.openAddEditReportModal(report)}
-                    >
-                      <Image
-                        src={editIcon}
-                        alt="Edit Report Name"
-                        minW={"1.75rem"}
-                      />
-                    </button>
-                  ) : null}
-                </>
+                <button onClick={() => props.openAddEditReportModal(report)}>
+                  <Image
+                    src={editIcon}
+                    alt="Edit Report Name"
+                    minW={"1.75rem"}
+                  />
+                </button>
               )}
               <Text fontWeight="bold" fontSize="16px">
                 {report.name}


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
When a report is submitted, the name text should be disabled, and the save button should be disabled. The modal still needs to be accessible to see the selected options for admins.

<img width="954" alt="image" src="https://github.com/user-attachments/assets/1df6c659-cc4a-488b-b6be-61b4d1a24210" />
<img width="924" alt="image" src="https://github.com/user-attachments/assets/dc599bc5-2871-40c5-91fd-afcd9269f849" />


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4595

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
https://d2l8l59b4bu011.cloudfront.net/
In Progress reports should behave the same.
Creating new reports should behave the same.
Complete a report and see the above when clicking the edit button. 

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
