### PR TITLE
[HCBS] - Make sure start date is before end date in banner form

### DIFF
--- a/services/app-api/utils/bannerValidation.ts
+++ b/services/app-api/utils/bannerValidation.ts
@@ -8,7 +8,26 @@ const bannerValidateSchema = object().shape({
   description: string().required(),
   link: string().url().notRequired(),
   startDate: number().notRequired(),
-  endDate: number().notRequired(),
+  endDate: number()
+    .notRequired()
+    .when("startDate", (startDate, schema) => {
+      const actualStartDate = Array.isArray(startDate)
+        ? startDate[0]
+        : startDate;
+      if (typeof actualStartDate === "number") {
+        return schema.test({
+          name: "is-after-start-date",
+          message: error.END_DATE_BEFORE_START_DATE,
+          test: function (endDateValue) {
+            if (typeof endDateValue === "number") {
+              return endDateValue > actualStartDate;
+            }
+            return true;
+          },
+        });
+      }
+      return schema;
+    }),
   isActive: boolean().notRequired(),
 });
 

--- a/services/app-api/utils/bannerValidation.ts
+++ b/services/app-api/utils/bannerValidation.ts
@@ -10,17 +10,14 @@ const bannerValidateSchema = object().shape({
   startDate: number().notRequired(),
   endDate: number()
     .notRequired()
-    .when("startDate", (startDate, schema) => {
-      const actualStartDate = Array.isArray(startDate)
-        ? startDate[0]
-        : startDate;
-      if (typeof actualStartDate === "number") {
+    .when("startDate", ([startDate], schema) => {
+      if (typeof startDate === "number") {
         return schema.test({
           name: "is-after-start-date",
           message: error.END_DATE_BEFORE_START_DATE,
           test: function (endDateValue) {
             if (typeof endDateValue === "number") {
-              return endDateValue > actualStartDate;
+              return endDateValue > startDate;
             }
             return true;
           },

--- a/services/app-api/utils/constants.ts
+++ b/services/app-api/utils/constants.ts
@@ -8,6 +8,7 @@ export const error = {
   SERVER_ERROR: "An unspecified server error occured.",
   CREATION_ERROR: "Could not be created due to a database error.",
   ALREADY_ARCHIVED: "Cannot update archived report.",
+  END_DATE_BEFORE_START_DATE: "End date must be after start date.",
 };
 
 export enum DeliverySystem {

--- a/services/app-api/utils/constants.ts
+++ b/services/app-api/utils/constants.ts
@@ -8,7 +8,7 @@ export const error = {
   SERVER_ERROR: "An unspecified server error occured.",
   CREATION_ERROR: "Could not be created due to a database error.",
   ALREADY_ARCHIVED: "Cannot update archived report.",
-  END_DATE_BEFORE_START_DATE: "End date must be after start date.",
+  END_DATE_BEFORE_START_DATE: "End date can't be before start date",
 };
 
 export enum DeliverySystem {

--- a/services/app-api/utils/tests/bannerValidation.test.ts
+++ b/services/app-api/utils/tests/bannerValidation.test.ts
@@ -1,4 +1,5 @@
 import { validateBannerPayload } from "../bannerValidation";
+import { error } from "../constants";
 
 const validObject = {
   key: "1023",
@@ -28,5 +29,62 @@ describe("Test validateBannerPayload function", () => {
     expect(async () => {
       await validateBannerPayload(invalidObject);
     }).rejects.toThrow();
+  });
+});
+
+describe("Test validateBannerPayload function", () => {
+  it("successfully validates a valid object", async () => {
+    const validatedData = await validateBannerPayload(validObject);
+    expect(validatedData).toEqual(validObject);
+  });
+  it("throws an error when validating an invalid object", () => {
+    expect(async () => {
+      await validateBannerPayload(invalidObject);
+    }).rejects.toThrow();
+  });
+});
+
+describe("validateBannerPayload (API)", () => {
+  const basePayload = {
+    key: "admin-banner-id",
+    title: "mock title",
+    description: "mock description",
+  };
+
+  it("should throw an error if the payload is undefined", async () => {
+    await expect(validateBannerPayload(undefined)).rejects.toThrow(
+      "Missing required data."
+    );
+  });
+
+  it("should pass when startDate is before endDate", async () => {
+    const payload = {
+      ...basePayload,
+      startDate: 11022933,
+      endDate: 103444405,
+    };
+    await expect(validateBannerPayload(payload)).resolves.toEqual(payload);
+  });
+
+  it("should throw an error when endDate is before startDate", async () => {
+    const payload = {
+      ...basePayload,
+      startDate: 103444405,
+      endDate: 11022933,
+    };
+    await expect(validateBannerPayload(payload)).rejects.toThrow(
+      error.END_DATE_BEFORE_START_DATE
+    );
+  });
+
+  it("should fail when endDate is equal to startDate", async () => {
+    const payload = {
+      ...basePayload,
+      startDate: 11022933,
+      endDate: 11022933,
+    };
+    await expect(validateBannerPayload(payload)).rejects.toThrow(
+      error.END_DATE_BEFORE_START_DATE
+    );
   });
 });

--- a/services/app-api/utils/tests/bannerValidation.test.ts
+++ b/services/app-api/utils/tests/bannerValidation.test.ts
@@ -44,7 +44,7 @@ describe("Test validateBannerPayload function", () => {
   });
 });
 
-describe("validateBannerPayload (API)", () => {
+describe("validateBannerPayload for startDate (API)", () => {
   const basePayload = {
     key: "admin-banner-id",
     title: "mock title",

--- a/services/app-api/utils/tests/bannerValidation.test.ts
+++ b/services/app-api/utils/tests/bannerValidation.test.ts
@@ -6,8 +6,8 @@ const validObject = {
   title: "this is a title",
   description: "this is a description",
   link: "https://www.google.com",
-  startDate: 11022933,
-  endDate: 103444405,
+  startDate: 11022933, // Jan 1, 1970
+  endDate: 103444405, // Jan 2, 1970
   isActive: false,
 };
 
@@ -16,8 +16,8 @@ const invalidObject = {
   title: "this is a title",
   description: "this is a description",
   link: "https://www.google.com",
-  startDate: 11022933,
-  endDate: 103444405,
+  startDate: 11022933, // Jan 1, 1970
+  endDate: 103444405, // Jan 2, 1970
 };
 
 describe("Test validateBannerPayload function", () => {
@@ -60,8 +60,8 @@ describe("validateBannerPayload for startDate (API)", () => {
   it("should pass when startDate is before endDate", async () => {
     const payload = {
       ...basePayload,
-      startDate: 11022933,
-      endDate: 103444405,
+      startDate: 11022933, // Jan 1, 1970
+      endDate: 103444405, // Jan 2, 1970
     };
     await expect(validateBannerPayload(payload)).resolves.toEqual(payload);
   });
@@ -69,8 +69,8 @@ describe("validateBannerPayload for startDate (API)", () => {
   it("should throw an error when endDate is before startDate", async () => {
     const payload = {
       ...basePayload,
-      startDate: 103444405,
-      endDate: 11022933,
+      startDate: 103444405, // Jan 2, 1970
+      endDate: 11022933, // Jan 1, 1970
     };
     await expect(validateBannerPayload(payload)).rejects.toThrow(
       error.END_DATE_BEFORE_START_DATE
@@ -80,8 +80,8 @@ describe("validateBannerPayload for startDate (API)", () => {
   it("should fail when endDate is equal to startDate", async () => {
     const payload = {
       ...basePayload,
-      startDate: 11022933,
-      endDate: 11022933,
+      startDate: 11022933, // Jan 1, 1970
+      endDate: 11022933, // Jan 1, 1970
     };
     await expect(validateBannerPayload(payload)).rejects.toThrow(
       error.END_DATE_BEFORE_START_DATE

--- a/services/ui-src/src/components/fields/DateField.tsx
+++ b/services/ui-src/src/components/fields/DateField.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { get, useFormContext } from "react-hook-form";
 import { Box } from "@chakra-ui/react";
-import { checkDateCompleteness, parseHtml } from "utils";
+import { parseMMDDYYYY, parseHtml } from "utils";
 import { SingleInputDateField as CmsdsDateField } from "@cmsgov/design-system";
 import { PageElementProps } from "../report/Elements";
 import { DateTemplate } from "../../types/report";
@@ -25,7 +25,7 @@ export const DateField = (props: PageElementProps<DateTemplate>) => {
 
   const onChangeHandler = (rawValue: string, maskedValue: string) => {
     setDisplayValue(rawValue);
-    const isValidDate = checkDateCompleteness(maskedValue);
+    const isValidDate = parseMMDDYYYY(maskedValue);
     if (isValidDate || maskedValue === "") {
       form.setValue(key, maskedValue, { shouldValidate: true });
     }

--- a/services/ui-src/src/components/forms/AdminBannerForm.test.tsx
+++ b/services/ui-src/src/components/forms/AdminBannerForm.test.tsx
@@ -162,7 +162,7 @@ describe("AdminBannerForm validation", () => {
 
     // Ensure that the error message for the end date is not displayed
     expect(
-      screen.queryByText("End date must be after start date")
+      screen.queryByText("End date can't be before start date")
     ).not.toBeInTheDocument();
 
     expect(mockWriteAdminBanner).toHaveBeenCalledWith({

--- a/services/ui-src/src/components/forms/AdminBannerForm.test.tsx
+++ b/services/ui-src/src/components/forms/AdminBannerForm.test.tsx
@@ -16,7 +16,12 @@ const adminBannerFormComponent = (
   </RouterWrappedComponent>
 );
 
+const HOURS = 60 * 60 * 1000;
+
 describe("<AdminBannerForm />", () => {
+  beforeEach(() => {
+    mockWriteAdminBanner.mockClear();
+  });
   test("AdminBannerForm is visible", () => {
     render(adminBannerFormComponent(mockWriteAdminBanner));
     expect(screen.getByRole("textbox", { name: "Title text" })).toBeVisible();
@@ -48,13 +53,12 @@ describe("<AdminBannerForm />", () => {
       await userEvent.type(startDateInput, "01/01/1970");
 
       const endDateInput = screen.getByLabelText("End date");
-      await userEvent.type(endDateInput, "01/01/1970");
+      // Modified: End date must be after start date
+      await userEvent.type(endDateInput, "01/02/1970");
 
       const submitButton = screen.getByText("Replace Current Banner");
       await userEvent.click(submitButton);
     });
-
-    const HOURS = 60 * 60 * 1000;
 
     expect(mockWriteAdminBanner).toHaveBeenCalledWith({
       key: "admin-banner-id",
@@ -62,11 +66,11 @@ describe("<AdminBannerForm />", () => {
       description: "mock description",
       link: "http://example.com",
       startDate: 5 * HOURS, // midnight UTC, in New York
-      endDate: 29 * HOURS - 1000, // 1 second before midnight of the next day
+      endDate: 53 * HOURS - 1000, // End of the next day in NY
     });
   });
 
-  test("AdminBannerForm shows an error when submit fails", async () => {
+  test("AdminBannerForm shows an error when submit fails (backend error)", async () => {
     mockWriteAdminBanner.mockImplementationOnce(() => {
       throw new Error("FAILURE");
     });
@@ -87,7 +91,7 @@ describe("<AdminBannerForm />", () => {
       await userEvent.type(startDateInput, "01/01/1970");
 
       const endDateInput = screen.getByLabelText("End date");
-      await userEvent.type(endDateInput, "01/01/1970");
+      await userEvent.type(endDateInput, "01/02/1970");
 
       const submitButton = screen.getByText("Replace Current Banner");
       await userEvent.click(submitButton);
@@ -147,7 +151,7 @@ describe("AdminBannerForm validation", () => {
       await userEvent.type(descriptionInput, "mock description");
       await userEvent.type(linkInput, "http://example.com");
       await userEvent.type(startDateInput, "01/01/1970");
-      await userEvent.type(endDateInput, "01/01/1970");
+      await userEvent.type(endDateInput, "01/02/1970");
       await userEvent.click(submitButton);
     });
 
@@ -156,7 +160,10 @@ describe("AdminBannerForm validation", () => {
       screen.queryAllByText("A response is required", { exact: false })
     ).toStrictEqual([]);
 
-    const HOURS = 60 * 60 * 1000;
+    // Ensure that the error message for the end date is not displayed
+    expect(
+      screen.queryByText("End date must be after start date")
+    ).not.toBeInTheDocument();
 
     expect(mockWriteAdminBanner).toHaveBeenCalledWith({
       key: "admin-banner-id",
@@ -164,7 +171,7 @@ describe("AdminBannerForm validation", () => {
       description: "mock description",
       link: "http://example.com",
       startDate: 5 * HOURS, // midnight UTC, in New York
-      endDate: 29 * HOURS - 1000, // 1 second before midnight of the next day
+      endDate: 53 * HOURS - 1000, // Expected end date for 01/02/1970
     });
   });
 });

--- a/services/ui-src/src/constants.ts
+++ b/services/ui-src/src/constants.ts
@@ -1,6 +1,11 @@
 // BANNERS
 export const bannerId = "admin-banner-id";
 
+// ERRORS
+export const error = {
+  END_DATE_BEFORE_START_DATE: "End date must be after start date.",
+};
+
 // HOST DOMAIN
 export const PRODUCTION_HOST_DOMAIN = "mdcthcbs.cms.gov";
 

--- a/services/ui-src/src/constants.ts
+++ b/services/ui-src/src/constants.ts
@@ -3,7 +3,7 @@ export const bannerId = "admin-banner-id";
 
 // ERRORS
 export const error = {
-  END_DATE_BEFORE_START_DATE: "End date must be after start date.",
+  END_DATE_BEFORE_START_DATE: "End date can't be before start date",
 };
 
 // HOST DOMAIN

--- a/services/ui-src/src/utils/other/time.test.ts
+++ b/services/ui-src/src/utils/other/time.test.ts
@@ -9,6 +9,7 @@ import {
   convertDateUtcToEt,
   formatMonthDayYear,
   getLocalHourMinuteTime,
+  parseMMDDYYYY,
   twoDigitCalendarDate,
 } from "./time";
 
@@ -165,5 +166,131 @@ describe("utils/time", () => {
     test("returns empty string when nothing is passed in", () => {
       expect(calculateNextQuarter("")).toBe("");
     });
+  });
+});
+
+// Test suite for parseMMDDYYYY function
+describe("parseMMDDYYYY", () => {
+  // Valid date string
+  it("should correctly parse a valid MMDDYYYY date string", () => {
+    const date = parseMMDDYYYY("12/25/2023");
+    expect(date).toBeInstanceOf(Date);
+    expect(date?.getFullYear()).toBe(2023);
+    expect(date?.getMonth()).toBe(11); // December (0-indexed)
+    expect(date?.getDate()).toBe(25);
+    expect(date?.getHours()).toBe(0); // Should be normalized to midnight
+    expect(date?.getMinutes()).toBe(0);
+    expect(date?.getSeconds()).toBe(0);
+    expect(date?.getMilliseconds()).toBe(0);
+  });
+
+  // Another valid date string (single digits for month/day)
+  it("should correctly parse a valid MMDDYYYY date string with single digit month/day", () => {
+    const date = parseMMDDYYYY("01/05/2024");
+    expect(date).toBeInstanceOf(Date);
+    expect(date?.getFullYear()).toBe(2024);
+    expect(date?.getMonth()).toBe(0); // January (0-indexed)
+    expect(date?.getDate()).toBe(5);
+  });
+
+  // Leap year date
+  it("should correctly parse a leap year date", () => {
+    const date = parseMMDDYYYY("02/29/2028"); // 2028 is a leap year
+    expect(date).toBeInstanceOf(Date);
+    expect(date?.getFullYear()).toBe(2028);
+    expect(date?.getMonth()).toBe(1); // February (0-indexed)
+    expect(date?.getDate()).toBe(29);
+  });
+
+  // Non-leap year 02/29 (should return null)
+  it("should return null for 02/29 in a non-leap year", () => {
+    const date = parseMMDDYYYY("02/29/2027");
+    expect(date).toBeNull();
+  });
+
+  // Invalid month
+  it("should return null for an invalid month", () => {
+    const date = parseMMDDYYYY("13/01/2023");
+    expect(date).toBeNull();
+  });
+
+  // Invalid day
+  it("should return null for an invalid day", () => {
+    const date = parseMMDDYYYY("01/32/2023");
+    expect(date).toBeNull();
+  });
+
+  // Invalid day for a specific month
+  it("should return null for an invalid day for a specific month", () => {
+    const date = parseMMDDYYYY("04/31/2023"); // April has 30 days
+    expect(date).toBeNull();
+  });
+
+  // Empty string
+  it("should return null for an empty string", () => {
+    const date = parseMMDDYYYY("");
+    expect(date).toBeNull();
+  });
+
+  // Null input
+  it("should return null for a null input", () => {
+    // @ts-ignore: Intentionally testing null input for robustness
+    const date = parseMMDDYYYY(null);
+    expect(date).toBeNull();
+  });
+
+  // Undefined input
+  it("should return null for an undefined input", () => {
+    // @ts-ignore: Intentionally testing undefined input for robustness
+    const date = parseMMDDYYYY(undefined);
+    expect(date).toBeNull();
+  });
+
+  // Incorrect format (missing slashes)
+  it("should return null for an incorrect format (missing slashes)", () => {
+    const date = parseMMDDYYYY("12-25-2023");
+    expect(date).toBeNull();
+  });
+
+  // Incorrect format (wrong number of digits)
+  it("should return null for an incorrect format (wrong number of digits)", () => {
+    const date = parseMMDDYYYY("1/2/2023");
+    expect(date).toBeNull();
+  });
+
+  // Incorrect format (extra characters)
+  it("should return null for an incorrect format (extra characters)", () => {
+    const date = parseMMDDYYYY("12/25/2023abc");
+    expect(date).toBeNull();
+  });
+
+  // Future date (valid)
+  it("should correctly parse a valid future date", () => {
+    const futureDate = parseMMDDYYYY("07/15/2050");
+    expect(futureDate).toBeInstanceOf(Date);
+    expect(futureDate?.getFullYear()).toBe(2050);
+    expect(futureDate?.getMonth()).toBe(6);
+    expect(futureDate?.getDate()).toBe(15);
+  });
+
+  // Date with leading zeros for month/day
+  it("should correctly parse a date with leading zeros for month/day", () => {
+    const date = parseMMDDYYYY("03/01/2023");
+    expect(date).toBeInstanceOf(Date);
+    expect(date?.getFullYear()).toBe(2023);
+    expect(date?.getMonth()).toBe(2);
+    expect(date?.getDate()).toBe(1);
+  });
+
+  // Zero for day or month (invalid based on typical date understanding)
+  it("should return null for day or month being zero", () => {
+    expect(parseMMDDYYYY("00/10/2023")).toBeNull();
+    expect(parseMMDDYYYY("10/00/2023")).toBeNull();
+  });
+
+  // Date string with extra spaces (should return null due to strict regex)
+  it("should return null for date string with extra spaces", () => {
+    expect(parseMMDDYYYY(" 12/25/2023 ")).toBeNull();
+    expect(parseMMDDYYYY("12 /25/2023")).toBeNull();
   });
 });

--- a/services/ui-src/src/utils/other/time.test.ts
+++ b/services/ui-src/src/utils/other/time.test.ts
@@ -180,37 +180,37 @@ describe("test parseMMDDYYYY helper function", () => {
 
   it("should return null for 02/29 in a non-leap year", () => {
     const date = parseMMDDYYYY("02/29/2027");
-    expect(date).toBeNull();
+    expect(date).toBeFalsy();
   });
 
   it("should return null for an invalid month", () => {
     const date = parseMMDDYYYY("13/01/2023");
-    expect(date).toBeNull();
+    expect(date).toBeFalsy();
   });
 
   it("should return null for an invalid day", () => {
     const date = parseMMDDYYYY("01/32/2023");
-    expect(date).toBeNull();
+    expect(date).toBeFalsy();
   });
 
   it("should return null for an invalid day for a specific month", () => {
     const date = parseMMDDYYYY("04/31/2023"); // April has 30 days
-    expect(date).toBeNull();
+    expect(date).toBeFalsy();
   });
 
   it("should return null for an incorrect format (missing slashes)", () => {
     const date = parseMMDDYYYY("12-25-2023");
-    expect(date).toBeNull();
+    expect(date).toBeFalsy();
   });
 
   it("should return null for an incorrect format (wrong number of digits)", () => {
     const date = parseMMDDYYYY("1/2/2023");
-    expect(date).toBeNull();
+    expect(date).toBeFalsy();
   });
 
   it("should return null for an incorrect format", () => {
     const date = parseMMDDYYYY("12/25/2023abc");
-    expect(date).toBeNull();
+    expect(date).toBeFalsy();
   });
 
   it("should correctly parse a valid future date", () => {
@@ -222,7 +222,7 @@ describe("test parseMMDDYYYY helper function", () => {
   });
 
   it("should return null for day or month being zero", () => {
-    expect(parseMMDDYYYY("00/10/2023")).toBeNull();
-    expect(parseMMDDYYYY("10/00/2023")).toBeNull();
+    expect(parseMMDDYYYY("00/10/2023")).toBeFalsy();
+    expect(parseMMDDYYYY("10/00/2023")).toBeFalsy();
   });
 });

--- a/services/ui-src/src/utils/other/time.test.ts
+++ b/services/ui-src/src/utils/other/time.test.ts
@@ -1,7 +1,6 @@
 import {
   calculateNextQuarter,
   calculateRemainingSeconds,
-  checkDateCompleteness,
   checkDateRangeStatus,
   convertDateEtToUtc,
   convertDateTimeEtToUtc,
@@ -24,14 +23,14 @@ const getLocalHourMinuteTimeRegex = /[0-2]?[0-9]:[0-5][0-9](a|p)m/;
 
 describe("utils/time", () => {
   describe("getLocalHourMinuteTime()", () => {
-    test("returns correct hourminute format", () => {
+    it("returns correct hourminute format", () => {
       const localHourMinuteTime = getLocalHourMinuteTime();
       expect(localHourMinuteTime).toMatch(getLocalHourMinuteTimeRegex);
     });
   });
 
   describe("convertDateTimeEtToUtc()", () => {
-    test("Valid ET datetime converts to UTC correctly", () => {
+    it("Converts valid ET datetime to UTC correctly", () => {
       const result = convertDateTimeEtToUtc(
         { year: 2022, month: 1, day: 1 },
         { hour: 0, minute: 0, second: 0 }
@@ -42,7 +41,7 @@ describe("utils/time", () => {
   });
 
   describe("convertDateEtToUtc()", () => {
-    test("Valid ET datetime converts to UTC correctly", () => {
+    it("Converts valid ET datetime to UTC correctly", () => {
       const result = convertDateEtToUtc(testDate.etFormattedString);
       expect(result).toBe(testDate.utcMS);
       expect(new Date(result).toUTCString()).toBe(testDate.utcString);
@@ -50,7 +49,7 @@ describe("utils/time", () => {
   });
 
   describe("convertDateUtcToEt()", () => {
-    test("Valid UTC datetime converts to ET correctly", () => {
+    it("Converts valid UTC datetime to ET correctly", () => {
       const result = convertDateUtcToEt(testDate.utcMS);
       expect(result).toBe(testDate.etFormattedString);
     });
@@ -61,21 +60,21 @@ describe("utils/time", () => {
     const oneDay = 1000 * 60 * 60 * 24; // 1000ms * 60s * 60m * 24h = 86,400,000ms
     const twoDays = oneDay * 2;
 
-    test("returns false if startDate is in the future", () => {
+    it("returns false if startDate is in the future", () => {
       const startDate = currentTime + oneDay;
       const endDate = currentTime + twoDays;
       const dateRangeStatus = checkDateRangeStatus(startDate, endDate);
       expect(dateRangeStatus).toBeFalsy();
     });
 
-    test("returns false if endDate is in the past", () => {
+    it("returns false if endDate is in the past", () => {
       const startDate = currentTime - twoDays;
       const endDate = currentTime - oneDay;
       const dateRangeStatus = checkDateRangeStatus(startDate, endDate);
       expect(dateRangeStatus).toBeFalsy();
     });
 
-    test("returns true if startDate is in the past and endDate is in the future", () => {
+    it("returns true if startDate is in the past and endDate is in the future", () => {
       const startDate = currentTime - oneDay;
       const endDate = currentTime + oneDay;
       const dateRangeStatus = checkDateRangeStatus(startDate, endDate);
@@ -84,12 +83,12 @@ describe("utils/time", () => {
   });
 
   describe("twoDigitCalendarDate()", () => {
-    test("should set 1 to 01", () => {
+    it("should set 1 to 01", () => {
       const startDay = 1;
       expect(twoDigitCalendarDate(startDay)).toBe("01");
     });
 
-    test("should set 12 to 12", () => {
+    it("should set 12 to 12", () => {
       const startMonth = 12;
       expect(twoDigitCalendarDate(startMonth)).toBe("12");
     });
@@ -101,25 +100,6 @@ describe("utils/time", () => {
       const formatted = formatMonthDayYear(date);
       // Imprecise matcher, because the result depends on the user's time zone
       expect(formatted).toMatch(/03\/\d\d\/2024/);
-    });
-  });
-
-  describe("checkDateCompleteness()", () => {
-    test("that it returns an object of { year, month, day }", () => {
-      expect(checkDateCompleteness("10/22/2024")).toEqual({
-        year: 2024,
-        month: 10,
-        day: 22,
-      });
-    });
-    test("incorrect date returns null", () => {
-      expect(checkDateCompleteness("10/22/24")).toBeNull();
-    });
-    test("not a date returns null", () => {
-      expect(checkDateCompleteness("banana")).toBeNull();
-    });
-    test("empty string returns null", () => {
-      expect(checkDateCompleteness("")).toBeNull();
     });
   });
 
@@ -144,34 +124,32 @@ describe("utils/time", () => {
   });
 
   describe("calculateTimeLeft()", () => {
-    test("returns 0 when no value is given", () => {
+    it("returns 0 when no value is given", () => {
       expect(calculateRemainingSeconds()).toBeCloseTo(0);
     });
 
-    test("expiration time greater than zero", () => {
+    it("expiration time greater than zero", () => {
       const expirationTime = "2050-11-18T12:53:11-05:00";
       expect(calculateRemainingSeconds(expirationTime)).toBeGreaterThan(0);
     });
   });
 
   describe("calculateNextQuarter()", () => {
-    test("returns same year and next period", () => {
+    it("returns same year and next period", () => {
       const previousQuarter = "2027 Q1";
       expect(calculateNextQuarter(previousQuarter)).toBe("2027 Q2");
     });
-    test("returns next year and next period", () => {
+    it("returns next year and next period", () => {
       const previousQuarter = "2027 Q4";
       expect(calculateNextQuarter(previousQuarter)).toBe("2028 Q1");
     });
-    test("returns empty string when nothing is passed in", () => {
+    it("returns empty string when nothing is passed in", () => {
       expect(calculateNextQuarter("")).toBe("");
     });
   });
 });
 
-// Test suite for parseMMDDYYYY function
-describe("parseMMDDYYYY", () => {
-  // Valid date string
+describe("test parseMMDDYYYY helper function", () => {
   it("should correctly parse a valid MMDDYYYY date string", () => {
     const date = parseMMDDYYYY("12/25/2023");
     expect(date).toBeInstanceOf(Date);
@@ -184,7 +162,6 @@ describe("parseMMDDYYYY", () => {
     expect(date?.getMilliseconds()).toBe(0);
   });
 
-  // Another valid date string (single digits for month/day)
   it("should correctly parse a valid MMDDYYYY date string with single digit month/day", () => {
     const date = parseMMDDYYYY("01/05/2024");
     expect(date).toBeInstanceOf(Date);
@@ -193,7 +170,6 @@ describe("parseMMDDYYYY", () => {
     expect(date?.getDate()).toBe(5);
   });
 
-  // Leap year date
   it("should correctly parse a leap year date", () => {
     const date = parseMMDDYYYY("02/29/2028"); // 2028 is a leap year
     expect(date).toBeInstanceOf(Date);
@@ -202,69 +178,41 @@ describe("parseMMDDYYYY", () => {
     expect(date?.getDate()).toBe(29);
   });
 
-  // Non-leap year 02/29 (should return null)
   it("should return null for 02/29 in a non-leap year", () => {
     const date = parseMMDDYYYY("02/29/2027");
     expect(date).toBeNull();
   });
 
-  // Invalid month
   it("should return null for an invalid month", () => {
     const date = parseMMDDYYYY("13/01/2023");
     expect(date).toBeNull();
   });
 
-  // Invalid day
   it("should return null for an invalid day", () => {
     const date = parseMMDDYYYY("01/32/2023");
     expect(date).toBeNull();
   });
 
-  // Invalid day for a specific month
   it("should return null for an invalid day for a specific month", () => {
     const date = parseMMDDYYYY("04/31/2023"); // April has 30 days
     expect(date).toBeNull();
   });
 
-  // Empty string
-  it("should return null for an empty string", () => {
-    const date = parseMMDDYYYY("");
-    expect(date).toBeNull();
-  });
-
-  // Null input
-  it("should return null for a null input", () => {
-    // @ts-ignore: Intentionally testing null input for robustness
-    const date = parseMMDDYYYY(null);
-    expect(date).toBeNull();
-  });
-
-  // Undefined input
-  it("should return null for an undefined input", () => {
-    // @ts-ignore: Intentionally testing undefined input for robustness
-    const date = parseMMDDYYYY(undefined);
-    expect(date).toBeNull();
-  });
-
-  // Incorrect format (missing slashes)
   it("should return null for an incorrect format (missing slashes)", () => {
     const date = parseMMDDYYYY("12-25-2023");
     expect(date).toBeNull();
   });
 
-  // Incorrect format (wrong number of digits)
   it("should return null for an incorrect format (wrong number of digits)", () => {
     const date = parseMMDDYYYY("1/2/2023");
     expect(date).toBeNull();
   });
 
-  // Incorrect format (extra characters)
-  it("should return null for an incorrect format (extra characters)", () => {
+  it("should return null for an incorrect format", () => {
     const date = parseMMDDYYYY("12/25/2023abc");
     expect(date).toBeNull();
   });
 
-  // Future date (valid)
   it("should correctly parse a valid future date", () => {
     const futureDate = parseMMDDYYYY("07/15/2050");
     expect(futureDate).toBeInstanceOf(Date);
@@ -273,24 +221,8 @@ describe("parseMMDDYYYY", () => {
     expect(futureDate?.getDate()).toBe(15);
   });
 
-  // Date with leading zeros for month/day
-  it("should correctly parse a date with leading zeros for month/day", () => {
-    const date = parseMMDDYYYY("03/01/2023");
-    expect(date).toBeInstanceOf(Date);
-    expect(date?.getFullYear()).toBe(2023);
-    expect(date?.getMonth()).toBe(2);
-    expect(date?.getDate()).toBe(1);
-  });
-
-  // Zero for day or month (invalid based on typical date understanding)
   it("should return null for day or month being zero", () => {
     expect(parseMMDDYYYY("00/10/2023")).toBeNull();
     expect(parseMMDDYYYY("10/00/2023")).toBeNull();
-  });
-
-  // Date string with extra spaces (should return null due to strict regex)
-  it("should return null for date string with extra spaces", () => {
-    expect(parseMMDDYYYY(" 12/25/2023 ")).toBeNull();
-    expect(parseMMDDYYYY("12 /25/2023")).toBeNull();
   });
 });

--- a/services/ui-src/src/utils/other/time.test.ts
+++ b/services/ui-src/src/utils/other/time.test.ts
@@ -30,7 +30,7 @@ describe("utils/time", () => {
   });
 
   describe("convertDateTimeEtToUtc()", () => {
-    it("Converts valid ET datetime to UTC correctly", () => {
+    it("converts valid ET datetime to UTC correctly", () => {
       const result = convertDateTimeEtToUtc(
         { year: 2022, month: 1, day: 1 },
         { hour: 0, minute: 0, second: 0 }
@@ -41,7 +41,7 @@ describe("utils/time", () => {
   });
 
   describe("convertDateEtToUtc()", () => {
-    it("Converts valid ET datetime to UTC correctly", () => {
+    it("converts valid ET datetime to UTC correctly", () => {
       const result = convertDateEtToUtc(testDate.etFormattedString);
       expect(result).toBe(testDate.utcMS);
       expect(new Date(result).toUTCString()).toBe(testDate.utcString);
@@ -49,7 +49,7 @@ describe("utils/time", () => {
   });
 
   describe("convertDateUtcToEt()", () => {
-    it("Converts valid UTC datetime to ET correctly", () => {
+    it("converts valid UTC datetime to ET correctly", () => {
       const result = convertDateUtcToEt(testDate.utcMS);
       expect(result).toBe(testDate.etFormattedString);
     });
@@ -95,7 +95,7 @@ describe("utils/time", () => {
   });
 
   describe("formatMonthDayYear()", () => {
-    it("Should render dates as MM/dd/yyyy", () => {
+    it("should render dates as MM/dd/yyyy", () => {
       const date = new Date("2024-03-20").valueOf();
       const formatted = formatMonthDayYear(date);
       // Imprecise matcher, because the result depends on the user's time zone
@@ -128,7 +128,7 @@ describe("utils/time", () => {
       expect(calculateRemainingSeconds()).toBeCloseTo(0);
     });
 
-    it("expiration time greater than zero", () => {
+    it("checks that expiration time is greater than zero", () => {
       const expirationTime = "2050-11-18T12:53:11-05:00";
       expect(calculateRemainingSeconds(expirationTime)).toBeGreaterThan(0);
     });

--- a/services/ui-src/src/utils/other/time.ts
+++ b/services/ui-src/src/utils/other/time.ts
@@ -148,3 +148,28 @@ export const calculateNextQuarter = (previousQuarter: string) => {
   }
   return "";
 };
+
+// Parses a date string in the format "MM/DD/YYYY" and returns a Date object
+export const parseMMDDYYYY = (dateString: string): Date | null => {
+  if (!dateString || !/^\d{2}\/\d{2}\/\d{4}$/.test(dateString)) {
+    return null;
+  }
+  const parts = dateString.split("/");
+  // Month is 0 indexed in JavaScript Date constructor
+  const month = parseInt(parts[0], 10) - 1;
+  const day = parseInt(parts[1], 10);
+  const year = parseInt(parts[2], 10);
+
+  const dateObj = new Date(year, month, day);
+
+  // Check if the date is valid
+  if (
+    dateObj.getFullYear() === year &&
+    dateObj.getMonth() === month &&
+    dateObj.getDate() === day
+  ) {
+    dateObj.setHours(0, 0, 0, 0); // Make sure the time is set to midnight
+    return dateObj;
+  }
+  return null;
+};

--- a/services/ui-src/src/utils/other/time.ts
+++ b/services/ui-src/src/utils/other/time.ts
@@ -99,22 +99,19 @@ export const formatMonthDayYear = (date: number) => {
   return [getPart("month"), getPart("day"), getPart("year")].join("/");
 };
 
-export const checkDateCompleteness = (date: string) => {
-  const month = parseInt(date.split("/")?.[0]);
-  const day = parseInt(date.split("/")?.[1]);
-  const year = parseInt(date.split("/")?.[2]);
-  const dateIsComplete = month && day && year.toString().length === 4;
-  return dateIsComplete ? { year, month, day } : null;
-};
-
 export const convertDatetimeStringToNumber = (
   date: string,
   time: TimeShape
 ): number | undefined => {
-  const completeDate = checkDateCompleteness(date);
+  const completeDate = parseMMDDYYYY(date);
   let convertedTime;
   if (completeDate) {
-    convertedTime = convertDateTimeEtToUtc(completeDate, time);
+    let dateShape = {
+      year: completeDate?.getFullYear(),
+      month: completeDate?.getMonth() + 1,
+      day: completeDate?.getDate(),
+    };
+    convertedTime = convertDateTimeEtToUtc(dateShape, time);
   }
   return convertedTime || undefined;
 };
@@ -156,9 +153,9 @@ export const parseMMDDYYYY = (dateString: string): Date | null => {
   }
   const parts = dateString.split("/");
   // Month is 0 indexed in JavaScript Date constructor
-  const month = parseInt(parts[0], 10) - 1;
-  const day = parseInt(parts[1], 10);
-  const year = parseInt(parts[2], 10);
+  const month = parseInt(parts[0]) - 1;
+  const day = parseInt(parts[1]);
+  const year = parseInt(parts[2]);
 
   const dateObj = new Date(year, month, day);
 
@@ -168,7 +165,7 @@ export const parseMMDDYYYY = (dateString: string): Date | null => {
     dateObj.getMonth() === month &&
     dateObj.getDate() === day
   ) {
-    dateObj.setHours(0, 0, 0, 0); // Make sure the time is set to midnight
+    dateObj.setHours(0, 0, 0, 0); // Set time to midnight
     return dateObj;
   }
   return null;

--- a/services/ui-src/src/utils/other/time.ts
+++ b/services/ui-src/src/utils/other/time.ts
@@ -107,9 +107,9 @@ export const convertDatetimeStringToNumber = (
   let convertedTime;
   if (completeDate) {
     let dateShape = {
-      year: completeDate?.getFullYear(),
-      month: completeDate?.getMonth() + 1,
-      day: completeDate?.getDate(),
+      year: completeDate.getFullYear(),
+      month: completeDate.getMonth() + 1,
+      day: completeDate.getDate(),
     };
     convertedTime = convertDateTimeEtToUtc(dateShape, time);
   }
@@ -146,10 +146,18 @@ export const calculateNextQuarter = (previousQuarter: string) => {
   return "";
 };
 
-// Parses a date string in the format "MM/DD/YYYY" and returns a Date object
-export const parseMMDDYYYY = (dateString: string): Date | null => {
+/**
+ * Parse a date string in the format "MM/DD/YYYY"
+ * @returns a Date, or `undefined` if the input is invalid
+ * @example
+ * parseMMDDYYYY("") === undefined
+ * parseMMDDYYYY("not a date") === undefined
+ * parseMMDDYYYY("99/99/9999") === undefined
+ * parseMMDDYYYY("12/31/2025") // December 31st, 2025
+ */
+export const parseMMDDYYYY = (dateString: string): Date | undefined => {
   if (!dateString || !/^\d{2}\/\d{2}\/\d{4}$/.test(dateString)) {
-    return null;
+    return undefined;
   }
   const parts = dateString.split("/");
   // Month is 0 indexed in JavaScript Date constructor
@@ -165,8 +173,7 @@ export const parseMMDDYYYY = (dateString: string): Date | null => {
     dateObj.getMonth() === month &&
     dateObj.getDate() === day
   ) {
-    dateObj.setHours(0, 0, 0, 0); // Set time to midnight
     return dateObj;
   }
-  return null;
+  return undefined;
 };

--- a/services/ui-src/src/utils/validation/bannerValidation.test.ts
+++ b/services/ui-src/src/utils/validation/bannerValidation.test.ts
@@ -40,8 +40,8 @@ describe("bannerFormValidateSchema (UI Form", () => {
     bannerTitle: { answer: "mock title" },
     bannerDescription: { answer: "mock description" },
     bannerLink: { answer: "http://example.com" },
-    bannerStartDate: { answer: startDate || "" },
-    bannerEndDate: { answer: endDate || "" },
+    bannerStartDate: { answer: startDate ?? "" },
+    bannerEndDate: { answer: endDate ?? "" },
   });
 
   it("should pass when startDate is before endDate", async () => {

--- a/services/ui-src/src/utils/validation/bannerValidation.test.ts
+++ b/services/ui-src/src/utils/validation/bannerValidation.test.ts
@@ -28,9 +28,19 @@ describe("Test validateBannerPayload function", () => {
     const validatedData = await validateBannerPayload(validObject);
     expect(validatedData).toEqual(validObject);
   });
+
   it("throws an error when validating an invalid object", () => {
     expect(async () => {
       await validateBannerPayload(invalidObject);
+    }).rejects.toThrow();
+  });
+
+  it("rejects payloads with start date after end date", () => {
+    expect(async () => {
+      await validateBannerPayload({
+        ...validObject,
+        startDate: validObject.endDate + 1,
+      });
     }).rejects.toThrow();
   });
 });

--- a/services/ui-src/src/utils/validation/bannerValidation.test.ts
+++ b/services/ui-src/src/utils/validation/bannerValidation.test.ts
@@ -1,4 +1,7 @@
-import { validateBannerPayload } from "./bannerValidation";
+import {
+  bannerFormValidateSchema,
+  validateBannerPayload,
+} from "./bannerValidation";
 import { error } from "../../constants";
 
 const validObject = {
@@ -32,46 +35,25 @@ describe("Test validateBannerPayload function", () => {
   });
 });
 
-describe("validateBannerPayload (API)", () => {
-  const basePayload = {
-    key: "admin-banner-id",
-    title: "mock title",
-    description: "mock description",
-  };
-
-  it("should throw an error if the payload is undefined", async () => {
-    await expect(validateBannerPayload(undefined)).rejects.toThrow(
-      "missing data"
-    );
+describe("bannerFormValidateSchema (UI Form", () => {
+  const createFormValues = (startDate?: string, endDate?: string) => ({
+    bannerTitle: { answer: "mock title" },
+    bannerDescription: { answer: "mock description" },
+    bannerLink: { answer: "http://example.com" },
+    bannerStartDate: { answer: startDate || "" },
+    bannerEndDate: { answer: endDate || "" },
   });
 
   it("should pass when startDate is before endDate", async () => {
-    const payload = {
-      ...basePayload,
-      startDate: 11022933,
-      endDate: 103444405,
-    };
-    await expect(validateBannerPayload(payload)).resolves.toEqual(payload);
+    const formValues = createFormValues("01/01/1970", "01/02/1970");
+    await expect(
+      bannerFormValidateSchema.validate(formValues)
+    ).resolves.toEqual(formValues);
   });
 
-  it("should throw an error when endDate is before startDate", async () => {
-    const payload = {
-      ...basePayload,
-      startDate: 103444405,
-      endDate: 11022933,
-    };
-    await expect(validateBannerPayload(payload)).rejects.toThrow(
-      error.END_DATE_BEFORE_START_DATE
-    );
-  });
-
-  it("should fail when endDate is equal to startDate", async () => {
-    const payload = {
-      ...basePayload,
-      startDate: 11022933,
-      endDate: 11022933,
-    };
-    await expect(validateBannerPayload(payload)).rejects.toThrow(
+  it("should throw an error when startDate is after endDate", async () => {
+    const formValues = createFormValues("01/02/1970", "01/01/1970");
+    await expect(bannerFormValidateSchema.validate(formValues)).rejects.toThrow(
       error.END_DATE_BEFORE_START_DATE
     );
   });

--- a/services/ui-src/src/utils/validation/bannerValidation.test.ts
+++ b/services/ui-src/src/utils/validation/bannerValidation.test.ts
@@ -44,6 +44,12 @@ describe("bannerFormValidateSchema (UI Form", () => {
     bannerEndDate: { answer: endDate ?? "" },
   });
 
+  it("should throw an error if the payload is undefined", async () => {
+    await expect(validateBannerPayload(undefined)).rejects.toThrow(
+      "missing data"
+    );
+  });
+
   it("should pass when startDate is before endDate", async () => {
     const formValues = createFormValues("01/01/1970", "01/02/1970");
     await expect(

--- a/services/ui-src/src/utils/validation/bannerValidation.test.ts
+++ b/services/ui-src/src/utils/validation/bannerValidation.test.ts
@@ -1,4 +1,5 @@
 import { validateBannerPayload } from "./bannerValidation";
+import { error } from "../../constants";
 
 const validObject = {
   key: "1023",
@@ -28,5 +29,50 @@ describe("Test validateBannerPayload function", () => {
     expect(async () => {
       await validateBannerPayload(invalidObject);
     }).rejects.toThrow();
+  });
+});
+
+describe("validateBannerPayload (API)", () => {
+  const basePayload = {
+    key: "admin-banner-id",
+    title: "mock title",
+    description: "mock description",
+  };
+
+  it("should throw an error if the payload is undefined", async () => {
+    await expect(validateBannerPayload(undefined)).rejects.toThrow(
+      "missing data"
+    );
+  });
+
+  it("should pass when startDate is before endDate", async () => {
+    const payload = {
+      ...basePayload,
+      startDate: 11022933,
+      endDate: 103444405,
+    };
+    await expect(validateBannerPayload(payload)).resolves.toEqual(payload);
+  });
+
+  it("should throw an error when endDate is before startDate", async () => {
+    const payload = {
+      ...basePayload,
+      startDate: 103444405,
+      endDate: 11022933,
+    };
+    await expect(validateBannerPayload(payload)).rejects.toThrow(
+      error.END_DATE_BEFORE_START_DATE
+    );
+  });
+
+  it("should fail when endDate is equal to startDate", async () => {
+    const payload = {
+      ...basePayload,
+      startDate: 11022933,
+      endDate: 11022933,
+    };
+    await expect(validateBannerPayload(payload)).rejects.toThrow(
+      error.END_DATE_BEFORE_START_DATE
+    );
   });
 });

--- a/services/ui-src/src/utils/validation/bannerValidation.ts
+++ b/services/ui-src/src/utils/validation/bannerValidation.ts
@@ -1,51 +1,85 @@
 import { BannerData } from "types/banners";
-import { checkDateCompleteness } from "utils/other/time";
+import { checkDateCompleteness, parseMMDDYYYY } from "utils/other/time";
 import { boolean, number, object, string } from "yup";
-
+import { error } from "../../constants";
 /**
  * This schema is used for live validation as the user fills out the form.
  * It differs from the banner write schema below, because the shape of the data
  * we bind to the form differs from the shape of the data we send to the backend.
  * We transform from one shape to the other in `onSubmit()`.
  */
-export const bannerFormValidateSchema = object().shape({
-  bannerTitle: object().shape({
-    answer: string().required("A response is required"),
-  }),
-  bannerDescription: object().shape({
-    answer: string().required("A response is required"),
-  }),
-  bannerLink: object().shape({
-    answer: string()
-      .url("Response must be a valid hyperlink/URL")
-      .notRequired(),
-  }),
-  bannerStartDate: object().shape({
-    answer: string()
-      .test({
-        message:
-          "Start date is invalid. Please enter date in MM/DD/YYYY format",
-        test: (value) => {
-          if (value) {
-            return checkDateCompleteness(value) !== null;
-          } else return true;
-        },
-      })
-      .required("A response is required"),
-  }),
-  bannerEndDate: object().shape({
-    answer: string()
-      .test({
-        message: "End date is invalid. Please enter date in MM/DD/YYYY format",
-        test: (value) => {
-          if (value) {
-            return checkDateCompleteness(value) !== null;
-          } else return true;
-        },
-      })
-      .required("A response is required"),
-  }),
-});
+export const bannerFormValidateSchema = object()
+  .shape({
+    bannerTitle: object().shape({
+      answer: string().required("A response is required"),
+    }),
+    bannerDescription: object().shape({
+      answer: string().required("A response is required"),
+    }),
+    bannerLink: object().shape({
+      answer: string()
+        .url("Response must be a valid hyperlink/URL")
+        .notRequired(),
+    }),
+    bannerStartDate: object().shape({
+      answer: string()
+        .test({
+          message:
+            "Start date is invalid. Please enter date in MM/DD/YYYY format",
+          test: (value) => {
+            if (value) {
+              return (
+                checkDateCompleteness(value) !== null &&
+                parseMMDDYYYY(value) !== null
+              );
+            } else return true;
+          },
+        })
+        .required("A response is required"),
+    }),
+    bannerEndDate: object().shape({
+      answer: string()
+        .test({
+          message:
+            "End date is invalid. Please enter date in MM/DD/YYYY format",
+          test: (value) => {
+            if (value) {
+              return (
+                checkDateCompleteness(value) !== null &&
+                parseMMDDYYYY(value) !== null
+              );
+            } else return true;
+          },
+        })
+        .required("A response is required"),
+    }),
+  })
+  .test(
+    "start-date-before-end-date-form",
+    "End date must be after start date",
+    function (value) {
+      const { bannerStartDate, bannerEndDate } = value || {};
+      const startDateString = bannerStartDate?.answer;
+      const endDateString = bannerEndDate?.answer;
+
+      if (startDateString && endDateString) {
+        const startDate = parseMMDDYYYY(startDateString);
+        const endDate = parseMMDDYYYY(endDateString);
+
+        if (startDate && endDate) {
+          if (endDate <= startDate) {
+            return this.createError({
+              path: "bannerEndDate.answer",
+              message: "End date must be after start date",
+            });
+          }
+        } else {
+          return true;
+        }
+      }
+      return true;
+    }
+  );
 
 const bannerWriteValidateSchema = object().shape({
   key: string().required(),
@@ -53,7 +87,26 @@ const bannerWriteValidateSchema = object().shape({
   description: string().required(),
   link: string().url().notRequired(),
   startDate: number().notRequired(),
-  endDate: number().notRequired(),
+  endDate: number()
+    .notRequired()
+    .when("startDate", (startDate, schema) => {
+      const actualStartDate = Array.isArray(startDate)
+        ? startDate[0]
+        : startDate;
+      if (typeof actualStartDate === "number") {
+        return schema.test({
+          name: "is-after-start-date-write",
+          message: error.END_DATE_BEFORE_START_DATE,
+          test: function (endDateValue) {
+            if (typeof endDateValue === "number") {
+              return endDateValue > actualStartDate;
+            }
+            return true;
+          },
+        });
+      }
+      return schema;
+    }),
   isActive: boolean().notRequired(),
 });
 

--- a/services/ui-src/src/utils/validation/bannerValidation.ts
+++ b/services/ui-src/src/utils/validation/bannerValidation.ts
@@ -1,5 +1,5 @@
 import { BannerData } from "types/banners";
-import { checkDateCompleteness, parseMMDDYYYY } from "utils/other/time";
+import { parseMMDDYYYY } from "utils/other/time";
 import { boolean, number, object, string } from "yup";
 import { error } from "../../constants";
 /**
@@ -28,10 +28,7 @@ export const bannerFormValidateSchema = object()
             "Start date is invalid. Please enter date in MM/DD/YYYY format",
           test: (value) => {
             if (value) {
-              return (
-                checkDateCompleteness(value) !== null &&
-                parseMMDDYYYY(value) !== null
-              );
+              return parseMMDDYYYY(value) !== null;
             } else return true;
           },
         })
@@ -44,10 +41,7 @@ export const bannerFormValidateSchema = object()
             "End date is invalid. Please enter date in MM/DD/YYYY format",
           test: (value) => {
             if (value) {
-              return (
-                checkDateCompleteness(value) !== null &&
-                parseMMDDYYYY(value) !== null
-              );
+              return parseMMDDYYYY(value) !== null;
             } else return true;
           },
         })

--- a/services/ui-src/src/utils/validation/bannerValidation.ts
+++ b/services/ui-src/src/utils/validation/bannerValidation.ts
@@ -56,7 +56,7 @@ export const bannerFormValidateSchema = object()
   })
   .test(
     "start-date-before-end-date-form",
-    "End date must be after start date",
+    error.END_DATE_BEFORE_START_DATE,
     function (value) {
       const { bannerStartDate, bannerEndDate } = value || {};
       const startDateString = bannerStartDate?.answer;
@@ -70,7 +70,7 @@ export const bannerFormValidateSchema = object()
           if (endDate <= startDate) {
             return this.createError({
               path: "bannerEndDate.answer",
-              message: "End date must be after start date",
+              message: error.END_DATE_BEFORE_START_DATE,
             });
           }
         } else {

--- a/services/ui-src/src/utils/validation/bannerValidation.ts
+++ b/services/ui-src/src/utils/validation/bannerValidation.ts
@@ -28,7 +28,7 @@ export const bannerFormValidateSchema = object()
             "Start date is invalid. Please enter date in MM/DD/YYYY format",
           test: (value) => {
             if (value) {
-              return parseMMDDYYYY(value) !== null;
+              return parseMMDDYYYY(value) !== undefined;
             } else return true;
           },
         })
@@ -41,7 +41,7 @@ export const bannerFormValidateSchema = object()
             "End date is invalid. Please enter date in MM/DD/YYYY format",
           test: (value) => {
             if (value) {
-              return parseMMDDYYYY(value) !== null;
+              return parseMMDDYYYY(value) !== undefined;
             } else return true;
           },
         })
@@ -84,16 +84,13 @@ const bannerWriteValidateSchema = object().shape({
   endDate: number()
     .notRequired()
     .when("startDate", (startDate, schema) => {
-      const actualStartDate = Array.isArray(startDate)
-        ? startDate[0]
-        : startDate;
-      if (typeof actualStartDate === "number") {
+      if (typeof startDate === "number") {
         return schema.test({
           name: "is-after-start-date-write",
           message: error.END_DATE_BEFORE_START_DATE,
           test: function (endDateValue) {
             if (typeof endDateValue === "number") {
-              return endDateValue > actualStartDate;
+              return endDateValue > startDate;
             }
             return true;
           },

--- a/services/ui-src/src/utils/validation/bannerValidation.ts
+++ b/services/ui-src/src/utils/validation/bannerValidation.ts
@@ -83,7 +83,7 @@ const bannerWriteValidateSchema = object().shape({
   startDate: number().notRequired(),
   endDate: number()
     .notRequired()
-    .when("startDate", (startDate, schema) => {
+    .when("startDate", ([startDate], schema) => {
       if (typeof startDate === "number") {
         return schema.test({
           name: "is-after-start-date-write",


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
There is a lot of yup validation here -- as Angela suggested. 
After Ben's awesome re-factor, typing the date correctly was possible!
Note: Dates are so weirrddddd. We go from `string` to `number` to "Date" to "ET" to "Utc" to `epoch` to `eons` to `galaxy years` to `1970` because 1970 is when time started - I'm just kidding - I'm exaggerating here.

Here's some context for some of the yup updates:
* yup quirk: `startDate` is passed into the custom validation function as a singleton array, instead of just its actual value. Thanks Ben for adding the code that => `always expects startDate to be an array with one number in it and the test for that on the frontend`
* `schema.test({...})` defines a custom validation rule for the endDate field, ensuring that if both startDate and endDate are present AND numbers, endDate must be after startDate. If not, it triggers an error message (error.END_DATE_BEFORE_START_DATE).
* `.when("startDate", (startDate, schema) => { ... })` - The first argument, "startDate", specifies which field to watch for changes. The second argument is a function that receives the value of startDate and the current schema for endDate. If startDate is a number, the schema adds a custom test to ensure that endDate is after startDate. If startDate is not a number (or not present), it just keeps the schema as-is (no extra rule).
* `checkDateCompleteness` is no longer needed as `parseMMDDYYYY` covers what it was doing. Twas redundant. Date parsing has evolved. For context - checkDateCompleteness was simply 
* for consistency in some unit tests instead of `test(` -> `it(`
* maybe too many time.ts tests, but was trying to bring code coverage up

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4301

---
### How to test
**Deploy Link:** https://d2mzrklpqm7rn2.cloudfront.net/
1. Login as an admin user: adminuser@test.com
2. Go to top right and click on "My Account" -> "Manage Account"
3. Click on "Banner Editor"
4. Enter a date for "Start date"
5. Enter an older for "End date"
6. The validation error matches MCR's version: "End date can't be before start date"
    <img width="300" alt="image of validation error when End date is older than Start date" src="https://github.com/user-attachments/assets/67bb0557-e2ba-4147-8fbf-6d161e8a24db">

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
