### PR TITLE
CMDCT-4679 - Delivery Methods confirmation modal

### DIFF
--- a/services/ui-src/src/components/fields/RadioField.test.tsx
+++ b/services/ui-src/src/components/fields/RadioField.test.tsx
@@ -133,6 +133,9 @@ describe("Radio field hide condition logic", () => {
 });
 
 describe("Radio field click action logic", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
   test("Radio field triggers a report delivery methods change when toggled", async () => {
     const deliveryElement = {
       ...mockRadioElement,
@@ -150,6 +153,58 @@ describe("Radio field click action logic", () => {
       await userEvent.click(radioField!);
     });
     expect(mockChangeDeliveryMethods).toHaveBeenCalled();
+  });
+
+  test("Confirmation modal is shown when delivery method is changed, and clicking yes changes the radio value", async () => {
+    const deliveryElement = {
+      ...mockRadioElement,
+      clickAction: "qmDeliveryMethodChange",
+      answer: "mock-answer",
+    };
+    const deliveryRadio = (
+      <div data-testid="test-radio-list">
+        <RadioField element={deliveryElement} formkey="elements.0" />
+      </div>
+    );
+    render(deliveryRadio);
+    const radioField = screen.getByText("Choice 1");
+    await act(async () => {
+      await userEvent.click(radioField!);
+    });
+    expect(mockChangeDeliveryMethods).toHaveBeenCalledTimes(0);
+
+    const modalYes = screen.getByText("Yes");
+    expect(modalYes).toBeVisible();
+    await act(async () => {
+      await userEvent.click(modalYes!);
+    });
+    expect(mockChangeDeliveryMethods).toHaveBeenCalledTimes(1);
+  });
+
+  test("Confirmation modal is shown when delivery method is changed, and clicking no does not change the radio value", async () => {
+    const deliveryElement = {
+      ...mockRadioElement,
+      clickAction: "qmDeliveryMethodChange",
+      answer: "mock-answer",
+    };
+    const deliveryRadio = (
+      <div data-testid="test-radio-list">
+        <RadioField element={deliveryElement} formkey="elements.0" />
+      </div>
+    );
+    render(deliveryRadio);
+    const radioField = screen.getByText("Choice 1");
+    await act(async () => {
+      await userEvent.click(radioField!);
+    });
+    expect(mockChangeDeliveryMethods).toHaveBeenCalledTimes(0);
+
+    const modalNo = screen.getByText("No");
+    expect(modalNo).toBeVisible();
+    await act(async () => {
+      await userEvent.click(modalNo!);
+    });
+    expect(mockChangeDeliveryMethods).toHaveBeenCalledTimes(0);
   });
 
   test("Radio field triggers a clear action when not reporting.", async () => {

--- a/services/ui-src/src/components/fields/RadioField.tsx
+++ b/services/ui-src/src/components/fields/RadioField.tsx
@@ -188,7 +188,8 @@ export const RadioField = (props: PageElementProps<RadioTemplate>) => {
         onConfirmHandler={modalConfirmHandler}
         content={{
           heading: "Are you sure?",
-          subheading: undefined,
+          subheading:
+            "Warning: Changing this response will clear any data previously entered in the corresponding delivery system measure results sections.",
           actionButtonText: "Yes",
           closeButtonText: "No",
         }}


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
- Added confirmation modal to "Measure Delivery Methods" radio selection
- Added tests for the above


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4679

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Testing link: https://d32vy2hunqr1jq.cloudfront.net/
- Create a new QMS report
- Go to edit LTSS-1 
- Under "Measure Delivery Methods" try changing the radio buttons and verify the following
   - If no radio buttons were selected, can select an option as normal
   - If a radio is already selected, trying to change it will show a modal with a warning
      - Clicking "Yes" confirms and changes the radio value
      - Clicking "No" keeps the current value


### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
