### PR TITLE
[HCBS] Logged out without warning FIX

### DIFF
--- a/services/app-api/package.json
+++ b/services/app-api/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "@aws-sdk/client-dynamodb": "^3.637.0",
     "@aws-sdk/lib-dynamodb": "^3.637.0",
+    "aws-jwt-verify": "5.0.0",
     "dompurify": "^3.1.6",
     "jsdom": "^26.0.0",
     "jwt-decode": "3.1.2",

--- a/services/app-api/types/types.ts
+++ b/services/app-api/types/types.ts
@@ -32,6 +32,7 @@ export interface APIGatewayProxyEvent {
   headers: Record<string, string | undefined>;
   pathParameters: Record<string, string | undefined> | null;
   queryStringParameters: Record<string, string | undefined> | null;
+  requestContext: any;
 }
 
 /**

--- a/services/app-api/yarn.lock
+++ b/services/app-api/yarn.lock
@@ -1747,6 +1747,11 @@ available-typed-arrays@^1.0.7:
   dependencies:
     possible-typed-array-names "^1.0.0"
 
+aws-jwt-verify@5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/aws-jwt-verify/-/aws-jwt-verify-5.0.0.tgz#95a70a59dc8cc6c0e7155a8b6500bab4c82d52bc"
+  integrity sha512-FQM5EYEm7AnVJ3oeTpvBZQm7hYnpI067Em1oopHBs7cCNAcw8Aw8NFbojFjkNXifsOzyYe1ks+bg7Q9fMsTZSA==
+
 aws-sdk-client-mock@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/aws-sdk-client-mock/-/aws-sdk-client-mock-4.0.1.tgz#51e5a877c46ad21a7e51d3b7840006b7255bbd39"


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
Users have reported that their session gets logged out without warning in the middle of clicking around and saving. 
To test this, I noted this occuring before implementing the fix suggested from this PR: [CMDCT-441 Authentication Timeout Fix](https://github.com/Enterprise-CMCS/macpro-mdct-mfp/pull/923). After adding the same updates from that PR, I ensured that I was logged in without being logged out.

In order to apply the changes, the package `aws-jwt-verify` is installed in this PR. 
This PR covers adding the changes that were made in MFP that resolved the authentication timeout issue.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4550

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
This one is hard to test because it's a matter of being logged in for a really long time and noting that it doesn't log you out unexpectedly. Longest time tested was 1.5 hr. Best way to test it is to have it open on the side, save a report, ensure you are not logged out unexpectedly without timeout modal popping up.

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
