### PR TITLE
in radio modal case qmDeliveryMethodChange, update state again

### DIFF
--- a/services/ui-src/src/components/fields/RadioField.test.tsx
+++ b/services/ui-src/src/components/fields/RadioField.test.tsx
@@ -36,10 +36,12 @@ jest.mock("utils/state/useStore");
 const mockedUseStore = useStore as jest.MockedFunction<typeof useStore>;
 const mockClearMeasure = jest.fn();
 const mockChangeDeliveryMethods = jest.fn();
+const mockSetAnswers = jest.fn();
 mockedUseStore.mockReturnValue({
   currentPageId: "my-id",
   clearMeasure: mockClearMeasure,
   changeDeliveryMethods: mockChangeDeliveryMethods,
+  setAnswers: mockSetAnswers,
 });
 
 const mockRadioElement: RadioTemplate = {
@@ -172,6 +174,7 @@ describe("Radio field click action logic", () => {
       await userEvent.click(radioField!);
     });
     expect(mockChangeDeliveryMethods).toHaveBeenCalledTimes(0);
+    expect(mockSetAnswers).toHaveBeenCalledTimes(0);
 
     const modalYes = screen.getByText("Yes");
     expect(modalYes).toBeVisible();
@@ -179,6 +182,7 @@ describe("Radio field click action logic", () => {
       await userEvent.click(modalYes!);
     });
     expect(mockChangeDeliveryMethods).toHaveBeenCalledTimes(1);
+    expect(mockSetAnswers).toHaveBeenCalledTimes(1);
   });
 
   test("Confirmation modal is shown when delivery method is changed, and clicking no does not change the radio value", async () => {
@@ -198,6 +202,7 @@ describe("Radio field click action logic", () => {
       await userEvent.click(radioField!);
     });
     expect(mockChangeDeliveryMethods).toHaveBeenCalledTimes(0);
+    expect(mockSetAnswers).toHaveBeenCalledTimes(0);
 
     const modalNo = screen.getByText("No");
     expect(modalNo).toBeVisible();
@@ -205,6 +210,7 @@ describe("Radio field click action logic", () => {
       await userEvent.click(modalNo!);
     });
     expect(mockChangeDeliveryMethods).toHaveBeenCalledTimes(0);
+    expect(mockSetAnswers).toHaveBeenCalledTimes(0);
   });
 
   test("Radio field triggers a clear action when not reporting.", async () => {

--- a/services/ui-src/src/components/fields/RadioField.tsx
+++ b/services/ui-src/src/components/fields/RadioField.tsx
@@ -152,6 +152,7 @@ export const RadioField = (props: PageElementProps<RadioTemplate>) => {
         changeDeliveryMethods(currentPageId, value);
         // Update zustand state with latest form values
         setAnswers(form.getValues());
+        autosave();
         return; // after the clear, allow normal setting of this page to occur
     }
   };

--- a/services/ui-src/src/components/fields/RadioField.tsx
+++ b/services/ui-src/src/components/fields/RadioField.tsx
@@ -57,7 +57,8 @@ const hintTextColor = (clickAction: string) => {
 
 export const RadioField = (props: PageElementProps<RadioTemplate>) => {
   const radio = props.element;
-  const { clearMeasure, changeDeliveryMethods, currentPageId } = useStore();
+  const { clearMeasure, changeDeliveryMethods, currentPageId, setAnswers } =
+    useStore();
   const { autosave } = useContext(ReportAutosaveContext);
 
   // get form context and register field
@@ -149,6 +150,8 @@ export const RadioField = (props: PageElementProps<RadioTemplate>) => {
         return;
       case "qmDeliveryMethodChange":
         changeDeliveryMethods(currentPageId, value);
+        // Update zustand state with latest form values
+        setAnswers(form.getValues());
         return; // after the clear, allow normal setting of this page to occur
     }
   };


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
- Calling to update zustand state again with proper data in case of `qmDeliveryMethodChange`
More detail: While `setAnswers()` is already being called on every change inside `ReportPageWrapper.tsx`, because we are showing a modal to the user before we actually make the switch, the `setAnswers()` is being called without any change. Now in these cases we will call `setAnswers()` again from inside `RadioField.tsx` with the 


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4799

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Login: https://d2uf3a1nswxoll.cloudfront.net/
- Navigate to LTSS-1
- For Measure Delivery Methods, select an initial radio selection, and refresh to make sure it saved
- Select a different radio selection, confirm on the modal, then refresh. Make sure the radio selection persists


### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
