### PR TITLE
[HCBS] Component Inventory Page - RETRY

### DIFF
--- a/services/ui-src/src/components/app/AppRoutes.tsx
+++ b/services/ui-src/src/components/app/AppRoutes.tsx
@@ -9,6 +9,7 @@ import {
   AdminBannerProvider,
   ExportedReportPage,
   ReportPageWrapper,
+  ComponentInventory,
 } from "components";
 import { useStore } from "utils";
 import { useEffect } from "react";
@@ -56,6 +57,11 @@ export const AppRoutes = () => {
             <Route
               path="/report/:reportType/:state/:reportId/:pageId?"
               element={<ReportPageWrapper />}
+            />
+            {/* Add feature flag for component inventory */}
+            <Route
+              path="/component-inventory"
+              element={<ComponentInventory />}
             />
             {/* TO DO: Load pageId by default? */}
           </Routes>

--- a/services/ui-src/src/components/component-inventory/ComponentInventory.tsx
+++ b/services/ui-src/src/components/component-inventory/ComponentInventory.tsx
@@ -25,6 +25,11 @@ export const ComponentInventory = () => {
       <div
         style={{
           margin: "20px",
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "flex-start",
+          borderBottom: "2px solid #ddd",
+          paddingBottom: "20px",
         }}
       >
         <Heading as="h2" variant="h2">
@@ -35,22 +40,36 @@ export const ComponentInventory = () => {
         ) : (
           <>
             <p>{componentExample.description}</p>
-            {componentExample.variants.map((variant) => (
-              <div
-                style={{
-                  border: "1px solid black",
-                  padding: "10px",
-                  margin: "20px",
-                }}
-              >
-                {variant}
-              </div>
-            ))}
+            <div
+              style={{
+                display: "flex",
+                flexWrap: "wrap",
+                gap: "20px",
+                marginTop: "20px",
+              }}
+            >
+              {componentExample.variants.map((variant, index) => (
+                <div
+                  key={index}
+                  style={{
+                    border: "1px solid #ccc",
+                    padding: "15px",
+                    borderRadius: "8px",
+                    boxShadow: "0 4px 8px #0000001a",
+                    minWidth: "300px",
+                    backgroundColor: "#fff",
+                  }}
+                >
+                  {variant}
+                </div>
+              ))}
+            </div>
           </>
         )}
       </div>
     );
   };
+
   return (
     <FormProvider {...methods}>
       <Heading as="h1" variant="h1" style={{ margin: "15px" }}>
@@ -61,11 +80,13 @@ export const ComponentInventory = () => {
         components used in the application, along with examples of how to use
         them.
       </p>
-      <Divider />
+      <Divider style={{ margin: "20px 0" }} />
       {/* Display all ElementType enum possibilities, even if not in elementObject */}
-      {Object.values(ElementType).map((type) => {
-        return buildComponentDisplay(type);
-      })}
+      <div style={{ display: "flex", flexDirection: "column" }}>
+        {Object.values(ElementType).map((type) => {
+          return buildComponentDisplay(type);
+        })}
+      </div>
     </FormProvider>
   );
 };

--- a/services/ui-src/src/components/component-inventory/ComponentInventory.tsx
+++ b/services/ui-src/src/components/component-inventory/ComponentInventory.tsx
@@ -1,0 +1,71 @@
+import { Divider, Heading } from "@chakra-ui/react";
+import { ReactNode } from "react";
+import { FormProvider, useForm } from "react-hook-form";
+import { elementObject } from "./elementObject";
+import { ElementType } from "types";
+
+export const ComponentInventory = () => {
+  const methods = useForm({});
+  /**
+   * TODO:
+   * Add more elements to the inventory as needed
+   * Style the inventory page
+   * Consider adding a search or filter functionality
+   * Leave space for PDF view with a construction cone 🏗️ emoji for in progress status
+   *  <PDFViewPlaceholder />
+   */
+
+  const buildComponentDisplay = (type: ElementType) => {
+    const componentExample = elementObject[type] as {
+      description: string;
+      variants: ReactNode[];
+    };
+
+    return (
+      <div
+        style={{
+          margin: "20px",
+        }}
+      >
+        <Heading as="h2" variant="h2">
+          {type}
+        </Heading>
+        {!componentExample ? (
+          <p>No example available for this component.</p>
+        ) : (
+          <>
+            <p>{componentExample.description}</p>
+            {componentExample.variants.map((variant) => (
+              <div
+                style={{
+                  border: "1px solid black",
+                  padding: "10px",
+                  margin: "20px",
+                }}
+              >
+                {variant}
+              </div>
+            ))}
+          </>
+        )}
+      </div>
+    );
+  };
+  return (
+    <FormProvider {...methods}>
+      <Heading as="h1" variant="h1" style={{ margin: "15px" }}>
+        Component Inventory
+      </Heading>
+      <p style={{ margin: "15px" }}>
+        This page is a work in progress. It will eventually contain all the
+        components used in the application, along with examples of how to use
+        them.
+      </p>
+      <Divider />
+      {/* Display all ElementType enum possibilities, even if not in elementObject */}
+      {Object.values(ElementType).map((type) => {
+        return buildComponentDisplay(type);
+      })}
+    </FormProvider>
+  );
+};

--- a/services/ui-src/src/components/component-inventory/elementObject.tsx
+++ b/services/ui-src/src/components/component-inventory/elementObject.tsx
@@ -1,0 +1,237 @@
+import { Accordion } from "@chakra-ui/react";
+import {
+  DateField,
+  DropdownField,
+  RadioField,
+  TextAreaField,
+  TextField,
+} from "components/fields";
+import { AccordionItem } from "components";
+
+import {
+  ButtonLinkElement,
+  DividerElement,
+  HeaderElement,
+  NestedHeadingElement,
+  ParagraphElement,
+  SubHeaderElement,
+  SubHeaderMeasureElement,
+} from "components/report/Elements";
+import { ElementType, HeaderIcon, NumberFieldTemplate } from "types";
+import { ReactNode } from "react";
+
+export const elementObject: {
+  [key: string]: {
+    description: string;
+    variants: ReactNode[];
+  };
+} = {
+  [ElementType.Header]: {
+    description: "Big text at the top of the page",
+    variants: [
+      <HeaderElement
+        formkey="5412"
+        element={{
+          type: ElementType.Header,
+          id: "id-header",
+          text: "HeaderElement",
+        }}
+      />,
+      <HeaderElement
+        formkey="5413"
+        element={{
+          type: ElementType.Header,
+          id: "id-header-with-icon",
+          text: "HeaderElement with Icon",
+          icon: HeaderIcon.Check,
+        }}
+      />,
+    ],
+  },
+  [ElementType.SubHeader]: {
+    description: "This is a subheader",
+    variants: [
+      <SubHeaderElement
+        formkey="5414"
+        element={{
+          type: ElementType.SubHeader,
+          id: "id-subheader",
+          text: "SubHeaderElement",
+        }}
+      />,
+    ],
+  },
+  [ElementType.NestedHeading]: {
+    description: "This is a nested heading",
+    variants: [
+      <NestedHeadingElement
+        formkey="5415"
+        element={{
+          type: ElementType.NestedHeading,
+          id: "id-nestedheading",
+          text: "NestedHeadingElement",
+        }}
+      />,
+    ],
+  },
+  [ElementType.Textbox]: {
+    description: "A field for entering text",
+    variants: [
+      <TextField
+        formkey="5416"
+        element={{
+          type: ElementType.Textbox,
+          id: "id-textfield",
+          label: "TextField",
+        }}
+      />,
+    ],
+  },
+  [ElementType.TextAreaField]: {
+    description: "A field for entering text",
+    variants: [
+      <TextAreaField
+        formkey="5417"
+        element={{
+          type: ElementType.TextAreaField,
+          id: "id-textareafield",
+          label: "TextAreaField",
+        }}
+      />,
+    ],
+  },
+  [ElementType.Paragraph]: {
+    description: "A paragraph of text for content.",
+    variants: [
+      <ParagraphElement
+        formkey="5418"
+        element={{
+          type: ElementType.Paragraph,
+          id: "id-paragraph",
+          text: "Useful for explanations or instructions.. lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.",
+        }}
+      />,
+    ],
+  },
+  [ElementType.Divider]: {
+    description: "A horizontal line to separate content",
+    variants: [
+      <DividerElement
+        element={{
+          type: ElementType.NestedHeading,
+          id: "",
+          text: "",
+        }}
+        formkey={""}
+      />,
+    ],
+  },
+  [ElementType.Accordion]: {
+    description: "A collapsible section for content",
+    variants: [
+      <Accordion allowToggle={true}>
+        <AccordionItem label="Accordion Item 1">
+          I am the content of the first accordion item.
+        </AccordionItem>
+        <AccordionItem label="Accordion Item 2">
+          I am the content of the second accordion item.
+        </AccordionItem>
+        <AccordionItem label="Accordion Item 3">
+          I am the content of the third accordion item.
+        </AccordionItem>
+      </Accordion>,
+    ],
+  },
+  [ElementType.Dropdown]: {
+    description: "A dropdown field for selecting options",
+    variants: [
+      <DropdownField
+        formkey="5419"
+        element={{
+          type: ElementType.Dropdown,
+          id: "id-dropdown",
+          label: "DropdownField",
+          options: [
+            { value: "Option 1", label: "Option 1" },
+            { value: "Option 2", label: "Option 2" },
+            { value: "Option 3", label: "Option 3" },
+          ],
+        }}
+      />,
+    ],
+  },
+  [ElementType.Radio]: {
+    description: "A radio button field for selecting one option",
+    variants: [
+      <RadioField
+        formkey="5420"
+        element={{
+          type: ElementType.Radio,
+          id: "id-radio",
+          label: "RadioField",
+          choices: [
+            { value: "Option 1", label: "Option 1" },
+            { value: "Option 2", label: "Option 2" },
+            { value: "Option 3", label: "Option 3" },
+          ],
+        }}
+      />,
+    ],
+  },
+  [ElementType.ButtonLink]: {
+    description: "A button that acts as a link",
+    variants: [
+      <ButtonLinkElement
+        formkey="5421"
+        element={{
+          type: ElementType.ButtonLink,
+          id: "id-buttonlink",
+          label: "ButtonLinkElement",
+          to: "why-is-this-undefined-three-times",
+        }}
+      />,
+    ],
+  },
+  [ElementType.Date]: {
+    description: "A field for selecting a date",
+    variants: [
+      <DateField
+        formkey="5422"
+        element={{
+          type: ElementType.Date,
+          id: "id-date-field",
+          label: "DateField",
+          helperText: "DateFieldElement is used to select a date.",
+        }}
+      />,
+    ],
+  },
+  ["SubHeaderMeasure"]: {
+    description: "A subheader for measures",
+    variants: [
+      <SubHeaderMeasureElement
+        formkey="5423"
+        element={{
+          type: ElementType.SubHeader,
+          id: "id-subheader",
+          text: "SubHeaderElement",
+        }}
+      />,
+    ],
+  },
+  [ElementType.NumberField]: {
+    description: "A field for entering numbers",
+    variants: [
+      <TextField
+        formkey="5424"
+        element={
+          {
+            type: ElementType.NumberField,
+            id: "id-number-field",
+            label: "Enter a number",
+          } as NumberFieldTemplate
+        }
+      />,
+    ],
+  },
+};

--- a/services/ui-src/src/components/component-inventory/elementObject.tsx
+++ b/services/ui-src/src/components/component-inventory/elementObject.tsx
@@ -9,7 +9,6 @@ import {
 import { AccordionItem } from "components";
 
 import {
-  ButtonLinkElement,
   DividerElement,
   HeaderElement,
   NestedHeadingElement,
@@ -117,12 +116,11 @@ export const elementObject: {
     description: "A horizontal line to separate content",
     variants: [
       <DividerElement
+        formkey="5419"
         element={{
-          type: ElementType.NestedHeading,
-          id: "",
-          text: "",
+          type: ElementType.Divider,
+          id: "id-divider",
         }}
-        formkey={""}
       />,
     ],
   },
@@ -146,15 +144,15 @@ export const elementObject: {
     description: "A dropdown field for selecting options",
     variants: [
       <DropdownField
-        formkey="5419"
+        formkey="5420"
         element={{
           type: ElementType.Dropdown,
           id: "id-dropdown",
           label: "DropdownField",
           options: [
-            { value: "Option 1", label: "Option 1" },
-            { value: "Option 2", label: "Option 2" },
-            { value: "Option 3", label: "Option 3" },
+            { value: "dropdown option 1", label: "dropdown option 1" },
+            { value: "dropdown option 2", label: "dropdown option 2" },
+            { value: "dropdown option 3", label: "dropdown option 3" },
           ],
         }}
       />,
@@ -164,30 +162,16 @@ export const elementObject: {
     description: "A radio button field for selecting one option",
     variants: [
       <RadioField
-        formkey="5420"
+        formkey="5421"
         element={{
           type: ElementType.Radio,
           id: "id-radio",
           label: "RadioField",
           choices: [
-            { value: "Option 1", label: "Option 1" },
-            { value: "Option 2", label: "Option 2" },
-            { value: "Option 3", label: "Option 3" },
+            { value: "radio option 1", label: "radio option 1" },
+            { value: "radio option 2", label: "radio option 2" },
+            { value: "radio option 3", label: "radio option 3" },
           ],
-        }}
-      />,
-    ],
-  },
-  [ElementType.ButtonLink]: {
-    description: "A button that acts as a link",
-    variants: [
-      <ButtonLinkElement
-        formkey="5421"
-        element={{
-          type: ElementType.ButtonLink,
-          id: "id-buttonlink",
-          label: "ButtonLinkElement",
-          to: "why-is-this-undefined-three-times",
         }}
       />,
     ],
@@ -196,7 +180,7 @@ export const elementObject: {
     description: "A field for selecting a date",
     variants: [
       <DateField
-        formkey="5422"
+        formkey="5423"
         element={{
           type: ElementType.Date,
           id: "id-date-field",
@@ -210,7 +194,7 @@ export const elementObject: {
     description: "A subheader for measures",
     variants: [
       <SubHeaderMeasureElement
-        formkey="5423"
+        formkey="5424"
         element={{
           type: ElementType.SubHeader,
           id: "id-subheader",
@@ -223,15 +207,29 @@ export const elementObject: {
     description: "A field for entering numbers",
     variants: [
       <TextField
-        formkey="5424"
+        formkey="5425"
         element={
           {
             type: ElementType.NumberField,
             id: "id-number-field",
             label: "Enter a number",
+            helperText: "Helper text is optional",
+          } as NumberFieldTemplate
+        }
+      />,
+      <TextField
+        formkey="5426"
+        element={
+          {
+            type: ElementType.NumberField,
+            id: "id-number-field-required",
+            label: "NumberField with required validation",
+            helperText: "This field is required.",
+            required: true,
           } as NumberFieldTemplate
         }
       />,
     ],
   },
+  // ButtonLinkElement needs ReportType, state, and reportId
 };

--- a/services/ui-src/src/components/fields/index.tsx
+++ b/services/ui-src/src/components/fields/index.tsx
@@ -1,0 +1,5 @@
+export { DateField } from "./DateField";
+export { DropdownField } from "./DropdownField";
+export { RadioField } from "./RadioField";
+export { TextField } from "./TextField";
+export { TextAreaField } from "./TextAreaField";

--- a/services/ui-src/src/components/index.ts
+++ b/services/ui-src/src/components/index.ts
@@ -27,6 +27,8 @@ export { QmsIntroductionCard } from "./cards/QmsIntroductionCard";
 export { TacmIntroductionCard } from "./cards/TacmIntroductionCard";
 export { CiIntroductionCard } from "./cards/CiIntroductionCard";
 export { ReportIntroCardActions } from "./cards/ReportIntroCardActions";
+// component inventory
+export { ComponentInventory } from "./component-inventory/ComponentInventory";
 // export
 export { ExportedReportBanner } from "./export/ExportedReportBanner";
 export { ExportedReportWrapper } from "./export/ExportedReportWrapper";


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->

This is a very rough draft for the spike for creating a component inventory page. 
Many of the elements depending on report details would require more in depth work.
This lists out the most basic components while showing a "No example available for this component." message for the ones not yet available.

### Related ticket(s)
CMDCT-4667
New Branch created for new PR - [last one](https://github.com/Enterprise-CMCS/macpro-mdct-hcbs/pull/314) was failing.

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
**Deploy Link:** https://d1gzyt2auyfbet.cloudfront.net/

1. Login in as stateuser@test.com
2. Go to url at top and add "/component-inventory" to view this page

Note: Next step would be adding a feature-flag and maybe a button to click to go to this view

<img width="871" height="732"  alt="picture of component inventory page" src="https://github.com/user-attachments/assets/18a86cbc-b52c-40f0-b967-44309e6a15f4" />
