### PR TITLE
Extract LengthOfStay from a kind of PerformanceRate to a standalone Element

### DIFF
--- a/services/app-api/forms/2026/elements.ts
+++ b/services/app-api/forms/2026/elements.ts
@@ -4,6 +4,7 @@ import {
   DividerTemplate,
   ElementType,
   HeaderTemplate,
+  LengthOfStayRateTemplate,
   MeasureDetailsTemplate,
   MeasureFooterTemplate,
   MeasureResultsNavigationTableTemplate,
@@ -16,6 +17,8 @@ import {
   SubHeaderTemplate,
   TextAreaBoxTemplate,
 } from "../../types/reports";
+
+const REPORT_YEAR = 2026;
 
 export const returnToRequiredDashboard: ButtonLinkTemplate = {
   type: ElementType.ButtonLink,
@@ -358,75 +361,45 @@ export const performanceRatePOM: PerformanceRateTemplate = {
 };
 
 //Rates for LTSS-7
-export const performanceRateFacilityDischarges: PerformanceRateTemplate = {
-  type: ElementType.PerformanceRate,
+export const performanceRateFacilityDischarges: LengthOfStayRateTemplate = {
+  type: ElementType.LengthOfStayRate,
   id: "measure-rates",
-  fields: [
-    {
-      id: "count-of-success",
-      label: "Count of Successful Discharges to the Community",
-    },
-    { id: "fac-count", label: "Facility Admission Count" },
-    {
-      id: "expected-count-of-success",
-      label: "Expected Count of Successful Discharges to the Community",
-    },
-    { id: "multi-plan", label: "Multi-Plan Population Rate" },
-    {
-      id: "opr-min-stay",
-      label: "Observed Performance Rate for Minimizing Length of Facility Stay",
-      autoCalc: true,
-    },
-    {
-      id: "epr-min-stay",
-      label: "Expected Performance Rate for Minimizing Length of Facility Stay",
-      autoCalc: true,
-    },
-    {
-      id: "rar-min-stay",
-      label: "Risk Adjusted Rate for Minimizing Length of Facility Stay",
-      autoCalc: true,
-    },
-  ],
-  rateType: PerformanceRateType.FIELDS,
+  labels: {
+    performanceTarget: `What is the ${
+      REPORT_YEAR + 2
+    } state performance target for this assessment?`,
+    actualCount: "Count of Successful Discharges to the Community",
+    denominator: "Facility Admission Count",
+    expectedCount: "Expected Count of Successful Discharges to the Community",
+    populationRate: "Multi-Plan Population Rate",
+    actualRate:
+      "Observed Performance Rate for Minimizing Length of Facility Stay",
+    expectedRate:
+      "Expected Performance Rate for Minimizing Length of Facility Stay",
+    adjustedRate: "Risk Adjusted Rate for Minimizing Length of Facility Stay",
+  },
   required: true,
-  rateCalc: RateCalc.FacilityLengthOfStayCalc,
 };
 
 //Rates for LTSS-8
-export const performanceRateFacilityTransitions: PerformanceRateTemplate = {
-  type: ElementType.PerformanceRate,
+export const performanceRateFacilityTransitions: LengthOfStayRateTemplate = {
+  type: ElementType.LengthOfStayRate,
   id: "measure-rates",
-  fields: [
-    {
-      id: "count-of-success",
-      label: "Count of Successful Transitions to the Community",
-    },
-    { id: "fac-count", label: "Long-Term Facility Stay Count" },
-    {
-      id: "expected-count-of-success",
-      label: "Expected Count of Successful Transitions to the Community",
-    },
-    { id: "multi-plan", label: "Multi-Plan Population Rate" },
-    {
-      id: "opr-min-stay",
-      label: "Observed Performance Rate for Minimizing Length of Facility Stay",
-      autoCalc: true,
-    },
-    {
-      id: "epr-min-stay",
-      label: "Expected Performance Rate for Minimizing Length of Facility Stay",
-      autoCalc: true,
-    },
-    {
-      id: "rar-min-stay",
-      label: "Risk Adjusted Rate for Minimizing Length of Facility Stay",
-      autoCalc: true,
-    },
-  ],
+  labels: {
+    performanceTarget: `What is the ${
+      REPORT_YEAR + 2
+    } state performance target for this assessment?`,
+    actualCount: "Count of Successful Transitions to the Community",
+    denominator: "Long-Term Facility Stay Count",
+    expectedCount: "Expected Count of Successful Transitions to the Community",
+    populationRate: "Multi-Plan Population Rate",
+    actualRate:
+      "Observed Performance Rate for Minimizing Length of Facility Stay",
+    expectedRate:
+      "Expected Performance Rate for Minimizing Length of Facility Stay",
+    adjustedRate: "Risk Adjusted Rate for Minimizing Length of Facility Stay",
+  },
   required: true,
-  rateType: PerformanceRateType.FIELDS,
-  rateCalc: RateCalc.FacilityLengthOfStayCalc,
 };
 
 // Rates for LTSS-6

--- a/services/app-api/types/reports.ts
+++ b/services/app-api/types/reports.ts
@@ -277,6 +277,7 @@ export enum ElementType {
   StatusTable = "statusTable",
   MeasureDetails = "measureDetails",
   MeasureFooter = "measureFooter",
+  LengthOfStayRate = "lengthOfStay",
   PerformanceRate = "performanceRate",
   StatusAlert = "statusAlert",
   Divider = "divider",
@@ -302,6 +303,7 @@ export type PageElement =
   | StatusTableTemplate
   | MeasureDetailsTemplate
   | MeasureFooterTemplate
+  | LengthOfStayRateTemplate
   | PerformanceRateTemplate
   | StatusAlertTemplate
   | DividerTemplate
@@ -458,6 +460,26 @@ export type MeasureFooterTemplate = {
   clear?: boolean;
 };
 
+const LengthOfStayRateFields = [
+  "performanceTarget",
+  "actualCount",
+  "denominator",
+  "expectedCount",
+  "populationRate",
+  "actualRate",
+  "expectedRate",
+  "adjustedRate",
+] as const;
+export type LengthOfStayField = typeof LengthOfStayRateFields[number];
+
+export type LengthOfStayRateTemplate = {
+  id: string;
+  type: ElementType.LengthOfStayRate;
+  labels: Record<LengthOfStayField, string>;
+  answer?: Record<LengthOfStayField, number | undefined>;
+  required?: boolean;
+};
+
 export type PerformanceData = {
   rates: AnyObject[];
   denominator?: number;
@@ -482,13 +504,11 @@ export type RateSetData = {
 export const enum PerformanceRateType {
   NDR = "NDR",
   NDR_Enhanced = "NDREnhanced",
-  FIELDS = "Fields",
   NDR_FIELDS = "NDRFields",
 }
 
 export const enum RateCalc {
   NDRCalc = "NDRCalc",
-  FacilityLengthOfStayCalc = "FacilityLengthOfStayCalc",
 }
 
 export type PerformanceRateTemplate = {

--- a/services/app-api/utils/reportValidation.ts
+++ b/services/app-api/utils/reportValidation.ts
@@ -162,6 +162,8 @@ const pageElementSchema = lazy((value: PageElement): Schema => {
       return measureDetailsTemplateSchema;
     case ElementType.MeasureFooter:
       return measureFooterSchema;
+    case ElementType.LengthOfStayRate:
+      return lengthOfStayRateSchema;
     case ElementType.PerformanceRate:
       return performanceRateSchema;
     case ElementType.StatusAlert:
@@ -251,6 +253,34 @@ const measureFooterSchema = object().shape({
   completeMeasure: boolean().notRequired(),
   completeSection: boolean().notRequired(),
   clear: boolean().notRequired(),
+});
+
+const lengthOfStayRateSchema = object().shape({
+  type: string().required(ElementType.LengthOfStayRate),
+  id: string().required(),
+  labels: object().shape({
+    performanceTarget: string().required(),
+    actualCount: string().required(),
+    denominator: string().required(),
+    expectedCount: string().required(),
+    populationRate: string().required(),
+    actualRate: string().required(),
+    expectedRate: string().required(),
+    adjustedRate: string().required(),
+  }),
+  required: boolean().notRequired(),
+  answer: object()
+    .shape({
+      performanceTarget: number().notRequired(),
+      actualCount: number().notRequired(),
+      denominator: number().notRequired(),
+      expectedCount: number().notRequired(),
+      populationRate: number().notRequired(),
+      actualRate: number().notRequired(),
+      expectedRate: number().notRequired(),
+      adjustedRate: number().notRequired(),
+    })
+    .notRequired(),
 });
 
 const performanceRateSchema = object().shape({

--- a/services/database/scripts/migrateLengthOfStayFields.ts
+++ b/services/database/scripts/migrateLengthOfStayFields.ts
@@ -1,0 +1,106 @@
+/* eslint-disable no-console */
+import { paginateScan, PutCommand } from "@aws-sdk/lib-dynamodb";
+import { createClient } from "./utils";
+
+/**
+ * This is a data migration function for the QMS elements
+ * `performanceRateFacilityDischarges` and `performanceRateFacilityTransitions`.
+ * During initial development, we stored the field labels and answers in arrays.
+ * Going forward, we will store them in objects.
+ * This migration will transform elements in existing reports to the new shape.
+ *
+ * IN ORDER TO RUN THIS SCRIPT YOU MUST SET THIS ENVIRONMENT VARIABLE
+ *   - reportTable (eg "val-qms-reports")
+ * AND UNCOMMENT THE `main()` CALL AT THE BOTTOM
+ */
+export const main = async () => {
+  try {
+    const TableName = process.env.reportTable;
+    const client = createClient();
+
+    console.info("Scanning for existing QMS reports");
+
+    let reportCount = 0;
+    let migratedCount = 0;
+    for await (let dynamoPage of paginateScan({ client }, { TableName })) {
+      for (let report of dynamoPage.Items ?? []) {
+        reportCount += 1;
+        for (let reportPage of report.pages) {
+          for (let element of reportPage.elements) {
+            if (needsMigration(element)) {
+              migratedCount += 1;
+              console.debug(
+                `Updating an element in ${report.state} report '${report.name}'`
+              );
+
+              updateElement(element);
+              await client.send(
+                new PutCommand({
+                  TableName,
+                  Item: report,
+                })
+              );
+            }
+          }
+        }
+      }
+    }
+
+    console.info(
+      `Migration complete! ${reportCount} reports scanned; ${migratedCount} elements updated.`
+    );
+    return { status: 200 };
+  } catch (err) {
+    console.error("Error!", err);
+    return { status: 500 };
+  }
+};
+
+const needsMigration = (element: any) => {
+  return element.type === "performanceRate" && element.rateType === "Fields";
+};
+
+/** Update the given element _in-place_, so that the report can just be re-put. */
+const updateElement = (element: any) => {
+  const getFieldLabel = (fieldId: string) => {
+    return element.fields.find((f) => f.id === fieldId)!.label;
+  };
+
+  const parseAnswerField = (fieldId: string) => {
+    const value = element.answer[0].rates[fieldId];
+    if (typeof value === "number") return value;
+    if (!value) return undefined;
+    return parseFloat(value);
+  };
+
+  element.type = "lengthOfStay";
+  element.labels = {
+    performanceTarget: `What is the 2028 state performance target for this assessment?`,
+    actualCount: getFieldLabel("count-of-success"),
+    denominator: getFieldLabel("fac-count"),
+    expectedCount: getFieldLabel("expected-count-of-success"),
+    populationRate: getFieldLabel("multi-plan"),
+    actualRate: getFieldLabel("opr-min-stay"),
+    expectedRate: getFieldLabel("epr-min-stay"),
+    adjustedRate: getFieldLabel("rar-min-stay"),
+  };
+
+  if (element.answer) {
+    element.answer = {
+      performanceTarget: parseAnswerField("performanceTarget"),
+      actualCount: parseAnswerField("count-of-success"),
+      denominator: parseAnswerField("fac-count"),
+      expectedCount: parseAnswerField("expected-count-of-success"),
+      populationRate: parseAnswerField("multi-plan"),
+      actualRate: parseAnswerField("opr-min-stay"),
+      expectedRate: parseAnswerField("epr-min-stay"),
+      adjustedRate: parseAnswerField("rar-min-stay"),
+    };
+  }
+
+  delete element.rateType;
+  delete element.rateCalc;
+  delete element.fields;
+};
+
+// main(); // <- uncomment this to make the script actually, like, do stuff

--- a/services/database/scripts/utils.ts
+++ b/services/database/scripts/utils.ts
@@ -1,0 +1,37 @@
+import {
+  DynamoDBClient,
+  QueryCommandOutput,
+  ScanCommandOutput,
+} from "@aws-sdk/client-dynamodb";
+import { DynamoDBDocumentClient, Paginator } from "@aws-sdk/lib-dynamodb";
+
+const config = {
+  region: "us-east-1",
+  logger: {
+    // DynamoDB is quite chatty. We'll ignore most of that for our scripts.
+    trace: () => {},
+    debug: () => {},
+    info: () => {},
+    // eslint-disable-next-line no-console
+    warn: console.warn,
+    // eslint-disable-next-line no-console
+    error: console.error,
+  },
+};
+
+export const createClient = () => {
+  return DynamoDBDocumentClient.from(new DynamoDBClient(config));
+};
+
+/** Given a paginator, eagerly collect all of its items in an array */
+export const collectPageItems = async <
+  T extends QueryCommandOutput | ScanCommandOutput
+>(
+  paginator: Paginator<T>
+) => {
+  let items: Record<string, any>[] = [];
+  for await (let page of paginator) {
+    items = items.concat(page.Items ?? []);
+  }
+  return items;
+};

--- a/services/ui-src/src/components/index.ts
+++ b/services/ui-src/src/components/index.ts
@@ -50,6 +50,7 @@ export { HelpPage } from "./pages/HelpPage/HelpPage";
 export { NotFoundPage } from "./pages/NotFound/NotFoundPage";
 export { ProfilePage } from "./pages/Profile/ProfilePage";
 // report
+export { Fields } from "../components/rates/types/Fields";
 export { PerformanceRateElement } from "./report/PerformanceRate";
 export { MeasureDetailsElement } from "./report/MeasureDetails";
 export { MeasureFooterElement } from "./report/MeasureFooter";

--- a/services/ui-src/src/components/rates/calculations.test.ts
+++ b/services/ui-src/src/components/rates/calculations.test.ts
@@ -1,0 +1,25 @@
+import { parseNumber } from "./calculations";
+
+describe("Rate calculations", () => {
+  describe("parseNumber", () => {
+    it.each([
+      { input: "42", expected: 42 },
+      { input: "12.", expected: 12 },
+      { input: ".012", expected: 0.012 },
+      { input: "12.5", expected: 12.5 },
+      { input: "-77", expected: -77 },
+      { input: "-.3", expected: -0.3 },
+      { input: "0", expected: 0 },
+      { input: "-0", expected: 0 }, // even though 0 and -0 are different things
+      { input: "", expected: undefined },
+      { input: "    ", expected: undefined },
+      { input: "1abc", expected: undefined }, // even though parseFloat("1abc") === 1
+      { input: "Infinity", expected: undefined }, // even though isNaN(Infinity) === false
+      { input: "1.5e2", expected: undefined }, // even though 1.5e2 === 150
+      { input: "0xaf", expected: undefined }, // even though 0xaf === 175
+      { input: "1_000", expected: undefined }, // even though 1_000 === 1000
+    ])("should return $expected given '$input'", ({ input, expected }) => {
+      expect(parseNumber(input)).toBe(expected);
+    });
+  });
+});

--- a/services/ui-src/src/components/rates/types/Fields.test.tsx
+++ b/services/ui-src/src/components/rates/types/Fields.test.tsx
@@ -1,13 +1,12 @@
-import { act, render, screen } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { Fields } from "./Fields";
 import userEvent from "@testing-library/user-event";
 import { useFormContext } from "react-hook-form";
-import { FacilityLengthOfStayCalc } from "../calculations";
 import { useStore } from "utils";
 import {
   ElementType,
-  PerformanceRateTemplate,
-  PerformanceRateType,
+  LengthOfStayField,
+  LengthOfStayRateTemplate,
 } from "types";
 import { testA11y } from "utils/testing/commonTests";
 import { mockStateUserStore } from "utils/testing/setupJest";
@@ -34,51 +33,28 @@ const mockGetValues = (returnValue: any) =>
 jest.mock("utils/state/useStore");
 const mockedUseStore = useStore as jest.MockedFunction<typeof useStore>;
 
-const mockedPerformanceElement: PerformanceRateTemplate = {
+const mockedPerformanceElement: LengthOfStayRateTemplate = {
   id: "mock-perf-id",
-  type: ElementType.PerformanceRate,
-  rateType: PerformanceRateType.FIELDS,
-  label: "test label",
-  helperText: "helper text",
-  fields: [
-    {
-      id: "count-of-success",
-      label: "Count of Successful Discharges to the Community",
-    },
-    { id: "fac-count", label: "Facility Admission Count" },
-    {
-      id: "expected-count-of-success",
-      label: "Expected Count of Successful Discharges to the Community",
-    },
-    { id: "multi-plan", label: "Multi-Plan Population Rate" },
-    {
-      id: "opr-min-stay",
-      label:
-        "Observed Performance Rate for the Minimizing Length of Facility Stay",
-      autoCalc: true,
-    },
-    {
-      id: "epr-min-stay",
-      label:
-        "Expected Performance Rate for the Minimizing Length of Facility Stay",
-      autoCalc: true,
-    },
-    {
-      id: "rar-min-stay",
-      label: "Risk Adjusted Rate for the Minimizing Length of Facility Stay",
-      autoCalc: true,
-    },
-  ],
-  multiplier: 1,
+  type: ElementType.LengthOfStayRate,
+  labels: {
+    performanceTarget: `What is the 2028 state performance target for this assessment?`,
+    actualCount: "Count of Successful Discharges to the Community",
+    denominator: "Facility Admission Count",
+    expectedCount: "Expected Count of Successful Discharges to the Community",
+    populationRate: "Multi-Plan Population Rate",
+    actualRate:
+      "Observed Performance Rate for Minimizing Length of Facility Stay",
+    expectedRate:
+      "Expected Performance Rate for Minimizing Length of Facility Stay",
+    adjustedRate: "Risk Adjusted Rate for Minimizing Length of Facility Stay",
+  },
 };
 
 const fieldsComponent = (
   <Fields
     formkey={"mock-key"}
-    calculation={FacilityLengthOfStayCalc}
-    year={2026}
     disabled={false}
-    {...mockedPerformanceElement}
+    element={mockedPerformanceElement}
   />
 );
 
@@ -87,64 +63,49 @@ describe("<Fields />", () => {
     beforeEach(() => {
       render(fieldsComponent);
     });
-    test("Fields is visible", () => {
-      expect(
-        screen.getByRole("textbox", {
-          name: "What is the 2028 state performance target for this assessment?",
-        })
-      ).toBeInTheDocument();
 
-      mockedPerformanceElement.fields?.forEach((field) => {
-        expect(
-          screen.getByRole("textbox", {
-            name: field.label,
-          })
-        ).toBeInTheDocument();
+    const labels = mockedPerformanceElement.labels;
+    const getInput = (fieldId: LengthOfStayField) => {
+      return screen.getByRole("textbox", { name: labels[fieldId] });
+    };
 
-        if (field.autoCalc)
-          expect(
-            screen.getByRole("textbox", { name: field.label })
-          ).toBeDisabled();
-      });
+    test("Fields are visible, and disabled appropriately", () => {
+      for (let fieldId of Object.keys(labels)) {
+        expect(getInput(fieldId as LengthOfStayField)).toBeInTheDocument();
+      }
+
+      for (let editableFieldId of [
+        "performanceTarget",
+        "actualCount",
+        "denominator",
+        "expectedCount",
+        "populationRate",
+      ] as const) {
+        expect(getInput(editableFieldId)).not.toBeDisabled();
+      }
+
+      for (let autoCalcFieldId of [
+        "actualRate",
+        "expectedRate",
+        "adjustedRate",
+      ] as const) {
+        expect(getInput(autoCalcFieldId)).toBeDisabled();
+      }
     });
+
     test("Fields should auto-calculate", async () => {
-      const countOfSuccessDis = screen.getByRole("textbox", {
-        name: "Count of Successful Discharges to the Community",
-      });
-      await act(async () => await userEvent.type(countOfSuccessDis, "1"));
+      const enterValue = async (fieldId: LengthOfStayField, value: string) => {
+        await userEvent.type(getInput(fieldId), value);
+      };
 
-      const facAdminCount = screen.getByRole("textbox", {
-        name: "Facility Admission Count",
-      });
-      await act(async () => await userEvent.type(facAdminCount, "2"));
+      await enterValue("actualCount", "1");
+      await enterValue("denominator", "2");
+      await enterValue("expectedCount", "1");
+      await enterValue("populationRate", "2");
 
-      const expectedCountOfSuccessDis = screen.getByRole("textbox", {
-        name: "Expected Count of Successful Discharges to the Community",
-      });
-      await act(
-        async () => await userEvent.type(expectedCountOfSuccessDis, "1")
-      );
-
-      const multiPlan = screen.getByRole("textbox", {
-        name: "Multi-Plan Population Rate",
-      });
-      await act(async () => await userEvent.type(multiPlan, "2"));
-
-      //rates
-      const oprMinStay = screen.getByRole("textbox", {
-        name: "Observed Performance Rate for the Minimizing Length of Facility Stay",
-      });
-      expect(oprMinStay).toHaveValue("0.5");
-
-      const eprMinStay = screen.getByRole("textbox", {
-        name: "Expected Performance Rate for the Minimizing Length of Facility Stay",
-      });
-      expect(eprMinStay).toHaveValue("0.5");
-
-      const rarMinStay = screen.getByRole("textbox", {
-        name: "Risk Adjusted Rate for the Minimizing Length of Facility Stay",
-      });
-      expect(rarMinStay).toHaveValue("2");
+      expect(getInput("actualRate")).toHaveValue("0.5");
+      expect(getInput("expectedRate")).toHaveValue("0.5");
+      expect(getInput("adjustedRate")).toHaveValue("2");
     });
   });
 

--- a/services/ui-src/src/components/rates/types/Fields.tsx
+++ b/services/ui-src/src/components/rates/types/Fields.tsx
@@ -1,77 +1,128 @@
 import React, { useEffect, useState } from "react";
-import { PerformanceData, PerformanceRateTemplate } from "types";
-import { Divider, Stack } from "@chakra-ui/react";
+import {
+  ElementType,
+  LengthOfStayField,
+  LengthOfStayRateTemplate,
+} from "types";
+import { Divider, Heading, Stack } from "@chakra-ui/react";
 import { TextField as CmsdsTextField } from "@cmsgov/design-system";
 import { useFormContext } from "react-hook-form";
-import { isNumber } from "../calculations";
+import { FacilityLengthOfStayCalc, parseNumber } from "../calculations";
+import { PageElementProps } from "components/report/Elements";
 
-export const Fields = (
-  props: PerformanceRateTemplate & {
-    formkey: string;
-    year: number;
-    calculation: Function;
-    disabled: boolean;
-  }
-) => {
-  const { answer, fields, calculation, multiplier, disabled } = props;
-  const arr =
-    fields?.map((field) => {
-      return { [field.id]: "" };
-    }) ?? [];
-  const initialValues = Object.assign({}, ...arr);
-  const defaultValue: PerformanceData = (answer as PerformanceData) ?? {
-    rates: [{ performanceTarget: "", ...initialValues }],
+export const Fields = (props: PageElementProps<LengthOfStayRateTemplate>) => {
+  const { formkey, disabled } = props;
+  const { labels, answer } = props.element;
+
+  const defaultAnswer = {
+    performanceTarget: undefined,
+    actualCount: undefined,
+    denominator: undefined,
+    expectedCount: undefined,
+    populationRate: undefined,
+    actualRate: undefined,
+    expectedRate: undefined,
+    adjustedRate: undefined,
   };
-  const [displayValue, setDisplayValue] =
-    useState<PerformanceData>(defaultValue);
+  const [displayValue, setDisplayValue] = useState<
+    NonNullable<LengthOfStayRateTemplate["answer"]>
+  >(answer ?? defaultAnswer);
 
-  // get form context and register field
+  // Get form context and register field
   const form = useFormContext();
-  const key = `${props.formkey}.answer`;
+  const key = `${formkey}.answer`;
   useEffect(() => {
     form.register(key, { required: true });
-    form.setValue(key, defaultValue);
+    form.setValue(key, defaultAnswer);
   }, []);
 
   const onChangeHandler = (event: React.ChangeEvent<HTMLInputElement>) => {
-    if (!isNumber(event.target.value)) return;
-
     const { name, value } = event.target;
-    const [index, type] = name.split(".");
-    const newDisplayValue = displayValue.rates[Number(index)];
-    newDisplayValue[type] = value ?? undefined;
+    const parsedValue = parseNumber(value);
 
-    const calculatedRate = calculation(newDisplayValue, multiplier);
+    if (parsedValue === undefined) return;
 
-    displayValue.rates[Number(index)] = calculatedRate;
-    setDisplayValue({ ...displayValue });
+    const calculatedRate = FacilityLengthOfStayCalc({
+      ...displayValue,
+      [name as LengthOfStayField]: parsedValue,
+    });
+
+    setDisplayValue(calculatedRate);
+
     form.setValue(`${key}`, displayValue, { shouldValidate: true });
-    form.setValue(`${key}.type`, props.type);
+    form.setValue(`${key}.type`, ElementType.LengthOfStayRate);
   };
 
   return (
-    <Stack gap="2rem">
-      <CmsdsTextField
-        label={`What is the ${
-          props.year + 2
-        } state performance target for this assessment?`}
-        name={`0.performanceTarget`}
-        onChange={onChangeHandler}
-        value={displayValue.rates[0].performanceTarget ?? ""}
-        disabled={disabled}
-      ></CmsdsTextField>
-      {fields?.map((field) => {
-        return (
-          <CmsdsTextField
-            label={field.label}
-            name={`0.${field.id}`}
-            onChange={onChangeHandler}
-            value={displayValue.rates[0][field.id] ?? ""}
-            disabled={field.autoCalc || disabled}
-          ></CmsdsTextField>
-        );
-      })}
-      <Divider></Divider>
+    <Stack gap={4} sx={sx.performance}>
+      <Heading variant="subHeader">Performance Rates</Heading>
+      <Stack gap="2rem">
+        <CmsdsTextField
+          label={labels.performanceTarget}
+          name="performanceTarget"
+          onChange={onChangeHandler}
+          value={displayValue.performanceTarget ?? ""}
+          disabled={disabled}
+        ></CmsdsTextField>
+        <CmsdsTextField
+          label={labels.actualCount}
+          name="actualCount"
+          onChange={onChangeHandler}
+          value={displayValue.actualCount ?? ""}
+          disabled={disabled}
+        ></CmsdsTextField>
+        <CmsdsTextField
+          label={labels.denominator}
+          name="denominator"
+          onChange={onChangeHandler}
+          value={displayValue.denominator ?? ""}
+          disabled={disabled}
+        ></CmsdsTextField>
+        <CmsdsTextField
+          label={labels.expectedCount}
+          name="expectedCount"
+          onChange={onChangeHandler}
+          value={displayValue.expectedCount ?? ""}
+          disabled={disabled}
+        ></CmsdsTextField>
+        <CmsdsTextField
+          label={labels.populationRate}
+          name="populationRate"
+          onChange={onChangeHandler}
+          value={displayValue.populationRate ?? ""}
+          disabled={disabled}
+        ></CmsdsTextField>
+        <CmsdsTextField
+          label={labels.actualRate}
+          name="actualRate"
+          onChange={onChangeHandler}
+          value={displayValue.actualRate ?? ""}
+          disabled={true}
+        ></CmsdsTextField>
+        <CmsdsTextField
+          label={labels.expectedRate}
+          name="expectedRate"
+          onChange={onChangeHandler}
+          value={displayValue.expectedRate ?? ""}
+          disabled={true}
+        ></CmsdsTextField>
+        <CmsdsTextField
+          label={labels.adjustedRate}
+          name="adjustedRate"
+          onChange={onChangeHandler}
+          value={displayValue.adjustedRate ?? ""}
+          disabled={true}
+        ></CmsdsTextField>
+        <Divider></Divider>
+      </Stack>
     </Stack>
   );
+};
+
+const sx = {
+  performance: {
+    input: {
+      width: "240px",
+    },
+  },
 };

--- a/services/ui-src/src/components/rates/types/NDR.tsx
+++ b/services/ui-src/src/components/rates/types/NDR.tsx
@@ -10,7 +10,7 @@ export const NDR = (
     formkey: string;
     year: number;
     calculation: Function;
-    disabled: boolean;
+    disabled?: boolean;
   }
 ) => {
   const { label, assessments, answer, multiplier, calculation, disabled } =

--- a/services/ui-src/src/components/rates/types/NDREnhanced.tsx
+++ b/services/ui-src/src/components/rates/types/NDREnhanced.tsx
@@ -10,7 +10,7 @@ export const NDREnhanced = (
     formkey: string;
     year: number;
     calculation: Function;
-    disabled: boolean;
+    disabled?: boolean;
   }
 ) => {
   const { label, assessments, answer, multiplier, calculation, disabled } =

--- a/services/ui-src/src/components/rates/types/NDRFields.tsx
+++ b/services/ui-src/src/components/rates/types/NDRFields.tsx
@@ -10,7 +10,7 @@ export const NDRFields = (
     formkey: string;
     year: number;
     calculation: Function;
-    disabled: boolean;
+    disabled?: boolean;
   }
 ) => {
   const {

--- a/services/ui-src/src/components/rates/types/index.tsx
+++ b/services/ui-src/src/components/rates/types/index.tsx
@@ -1,4 +1,3 @@
 export { NDR } from "./NDR";
 export { NDREnhanced } from "./NDREnhanced";
 export { NDRFields } from "./NDRFields";
-export { Fields } from "./Fields";

--- a/services/ui-src/src/components/report/Page.tsx
+++ b/services/ui-src/src/components/report/Page.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import { VStack } from "@chakra-ui/react";
 import {
   HeaderElement,
@@ -28,6 +29,7 @@ import {
   TextAreaField,
   TextField,
   StatusAlert,
+  Fields,
 } from "components";
 import { useStore } from "utils";
 import { SubmissionParagraph } from "./SubmissionParagraph";
@@ -40,67 +42,75 @@ export const Page = ({ elements }: Props) => {
   const { userIsEndUser } = useStore().user || {};
   const { report } = useStore();
 
-  const composedElements = elements.map((element, index) => {
-    const props = {
-      key: index,
-      /*
-       * This `any` is currently needed to support element nesting.
-       * None of the PageElement template types include a formkey property...
-       * yet any of them _could_ be given a formkey, if they appear as children
-       * of (for example) a radio button. See RadioField.tsx:formatChoices().
-       */
-      formkey: (element as any).formkey ?? `elements.${index}`,
-      disabled: !userIsEndUser || report?.status === ReportStatus.SUBMITTED,
-    };
+  const buildElement = (element: PageElement, index: number) => {
+    /*
+     * This `as any` cast is currently needed to support element nesting.
+     * None of the PageElement template types include a formkey property...
+     * yet any of them _could_ be given a formkey, if they appear as a child
+     * of (for example) a radio button. See RadioField.tsx:formatChoices().
+     */
+    const formkey = (element as any).formkey ?? `elements.${index}`;
+    const disabled =
+      !userIsEndUser || report?.status === ReportStatus.SUBMITTED;
+
     switch (element.type) {
       case ElementType.Header:
-        return <HeaderElement {...{ ...props, element }} />;
+        return <HeaderElement {...{ formkey, disabled, element }} />;
       case ElementType.SubHeader:
-        return <SubHeaderElement {...{ ...props, element }} />;
+        return <SubHeaderElement {...{ formkey, disabled, element }} />;
       case ElementType.NestedHeading:
-        return <NestedHeadingElement {...{ ...props, element }} />;
+        return <NestedHeadingElement {...{ formkey, disabled, element }} />;
       case ElementType.Paragraph:
-        return <ParagraphElement {...{ ...props, element }} />;
+        return <ParagraphElement {...{ formkey, disabled, element }} />;
       case ElementType.Textbox:
-        return <TextField {...{ ...props, element }} />;
+        return <TextField {...{ formkey, disabled, element }} />;
       case ElementType.TextAreaField:
-        return <TextAreaField {...{ ...props, element }} />;
+        return <TextAreaField {...{ formkey, disabled, element }} />;
       case ElementType.Date:
-        return <DateField {...{ ...props, element }} />;
+        return <DateField {...{ formkey, disabled, element }} />;
       case ElementType.Dropdown:
-        return <DropdownField {...{ ...props, element }} />;
+        return <DropdownField {...{ formkey, disabled, element }} />;
       case ElementType.Accordion:
-        return <AccordionElement {...{ ...props, element }} />;
+        return <AccordionElement {...{ formkey, disabled, element }} />;
       case ElementType.Radio:
-        return <RadioField {...{ ...props, element }} />;
+        return <RadioField {...{ formkey, disabled, element }} />;
       case ElementType.ButtonLink:
-        return <ButtonLinkElement {...{ ...props, element }} />;
+        return <ButtonLinkElement {...{ formkey, disabled, element }} />;
       case ElementType.MeasureTable:
-        return <MeasureTableElement {...{ ...props, element }} />;
+        return <MeasureTableElement {...{ formkey, disabled, element }} />;
       case ElementType.MeasureResultsNavigationTable:
         return (
-          <MeasureResultsNavigationTableElement {...{ ...props, element }} />
+          <MeasureResultsNavigationTableElement
+            {...{ formkey, disabled, element }}
+          />
         );
       case ElementType.StatusTable:
-        return <StatusTableElement {...{ ...props, element }} />;
+        return <StatusTableElement />;
       case ElementType.MeasureDetails:
-        return <MeasureDetailsElement {...{ ...props, element }} />;
+        return <MeasureDetailsElement />;
       case ElementType.MeasureFooter:
-        return <MeasureFooterElement {...{ ...props, element }} />;
+        return <MeasureFooterElement {...{ formkey, disabled, element }} />;
+      case ElementType.LengthOfStayRate:
+        return <Fields {...{ formkey, disabled, element }} />;
       case ElementType.PerformanceRate:
-        return <PerformanceRateElement {...{ ...props, element }} />;
+        return <PerformanceRateElement {...{ formkey, disabled, element }} />;
       case ElementType.StatusAlert:
-        return <StatusAlert {...{ ...props, element }} />;
+        return <StatusAlert {...{ formkey, disabled, element }} />;
       case ElementType.Divider:
-        return <DividerElement {...{ ...props, element }} />;
+        return <DividerElement {...{ formkey, disabled, element }} />;
       case ElementType.SubmissionParagraph:
-        return <SubmissionParagraph {...{ ...props, element }} />;
+        return <SubmissionParagraph />;
       case ElementType.SubHeaderMeasure:
-        return <SubHeaderMeasureElement {...{ ...props, element }} />;
+        return <SubHeaderMeasureElement {...{ formkey, disabled, element }} />;
       default:
         assertExhaustive(element);
         return null;
     }
+  };
+
+  const composedElements = elements.map((element, index) => {
+    const el = buildElement(element, index);
+    return <React.Fragment key={index}>{el}</React.Fragment>;
   });
 
   return (

--- a/services/ui-src/src/components/report/PerformanceRate.tsx
+++ b/services/ui-src/src/components/report/PerformanceRate.tsx
@@ -1,25 +1,23 @@
 import { PageElementProps } from "components/report/Elements";
-import { PerformanceRateTemplate, ReportStatus } from "types";
+import { PerformanceRateTemplate } from "types";
 import * as PerformanceType from "./../rates/types";
 import { Heading, Stack, Text } from "@chakra-ui/react";
 import { useStore } from "utils";
-import * as Calculations from "./../rates/calculations";
+import { NDRCalc } from "components/rates/calculations";
 
 export const PerformanceRateElement = (
   props: PageElementProps<PerformanceRateTemplate>
 ) => {
   const performanceRateProp = props.element;
-  const { rateType, rateCalc, helperText, label } = performanceRateProp;
+  const { rateType, helperText, label } = performanceRateProp;
   const { report } = useStore();
-  const { userIsEndUser } = useStore().user || {};
 
   if (!report?.year) return null;
 
   const PerformanceRate = PerformanceType[rateType];
-  const Calculation = Calculations[rateCalc ?? "NDRCalc"];
   performanceRateProp.multiplier = performanceRateProp.multiplier ?? 1;
 
-  const disabled = !userIsEndUser || report?.status === ReportStatus.SUBMITTED;
+  const disabled = props.disabled;
 
   return (
     <Stack gap={4} sx={sx.performance}>
@@ -30,7 +28,7 @@ export const PerformanceRateElement = (
           formkey: props.formkey,
           year: report.year,
           ...performanceRateProp,
-          calculation: Calculation,
+          calculation: NDRCalc,
           disabled: disabled,
         }}
       ></PerformanceRate>

--- a/services/ui-src/src/types/report.ts
+++ b/services/ui-src/src/types/report.ts
@@ -176,6 +176,7 @@ export enum ElementType {
   StatusTable = "statusTable",
   MeasureDetails = "measureDetails",
   MeasureFooter = "measureFooter",
+  LengthOfStayRate = "lengthOfStay",
   PerformanceRate = "performanceRate",
   StatusAlert = "statusAlert",
   Divider = "divider",
@@ -200,6 +201,7 @@ export type PageElement =
   | StatusTableTemplate
   | MeasureDetailsTemplate
   | MeasureFooterTemplate
+  | LengthOfStayRateTemplate
   | PerformanceRateTemplate
   | StatusAlertTemplate
   | DividerTemplate
@@ -364,6 +366,26 @@ export type MeasureFooterTemplate = {
   clear?: boolean;
 };
 
+const LengthOfStayRateFields = [
+  "performanceTarget",
+  "actualCount",
+  "denominator",
+  "expectedCount",
+  "populationRate",
+  "actualRate",
+  "expectedRate",
+  "adjustedRate",
+] as const;
+export type LengthOfStayField = typeof LengthOfStayRateFields[number];
+
+export type LengthOfStayRateTemplate = {
+  id: string;
+  type: ElementType.LengthOfStayRate;
+  labels: Record<LengthOfStayField, string>;
+  answer?: Record<LengthOfStayField, number | undefined>;
+  required?: boolean;
+};
+
 export type PerformanceData = {
   rates: AnyObject[];
   denominator?: number;
@@ -388,13 +410,11 @@ export type RateSetData = {
 export const enum PerformanceRateType {
   NDR = "NDR",
   NDR_Enhanced = "NDREnhanced",
-  FIELDS = "Fields",
   NDR_FIELDS = "NDRFields",
 }
 
 export const enum RateCalc {
   NDRCalc = "NDRCalc",
-  FacilityLengthOfStayCalc = "FacilityLengthOfStayCalc",
 }
 
 export type PerformanceRateTemplate = {


### PR DESCRIPTION
### Description
Everything we render within a report page has an ElementType. The HeaderElement, the TextFieldElement, the RadioElement. Most of these are very specific, and correspond to a single "thing" on the page. PerformanceRate is an exception in both respects. It is non-specific, in that there are several kinds of PerformanceRate, and each of those renders multiple related inputs to the page.

This PR takes one of the kinds of PerformanceRate, and elevates it to its own ElementType. It still contains multiple inputs (eight of them, in fact), but since they are very tightly related inputs, it is not inappropriate to do so.

TODO Ben: describe the changes in more detail.

### Related ticket(s)
CMDCT-4450

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->


### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary

