### PR TITLE
Let things be a little dirtier

### DIFF
--- a/services/app-api/forms/2026/elements.ts
+++ b/services/app-api/forms/2026/elements.ts
@@ -58,19 +58,20 @@ export const measureInstructions: AccordionTemplate = {
   label: "Instructions",
   value:
     "<strong>Instructions for Completing this Measure</strong>" +
-    "<p>Before you can click the <b>“Complete measure”</b> button, you must answer all required (non-optional) questions for the measure and any associated measure sections (such as delivery method or measure part).<p>" +
+    "<p>Before you can click the <b>“Complete measure”</b> button, you must answer all required (non-optional) questions for the measure and any associated measure sections (such as delivery method or measure part).</p>" +
     "<p>Please review your responses to ensure all mandatory fields are filled out before proceeding.</p>" +
-    "<p>The <b>“Clear measure data”</b> button can be used to reset the entire measure (including any completed sections).  All data previously entered will be cleared and not submitted upon report completion.</p>",
+    "<p>The <b>“Clear measure data”</b> button can be used to reset the entire measure (including any completed sections). All data previously entered will be cleared and not submitted upon report completion.</p>",
 };
 
 export const deliveryMethodMeasureInstructions: AccordionTemplate = {
   type: ElementType.Accordion,
   id: "delivery-method-measure-instructions",
   label: "Instructions",
-  value: `<b>Instructions for Completing this section</b> <p>Before you can click the "<b>Complete section</b>" button, 
-    you must answer all required (non-optional) questions for the measure section.</p>
-    <p>Please review your responses to ensure all mandatory fields are filled out before proceeding.</p>
-    <p>Once complete, you can still edit this section but the status will change to ‘In progress’ and you will need to re-select the ‘Complete section’ button.</p>`,
+  value:
+    "<b>Instructions for Completing this section</b>" +
+    "<p>Before you can click the <b>“Complete section”</b> button, you must answer all required (non-optional) questions for the measure section.</p>" +
+    "<p>Please review your responses to ensure all mandatory fields are filled out before proceeding.</p>" +
+    "<p>Once complete, you can still edit this section but the status will change to “In progress” and you will need to re-select the “Complete section” button.</p>",
 };
 
 export const measureDetailsSection: MeasureDetailsTemplate = {

--- a/services/app-api/forms/2026/qms.ts
+++ b/services/app-api/forms/2026/qms.ts
@@ -69,9 +69,13 @@ export const qmsReportTemplate: ReportTemplate = {
           label: "Instructions",
           value:
             "<b>Instructions for Completing the QMS Report</b>" +
-            "<p>Below is a list of all required measures.  Select the respective “Start” or “Edit” buttons to navigate to each measure overview page and begin filling in all required fields.  Once all required fields are completed for the measure, and any associated sub-measure sections, the “Complete Measure” button will become active.  Clicking the button will complete the measure and place it in the <b>Complete</b> status.</p>" +
+            "<p>Below is a list of all required measures. Select the respective “Start” or “Edit” buttons to navigate to each measure overview page and begin filling in all required fields. Once all required fields are completed for the measure, and any associated sub-measure sections, the “Complete Measure” button will become active. Clicking the button will complete the measure and place it in the <b>Complete</b> status.</p>" +
             "<p><b>Understanding Measure Statuses </b></p>" +
-            "<p><ul><li><b>Not Started</b>:  No data has been entered or actions taken on the measure.</li><li><b>In Progress</b>:  The measure is actively being worked on, with some or all data entered.</li><li><b>Complete</b>:  The measure has been completed.</li></ul><p>" +
+            "<ul>" +
+            "  <li><b>Not Started</b>: No data has been entered or actions taken on the measure.</li>" +
+            "  <li><b>In Progress</b>: The measure is actively being worked on, with some or all data entered.</li>" +
+            "  <li><b>Complete</b>: The measure has been completed.</li>" +
+            "</ul>" +
             "<p>Before submitting this form, all required measures must be in the <b>Complete</b> status.</p>",
         },
         {
@@ -98,10 +102,14 @@ export const qmsReportTemplate: ReportTemplate = {
           label: "Instructions",
           value:
             "<b>Instructions for Completing the QMS Report</b>" +
-            "<p>Below is a list of all optional measures.  Select the respective “Start” or “Edit” buttons to navigate to each measure overview page and begin filling in all required fields.  Once all required fields are completed for the measure, and any associated sub-measure sections, the “Complete Measure” button will become active.  Clicking the button will complete the measure and place it in the <b>Complete</b> status.</p>" +
-            "<p>Please note, the report cannot be submitted as long as any optional measures remain in the <b>In Progress</b> status. If you do not wish to complete an optional measure, you may clear the measure details which will return the measure to the <b>Not Started</b> status." +
+            "<p>Below is a list of all optional measures. Select the respective “Start” or “Edit” buttons to navigate to each measure overview page and begin filling in all required fields. Once all required fields are completed for the measure, and any associated sub-measure sections, the “Complete Measure” button will become active. Clicking the button will complete the measure and place it in the <b>Complete</b> status.</p>" +
+            "<p>Please note, the report cannot be submitted as long as any optional measures remain in the <b>In Progress</b> status. If you do not wish to complete an optional measure, you may clear the measure details which will return the measure to the <b>Not Started</b> status.</p>" +
             "<p><b>Understanding Measure Statuses </b></p>" +
-            "<p><ul><li><b>Not Started</b>:  No data has been entered or actions taken on the measure.</li><li><b>In Progress</b>:  The measure is actively being worked on, with some or all data entered.</li><li><b>Complete</b>:  The measure has been completed.</li></ul><p>" +
+            "<ul>" +
+            "  <li><b>Not Started</b>: No data has been entered or actions taken on the measure.</li>" +
+            "  <li><b>In Progress</b>: The measure is actively being worked on, with some or all data entered.</li>" +
+            "  <li><b>Complete</b>: The measure has been completed.</li>" +
+            "</ul>" +
             "<p>Before submitting this form, all required measures must be in the <b>Complete</b> status.</p>",
         },
         {

--- a/services/app-api/handlers/reports/buildReport.test.ts
+++ b/services/app-api/handlers/reports/buildReport.test.ts
@@ -1,15 +1,10 @@
 import { ReportOptions, ReportType } from "../../types/reports";
 import { User } from "../../types/types";
+import { validateReportPayload } from "../../utils/reportValidation";
 import { buildReport } from "./buildReport";
 
-const putMock = jest.fn();
-jest.mock("../../storage/reports", () => ({
-  putReport: () => putMock(),
-}));
-
-const validateReportPayloadMock = jest.fn();
 jest.mock("../../utils/reportValidation", () => ({
-  validateReportPayload: () => validateReportPayloadMock(),
+  validateReportPayload: jest.fn().mockImplementation(async (rpt) => rpt),
 }));
 
 describe("Test create report handler", () => {
@@ -41,7 +36,6 @@ describe("Test create report handler", () => {
     expect(report.type).toBe(ReportType.QMS);
     expect(report.lastEditedBy).toBe("James Holden");
     expect(report.lastEditedByEmail).toBe("james.holden@test.com");
-    expect(putMock).toHaveBeenCalled();
   });
 });
 
@@ -52,7 +46,7 @@ describe("Test validation error", () => {
 
   test("Test that a validation failure throws invalid request error", async () => {
     // Manually throw validation error
-    validateReportPayloadMock.mockImplementation(() => {
+    (validateReportPayload as jest.Mock).mockImplementationOnce(() => {
       throw new Error("you be havin some validatin errors");
     });
 

--- a/services/app-api/handlers/reports/buildReport.ts
+++ b/services/app-api/handlers/reports/buildReport.ts
@@ -3,7 +3,6 @@ import {
   getReportTemplate,
   getCmitInfo,
 } from "../../forms/yearlyFormSelection";
-import { putReport } from "../../storage/reports";
 import {
   Report,
   ReportStatus,
@@ -86,9 +85,7 @@ export const buildReport = async (
     throw new Error("Invalid request");
   }
 
-  // Save
-  await putReport(validatedReport);
-  return report;
+  return validatedReport;
 };
 
 /**

--- a/services/app-api/handlers/reports/create.test.ts
+++ b/services/app-api/handlers/reports/create.test.ts
@@ -1,4 +1,5 @@
 import { StatusCodes } from "../../libs/response-lib";
+import { putReport } from "../../storage/reports";
 import { proxyEvent } from "../../testing/proxyEvent";
 import { APIGatewayProxyEvent, UserRoles } from "../../types/types";
 import { canWriteState } from "../../utils/authorization";
@@ -17,6 +18,10 @@ jest.mock("../../utils/authorization", () => ({
 
 jest.mock("./buildReport", () => ({
   buildReport: jest.fn().mockReturnValue({ id: "A report" }),
+}));
+
+jest.mock("../../storage/reports", () => ({
+  putReport: jest.fn(),
 }));
 
 const testEvent: APIGatewayProxyEvent = {
@@ -58,6 +63,7 @@ describe("Test create report handler", () => {
   test("Test Successful create", async () => {
     const res = await createReport(testEvent);
 
+    expect(putReport).toHaveBeenCalled();
     expect(res.statusCode).toBe(StatusCodes.Ok);
   });
 });

--- a/services/app-api/handlers/reports/create.ts
+++ b/services/app-api/handlers/reports/create.ts
@@ -5,6 +5,7 @@ import { canWriteState } from "../../utils/authorization";
 import { error } from "../../utils/constants";
 import { buildReport } from "./buildReport";
 import { ReportOptions } from "../../types/reports";
+import { putReport } from "../../storage/reports";
 
 export const createReport = handler(
   parseReportTypeAndState,
@@ -23,6 +24,7 @@ export const createReport = handler(
 
     const options = body as ReportOptions;
     const report = await buildReport(reportType, state, options, user);
+    await putReport(report);
 
     return ok(report);
   }

--- a/services/app-api/utils/sanitize.ts
+++ b/services/app-api/utils/sanitize.ts
@@ -13,7 +13,7 @@ const DOMPurify = createDOMPurify(windowEmulator);
  */
 DOMPurify.setConfig({
   // Only these tags will be allowed through
-  ALLOWED_TAGS: ["ul", "ol", "li", "a", "#text"],
+  ALLOWED_TAGS: ["b", "strong", "i", "em", "p", "ul", "ol", "li", "a", "#text"],
   // On those tags, only these attributes are allowed
   ALLOWED_ATTR: ["href", "alt"],
   // If a tag is removed, so will all its child elements & text

--- a/services/app-api/utils/tests/sanitize.test.ts
+++ b/services/app-api/utils/tests/sanitize.test.ts
@@ -115,11 +115,11 @@ describe("Test sanitizeObject", () => {
 describe("Test sanitizeObject is friendly to the markup embedded in our report templates", () => {
   test("Test that a freshly created 2026 QMS report will not be affected by sanitization", async () => {
     for (let optionValues of booleanCombinations(4)) {
-      const [cahps, hciiad, nciad, pom] = optionValues;
+      const [cahps, hciidd, nciad, pom] = optionValues;
       const options = {
         name: "mock-report",
         year: 2026,
-        options: { cahps, hciiad, nciad, pom },
+        options: { cahps, hciidd, nciad, pom },
       };
       const user = {
         fullName: "Mock User",


### PR DESCRIPTION
### Description
1. We sanitize the body of every request that hits our API, to ensure we never store or even interact with potentially dangerous data.
2. We use the library DOMPurify for this, with a very strict config set to allow through only a limited set of HTML tags.
3. Within our own report templates, we use tags outside of that limited set.
4. As a user completes a report, we store the answers directly in the template. In other words, every time a user saves report data, they are also re-saving the template.
5. Therefore, the first time each report is saved by a user, that report's template is mangled by DOMPurify.

This PR loosens up the DOMPurify config, to allow a slightly broader set of tags, which includes all tags currently in use in our report templates.

In order to verify this is working correctly, and to ensure future edits to the report templates do not quietly add unsanitizable tags, I created a unit test that actually instantiates all possible versions of the QMS report, and asserts that each version makes it through the sanitizer unchanged.

In order to write that unit test, I had to separate the action of building a report from the action of saving that report to the database. Well, I guess I didn't _have_ to, but it saved me from some extra mocking, and it makes more sense to me this way.

Note that I had to make some edits to the instructions in order to make sure DOMPurify wouldn't change them. It was doing weird stuff like generating closing `<p>` tags in weird spots, and stripping out empty ones. It's possible these edits changed the spacing on the page. Hopefully it still looks right?

<img width="864" alt="image" src="https://github.com/user-attachments/assets/9f0fd3ef-dc64-4c28-8570-02cce2a0c206" />
<img width="847" alt="image" src="https://github.com/user-attachments/assets/07a1b701-7fe8-4945-bee9-ff8e90134f9a" />
<img width="877" alt="image" src="https://github.com/user-attachments/assets/0ceaae13-d1ad-48fa-a757-f21feef30427" />
<img width="898" alt="image" src="https://github.com/user-attachments/assets/6469e241-2ea3-4b63-87ca-d68fa76999ac" />


### Related ticket(s)
CMDCT-4630

---
### How to test
https://d1cx8o2bjaw6wo.cloudfront.net/

I guess, make sure you can still create a report.

And save changes to it.

And that the instruction accordions look OK, I guess.

That should be it though.

### Important updates
n/a

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- ~[ ] I have updated relevant documentation, if necessary~
