### PR TITLE
[HCBS] Admin Banner Dates to be the same

### DIFF
--- a/services/app-api/utils/bannerValidation.ts
+++ b/services/app-api/utils/bannerValidation.ts
@@ -17,7 +17,7 @@ const bannerValidateSchema = object().shape({
           message: error.END_DATE_BEFORE_START_DATE,
           test: function (endDateValue) {
             if (typeof endDateValue === "number") {
-              return endDateValue > startDate;
+              return endDateValue >= startDate;
             }
             return true;
           },

--- a/services/app-api/utils/tests/bannerValidation.test.ts
+++ b/services/app-api/utils/tests/bannerValidation.test.ts
@@ -77,14 +77,12 @@ describe("validateBannerPayload for startDate (API)", () => {
     );
   });
 
-  it("should fail when endDate is equal to startDate", async () => {
+  it("should pass when endDate is equal to startDate", async () => {
     const payload = {
       ...basePayload,
       startDate: 11022933, // Jan 1, 1970
       endDate: 11022933, // Jan 1, 1970
     };
-    await expect(validateBannerPayload(payload)).rejects.toThrow(
-      error.END_DATE_BEFORE_START_DATE
-    );
+    await expect(validateBannerPayload(payload)).resolves.toEqual(payload);
   });
 });

--- a/services/ui-src/src/utils/validation/bannerValidation.test.ts
+++ b/services/ui-src/src/utils/validation/bannerValidation.test.ts
@@ -67,6 +67,13 @@ describe("bannerFormValidateSchema (UI Form", () => {
     ).resolves.toEqual(formValues);
   });
 
+  it("should pass when startDate is the same as endDate", async () => {
+    const formValues = createFormValues("01/01/1970", "01/01/1970");
+    await expect(
+      bannerFormValidateSchema.validate(formValues)
+    ).resolves.toEqual(formValues);
+  });
+
   it("should throw an error when startDate is after endDate", async () => {
     const formValues = createFormValues("01/02/1970", "01/01/1970");
     await expect(bannerFormValidateSchema.validate(formValues)).rejects.toThrow(

--- a/services/ui-src/src/utils/validation/bannerValidation.ts
+++ b/services/ui-src/src/utils/validation/bannerValidation.ts
@@ -61,7 +61,7 @@ export const bannerFormValidateSchema = object()
         const endDate = parseMMDDYYYY(endDateString);
 
         if (startDate && endDate) {
-          if (endDate <= startDate) {
+          if (startDate > endDate) {
             return this.createError({
               path: "bannerEndDate.answer",
               message: error.END_DATE_BEFORE_START_DATE,
@@ -90,7 +90,7 @@ const bannerWriteValidateSchema = object().shape({
           message: error.END_DATE_BEFORE_START_DATE,
           test: function (endDateValue) {
             if (typeof endDateValue === "number") {
-              return endDateValue > startDate;
+              return endDateValue >= startDate;
             }
             return true;
           },


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
This ticket fixes the banner dates so that a user can set a banner start date and end date for the same date.

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4698

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
Deploy Link: 
1. Login as adminuser@test.com
2. Click on top right - My account -> Manage Account
3. Click on Banner Editor
4. Fill out to ensure start date and end date does NOT render an error.
5. Upon creating the banner, if you enter today's date, status will be active as shown below:
   | Banner |
   | --- |
   | <img width="600" alt="example of banner dates being the same date" src="https://github.com/user-attachments/assets/fcbb970b-f230-498c-bba0-1fe340d59372" > |

### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [ ] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
