### PR TITLE
Better labeling for editing and entering reports

### DIFF
--- a/services/ui-src/src/components/pages/Dashboard/DashboardTable.test.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardTable.test.tsx
@@ -71,7 +71,9 @@ describe("Dashboard table with state user", () => {
   it("should render report name and edit button in table", async () => {
     render(dashboardTableComponent);
     expect(screen.getByText("report 1")).toBeInTheDocument();
-    expect(screen.getAllByAltText("Edit Report Name").length).toBe(3);
+    expect(screen.getAllByLabelText("Edit report 1 report name").length).toBe(
+      1
+    );
   });
 });
 
@@ -84,7 +86,9 @@ describe("Dashboard table with admin user", () => {
   it("should not render the proper controls when admin", async () => {
     render(adminDashboardTableComponent);
     expect(screen.getByText("report 1")).toBeInTheDocument();
-    expect(screen.queryByAltText("Edit Report Name")).not.toBeInTheDocument();
+    expect(
+      screen.queryByLabelText("Edit report 1 report name")
+    ).not.toBeInTheDocument();
     expect(screen.getAllByText("Archive").length).toBe(2);
     expect(screen.getAllByText("View").length).toBe(3);
     expect(screen.getAllByText("Unlock").length).toBe(3);

--- a/services/ui-src/src/components/pages/Dashboard/DashboardTable.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardTable.tsx
@@ -66,7 +66,11 @@ export const HorizontalTable = (props: TableProps) => {
           {props.showEditNameColumn && (
             <Td fontWeight={"bold"}>
               <button onClick={() => props.openAddEditReportModal(report)}>
-                <Image src={editIcon} alt="Edit Report Name" minW={"1.75rem"} />
+                <Image
+                  src={editIcon}
+                  aria-label={"Edit " + report.name + " report name"}
+                  minW={"1.75rem"}
+                />
               </button>
             </Td>
           )}
@@ -91,6 +95,11 @@ export const HorizontalTable = (props: TableProps) => {
               onClick={() => props.navigate(reportBasePath(report))}
               variant="outline"
               disabled={report.archived}
+              aria-label={
+                report.status !== ReportStatus.SUBMITTED
+                  ? "Edit " + report.name + " report"
+                  : "View " + report.name + " report"
+              }
             >
               {props.userIsEndUser && report.status !== ReportStatus.SUBMITTED
                 ? "Edit"
@@ -149,7 +158,7 @@ export const VerticalTable = (props: TableProps) => {
                 <button onClick={() => props.openAddEditReportModal(report)}>
                   <Image
                     src={editIcon}
-                    alt="Edit Report Name"
+                    aria-label={"Edit " + report.name + " report name"}
                     minW={"1.75rem"}
                   />
                 </button>
@@ -184,6 +193,11 @@ export const VerticalTable = (props: TableProps) => {
               height="30px"
               fontSize="sm"
               disabled={report.archived}
+              aria-label={
+                report.status !== ReportStatus.SUBMITTED
+                  ? "Edit " + report.name + " report"
+                  : "View " + report.name + " report"
+              }
             >
               {props.userIsEndUser && report.status !== ReportStatus.SUBMITTED
                 ? "Edit"

--- a/services/ui-src/src/components/pages/Dashboard/DashboardTable.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardTable.tsx
@@ -68,7 +68,7 @@ export const HorizontalTable = (props: TableProps) => {
               <button onClick={() => props.openAddEditReportModal(report)}>
                 <Image
                   src={editIcon}
-                  aria-label={"Edit " + report.name + " report name"}
+                  aria-label={`Edit ${report.name} report name`}
                   minW={"1.75rem"}
                 />
               </button>
@@ -97,8 +97,8 @@ export const HorizontalTable = (props: TableProps) => {
               disabled={report.archived}
               aria-label={
                 report.status !== ReportStatus.SUBMITTED
-                  ? "Edit " + report.name + " report"
-                  : "View " + report.name + " report"
+                  ? `Edit ${report.name} report`
+                  : `View ${report.name} report`
               }
             >
               {props.userIsEndUser && report.status !== ReportStatus.SUBMITTED
@@ -158,7 +158,7 @@ export const VerticalTable = (props: TableProps) => {
                 <button onClick={() => props.openAddEditReportModal(report)}>
                   <Image
                     src={editIcon}
-                    aria-label={"Edit " + report.name + " report name"}
+                    aria-label={`Edit ${report.name} report name`}
                     minW={"1.75rem"}
                   />
                 </button>


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Modifying aria-labels for the "Edit Report Name" and "Edit" buttons in the report dashboard to be more specific
![image](https://github.com/user-attachments/assets/d81f332b-0851-41f0-822a-1a1cec6e8810)


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4466

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
**Deploy Link:** https://d219no0jteicvi.cloudfront.net/

1. Create a report, and inspect the aria-label "Edit Report Name" and "Edit" buttons. 
2. Confirm that they are now report name specific (e.g. if the report is named abc the aria labels should be "Edit abc report name" and "Edit abc report"

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
