### PR TITLE
CodeClimate -> QLTY

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,8 +47,8 @@ jobs:
         with:
           oidc: true
           files: |
-            ${{github.workspace}}/services/app-api/coverage/lcov.info:lcov
-            ${{github.workspace}}/services/ui-src/coverage/lcov.info:lcov
+            ${{github.workspace}}/services/app-api/coverage/lcov.info
+            ${{github.workspace}}/services/ui-src/coverage/lcov.info
       - name: Store unit test results
         if: failure()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,13 +42,11 @@ jobs:
           echo "PATH=$(pwd)/node_modules/.bin/:$PATH" >> $GITHUB_ENV
       - name: run unit tests
         run: ./scripts/test-unit.sh
-      - name: publish test coverage to code climate
-        if: env.CODE_CLIMATE_ID != ''
-        uses: paambaati/codeclimate-action@v6
-        env:
-          CC_TEST_REPORTER_ID: ${{ secrets.CODE_CLIMATE_ID }}
+      - name: publish test coverage to qlty
+        uses: qltysh/qlty-action/coverage@v1
         with:
-          coverageLocations: |
+          oidc: true
+          files: |
             ${{github.workspace}}/services/app-api/coverage/lcov.info:lcov
             ${{github.workspace}}/services/ui-src/coverage/lcov.info:lcov
       - name: Store unit test results

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # MDCT-HCBS
 
 [![CodeQL](https://github.com/Enterprise-CMCS/macpro-mdct-hcbs/actions/workflows/codeql-analysis.yml/badge.svg?branch=main)](https://github.com/Enterprise-CMCS/macpro-mdct-hcbs/actions/workflows/codeql-analysis.yml)
-[![Maintainability](https://api.codeclimate.com/v1/badges/93cd54dad7df73b09209/maintainability)](https://codeclimate.com/repos/664553bb1a9a4300ce1216ac/maintainability)
-[![Test Coverage](https://api.codeclimate.com/v1/badges/93cd54dad7df73b09209/test_coverage)](https://codeclimate.com/repos/664553bb1a9a4300ce1216ac/test_coverage)
+[![Maintainability](https://qlty.sh/badges/5213e13f-d38a-4a72-aa4c-87979bb19c6b/maintainability.svg)](https://qlty.sh/gh/Enterprise-CMCS/projects/macpro-mdct-hcbs)
+[![Code Coverage](https://qlty.sh/badges/5213e13f-d38a-4a72-aa4c-87979bb19c6b/test_coverage.svg)](https://qlty.sh/gh/Enterprise-CMCS/projects/macpro-mdct-hcbs)
 
 ### Integration Environment Deploy Status:
 | Branch  | Build Status |


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Switched CodeClimate config for their new shiny QLTY.

#### Guide for other apps:
1. Update the action to follow the same pattern as in this PR. Note
After it successfully runs, you should see something like this in the action:
![image](https://github.com/user-attachments/assets/9f0fb001-2233-4543-9a71-64f69fdbeeca)

3. Someone with admin in the repo needs to go to branch settings -> main/master and remove codeclimate status checks, and add the following (they'll autofill after the new action has run once successfully):
- qlty check
- qlty coverage
- qlty coverage diff

Example:
![image](https://github.com/user-attachments/assets/775c6ce6-6071-4cf0-955d-04f6ec49479e)

3. Update badges on the readme. The example badge can be found in qlty for a repo, but the format is. The Code Coverage example is broken on their side right now.
```
[![Maintainability](https://qlty.sh/badges/{REPO_ID}/maintainability.svg)]({QLTY_URL})
[![Code Coverage](https://qlty.sh/badges/{REPO_ID}/test_coverage.svg)]({QLTY_URL})
```

This will display 0 until it is merged into main:
![image](https://github.com/user-attachments/assets/ba881c8e-3640-45e6-8c96-e3e7b4e6740d)

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
N/A, but this blocks everything else

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->


### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
