### PR TITLE
QMS - UAT - POM: People Participate in the Life of the Community Bug Fix

### DIFF
--- a/services/app-api/forms/2026/qms/measureTemplates.ts
+++ b/services/app-api/forms/2026/qms/measureTemplates.ts
@@ -1283,7 +1283,7 @@ export const measureTemplates: Record<
     ],
   },
   [MeasureTemplateName["MLTSS-POM-2"]]: {
-    id: "MLTSS-POM-1",
+    id: "MLTSS-POM-2",
     title: "POM: People Participate in the Life of the Community (MLTSS)",
     type: PageType.MeasureResults,
     sidebar: false,


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
UAT testing was done and it was found that MLTSS was not loading properly.

This PR covers correcting the id for MLTSS for POM-2, it' previously was mislabeled and was causing funky errors such as it not showing up when you click on that measure - which makes total sense considering the id was wrong.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4273

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
**Deploy Link:** https://d59261nijki1b.cloudfront.net/
1. Login as a state user
2. When creating a report, select yes for POMS
3. Navigate to required measures
4. Select POM: People Participate in the Life of the Community
5. Confirm bugs no longer exist

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
