### PR TITLE
CMDCT-4741 - add report modal ci updates

### DIFF
--- a/services/ui-src/src/components/modals/AddEditReportModal.test.tsx
+++ b/services/ui-src/src/components/modals/AddEditReportModal.test.tsx
@@ -182,7 +182,7 @@ describe("Test AddEditReportModal types", () => {
   test.each([
     { type: ReportType.QMS, text: "Quality Measure Set Report" },
     { type: ReportType.TACM, text: "TACM Report" },
-    { type: ReportType.CI, text: "CICM Report" },
+    { type: ReportType.CI, text: "Critical Incident Report" },
   ])("$type report type renders a title", ({ type, text }) => {
     render(
       <RouterWrappedComponent>

--- a/services/ui-src/src/components/modals/AddEditReportModal.tsx
+++ b/services/ui-src/src/components/modals/AddEditReportModal.tsx
@@ -21,6 +21,8 @@ export type AddEditReportModalOptions = {
     yearSelect: string;
     shortName: string;
     sampleName: string;
+    topText?: string;
+    yearHelperText?: string;
   };
   reportOptions: Record<string, any>;
   optionsElements: React.ReactNode;
@@ -46,6 +48,8 @@ const buildModalOptions = (
           yearSelect: "",
           shortName: "",
           sampleName: "",
+          topText: "",
+          yearHelperText: "",
         },
         reportOptions: {},
         optionsElements: undefined,
@@ -124,10 +128,7 @@ export const AddEditReportModal = ({
       <FormProvider {...form}>
         <form id="addEditReportModal" onSubmit={form.handleSubmit(onSubmit)}>
           <Flex direction="column" gap="1.5rem">
-            <Text>
-              Answering “Yes” or “No” to the following questions will impact
-              which measure results must be reported.
-            </Text>
+            <Text>{verbiage.topText || ""}</Text>
             <TextField
               element={{
                 type: ElementType.Textbox,
@@ -148,8 +149,7 @@ export const AddEditReportModal = ({
                 options: dropdownYears,
                 answer: selectedReport?.year.toString(),
                 required: true,
-                helperText:
-                  "This is the final year in a multi-year reporting period, used to indicate the endpoint of data collection.  For example, if a report covers the period of 2025 and 2026, the reporting year would be 2026.",
+                helperText: verbiage.yearHelperText || "",
               }}
               disabled={!!selectedReport}
               formkey={"year"}

--- a/services/ui-src/src/components/modals/AddEditReportModal.tsx
+++ b/services/ui-src/src/components/modals/AddEditReportModal.tsx
@@ -127,14 +127,14 @@ export const AddEditReportModal = ({
     >
       <FormProvider {...form}>
         <form id="addEditReportModal" onSubmit={form.handleSubmit(onSubmit)}>
-          <Flex direction="column" gap="1.5rem">
-            <Text>{verbiage.topText || ""}</Text>
+          <Flex direction="column" gap="2rem">
+            {verbiage.topText && <Text>{verbiage.topText}</Text>}
             <TextField
               element={{
                 type: ElementType.Textbox,
                 id: "",
                 label: `${verbiage.reportName} Name`,
-                helperText: `Name the ${verbiage.shortName} report so you can easily refer to it. Consider using timeframe(s). Sample Report Name: ${activeState} ${verbiage.sampleName}`,
+                helperText: `Name the ${verbiage.shortName} report so you can easily refer to it. Consider using timeframe(s). Sample Report Name: "${activeState} ${verbiage.sampleName}"`,
                 answer: selectedReport?.name,
                 required: true,
               }}

--- a/services/ui-src/src/components/modals/AddEditReportModal.tsx
+++ b/services/ui-src/src/components/modals/AddEditReportModal.tsx
@@ -134,7 +134,7 @@ export const AddEditReportModal = ({
                 type: ElementType.Textbox,
                 id: "",
                 label: `${verbiage.reportName} Name`,
-                helperText: `Name the ${verbiage.shortName} report so you can easily refer to it. Consider using timeframe(s). Sample Report Name: "${activeState} ${verbiage.sampleName}"`,
+                helperText: `Name this ${verbiage.shortName} report so you can easily refer to it. Consider using timeframe(s). Sample Report Name: "${activeState} ${verbiage.sampleName}"`,
                 answer: selectedReport?.name,
                 required: true,
               }}

--- a/services/ui-src/src/components/modals/AddFormOptions/CiOptions.tsx
+++ b/services/ui-src/src/components/modals/AddFormOptions/CiOptions.tsx
@@ -1,10 +1,10 @@
 import { AddEditReportModalOptions } from "../AddEditReportModal";
 
 const verbiage = {
-  reportName: "CICM Report",
-  yearSelect: "Select the CICM measurement year.",
-  shortName: "CICM",
-  sampleName: "HCBS CICM Measurement Year 2026",
+  reportName: "Critical Incident Report",
+  yearSelect: "Select the critical incident reporting year",
+  shortName: "CI",
+  sampleName: "HCBS CI Report for 2026",
 };
 
 export const CiOptions = (): AddEditReportModalOptions => ({

--- a/services/ui-src/src/components/modals/AddFormOptions/QmsOptions.tsx
+++ b/services/ui-src/src/components/modals/AddFormOptions/QmsOptions.tsx
@@ -7,6 +7,10 @@ const verbiage = {
   yearSelect: "Select the quality measure set reporting year.",
   shortName: "QMS",
   sampleName: "HCBS QMS Report for 2026",
+  topText:
+    "Answering “Yes” or “No” to the following questions will impact which measure results must be reported.",
+  yearHelperText:
+    "This is the final year in a multi-year reporting period, used to indicate the endpoint of data collection.  For example, if a report covers the period of 2025 and 2026, the reporting year would be 2026.",
 };
 
 const parseReportOptions = (selectedReport: Report | undefined) => {


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
- Modified `AddEditReportModal.tsx` to be able to provide variable `topText` and `yearHelperText` per report (currently only the QMS report needs them
- Modified the CI report verbiage


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4741

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Login: https://dvsfspmlgpvt9.cloudfront.net/
- Click "Enter CI Report online" -> "Start Critical Incident Report"
- Verify that the verbiage matches the story
- Go through the same flow for QMS and verify all the verbiage there is the same as to what it is today


### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
