### PR TITLE
Prevent no-op "updates" from resetting measure status

### DIFF
--- a/services/ui-src/src/utils/state/reportLogic/reportActions.test.ts
+++ b/services/ui-src/src/utils/state/reportLogic/reportActions.test.ts
@@ -22,6 +22,8 @@ import {
   saveReport,
   markPageComplete,
   changeDeliveryMethods,
+  deepEquals,
+  deepMerge,
 } from "./reportActions";
 import {
   mock2MeasureTemplate,
@@ -99,143 +101,240 @@ const testReport: Report = {
   ],
 };
 
-describe("state/management/reportState: buildState", () => {
-  test("initializes relevant parts of the state", () => {
-    const result = buildState(testReport, false);
-    expect(result.pageMap!.size).toEqual(6);
-    expect(result.report).not.toBeUndefined();
-    expect(result.rootPage).not.toBeUndefined();
-    expect(result.parentPage?.parent).toEqual("root");
-    expect(result.currentPageId).toEqual("general-info");
-  });
-
-  test("returns early when no report provided", () => {
-    const result = buildState(undefined, false);
-    expect(result.report).toBeUndefined();
-  });
-});
-
-describe("state/management/reportState: setPage", () => {
-  test("updates the page info", () => {
-    const state = buildState(testReport, false) as HcbsReportState;
-    const result = setPage("req-measure-result", state);
-    expect(result.currentPageId).toEqual("req-measure-result");
-  });
-});
-
-describe("state/management/reportState: mergeAnswers", () => {
-  test("Adds answers to a question", () => {
-    // Jest is garbage
-    global.structuredClone = (val: unknown) => {
-      return JSON.parse(JSON.stringify(val));
-    };
-
-    const state = buildState(testReport, false) as HcbsReportState;
-
-    const answers = { elements: [null, { answer: "ANSWERED" }] };
-    const result = mergeAnswers(answers, state);
-
-    const page = result?.report?.pages[1] as FormPageTemplate;
-    const elements = page?.elements!;
-    const question = elements[1] as TextboxTemplate;
-    expect(page.status).toEqual(PageStatus.IN_PROGRESS);
-    expect(question.answer).toEqual("ANSWERED");
-  });
-});
-
-describe("state/management/reportState: substitute", () => {
-  test("substitute the measure", () => {
-    const response = substitute(testReport, mockMeasureTemplateNotReporting);
-    const measure = response.report.pages[4] as MeasurePageTemplate;
-    expect(measure.required).toBe(false);
-  });
-});
-
-describe("state/management/reportState: resetMeasure", () => {
-  test("reset measure", async () => {
-    global.structuredClone = (val: unknown) => {
-      return JSON.parse(JSON.stringify(val));
-    };
-
-    const state = buildState(testReport, false) as HcbsReportState;
-    const response = resetMeasure("LTSS-1", state);
-    const measure = response!.report!.pages[4] as MeasurePageTemplate;
-    const reportingRadio = measure.elements[0] as RadioTemplate;
-    const question = measure.elements[1] as TextboxTemplate;
-
-    expect(measure.status).toBe(PageStatus.NOT_STARTED);
-    expect(reportingRadio.answer).toBeFalsy();
-    expect(question.answer).toBeFalsy();
-  });
-});
-
-describe("state/management/reportState: clearMeasure", () => {
-  test("clear measure", async () => {
-    global.structuredClone = (val: unknown) => {
-      return JSON.parse(JSON.stringify(val));
-    };
-
-    const state = buildState(testReport, false) as HcbsReportState;
-    const response = clearMeasure("LTSS-1", state, {
-      ["measure-reporting-radio"]: "no",
+describe("reportActions", () => {
+  describe("state/management/reportState: buildState", () => {
+    test("initializes relevant parts of the state", () => {
+      const result = buildState(testReport, false);
+      expect(result.pageMap!.size).toEqual(6);
+      expect(result.report).not.toBeUndefined();
+      expect(result.rootPage).not.toBeUndefined();
+      expect(result.parentPage?.parent).toEqual("root");
+      expect(result.currentPageId).toEqual("general-info");
     });
-    const measure = response!.report!.pages[4] as MeasurePageTemplate;
-    const reportingRadio = measure.elements[0] as RadioTemplate;
-    const question = measure.elements[1] as TextboxTemplate;
 
-    expect(measure.status).toBe(PageStatus.IN_PROGRESS);
-    expect(reportingRadio.answer).toBe("no");
-    expect(question.answer).toBeFalsy();
+    test("returns early when no report provided", () => {
+      const result = buildState(undefined, false);
+      expect(result.report).toBeUndefined();
+    });
   });
-});
 
-describe("state/management/reportState: markPageComplete", () => {
-  test("complete measure", async () => {
-    global.structuredClone = (val: unknown) => {
-      return JSON.parse(JSON.stringify(val));
-    };
-
-    const state = buildState(testReport, false) as HcbsReportState;
-    const response = markPageComplete("LTSS-1", state);
-    const measure = response!.report!.pages[4] as MeasurePageTemplate;
-
-    expect(measure.status).toBe(PageStatus.COMPLETE);
+  describe("state/management/reportState: setPage", () => {
+    test("updates the page info", () => {
+      const state = buildState(testReport, false) as HcbsReportState;
+      const result = setPage("req-measure-result", state);
+      expect(result.currentPageId).toEqual("req-measure-result");
+    });
   });
-});
 
-describe("state/management/reportState: saveReport", () => {
-  test("updates store on success", async () => {
-    const state = buildState(testReport, false) as HcbsReportState;
-    const result = await saveReport(state);
-    expect(result?.lastSavedTime).toBeTruthy();
+  describe("deepEquals", () => {
+    test("Rejects values with different types", () => {
+      const obj1 = { foo: "123" };
+      const obj2 = { foo: 123 };
+      expect(deepEquals(obj1, obj2)).toBe(false);
+      expect(deepEquals(obj2, obj1)).toBe(false);
+    });
+
+    test("Rejects arrays with different lengths", () => {
+      const obj1 = [1, 2, 3];
+      const obj2 = [1, 2];
+      expect(deepEquals(obj1, obj2)).toBe(false);
+      expect(deepEquals(obj2, obj1)).toBe(false);
+    });
+
+    test("Rejects arrays with different contents", () => {
+      const obj1 = ["a", "b", "c"];
+      const obj2 = ["a", "b", "x"];
+      expect(deepEquals(obj1, obj2)).toBe(false);
+      expect(deepEquals(obj2, obj1)).toBe(false);
+    });
+
+    test("Rejects objects with different shapes", () => {
+      const obj1 = { foo: "bar" };
+      const obj2 = { foo: "bar", baz: "quux" };
+      expect(deepEquals(obj1, obj2)).toBe(false);
+      expect(deepEquals(obj2, obj1)).toBe(false);
+    });
+
+    test("Rejects an object and null", () => {
+      // null is a special case because `typeof null === "object"`
+      const obj1 = { foo: "bar" };
+      const obj2 = null;
+      expect(deepEquals(obj1, obj2)).toBe(false);
+      expect(deepEquals(obj2, obj1)).toBe(false);
+    });
+
+    test("Accepts NaN and NaN", () => {
+      // NaN is a special case because `(NaN === NaN) === false`
+      const obj1 = NaN;
+      const obj2 = NaN;
+      expect(deepEquals(obj1, obj2)).toBe(true);
+    });
+
+    test("Accepts normal values", () => {
+      const obj1 = {
+        bool: true,
+        num: 123,
+        obj: { foo: "bar" },
+        str: "hello",
+        nul: null,
+        arr: [1, 2, 3],
+      };
+      const obj2 = deepMerge(obj1, {});
+      expect(deepEquals(obj1, obj2)).toBe(true);
+      expect(deepEquals(obj2, obj1)).toBe(true);
+    });
+
+    test("Accepts weird values", () => {
+      /*
+       * I call these values are "weird" because JSON.stringify mangles them.
+       * That makes testing difficult, since we mock structuredClone with JSON,
+       * and our answer-merging code relies on structuredClone.
+       */
+      const obj1 = {
+        bigint: 456n,
+        undef: undefined,
+        nan: NaN,
+        negz: -0,
+        inf: Infinity,
+        dat: new Date(2025, 8, 1),
+      };
+      const obj2 = {
+        bigint: 456n,
+        undef: undefined,
+        nan: NaN,
+        negz: -0,
+        inf: Infinity,
+        dat: new Date(2025, 8, 1),
+      };
+      expect(deepEquals(obj1, obj2)).toBe(true);
+    });
+
+    test("Rejects really weird values", () => {
+      /*
+       * For symbols and functions, identical definitions yield unequal objects.
+       * That's really weird, you might say.
+       * If we ever embed functions or symbols into report bodies,
+       * we may have to write special-case code to handle these.
+       */
+      expect(deepEquals({ x: Symbol("💿") }, { x: Symbol("💿") })).toBe(false);
+      expect(deepEquals({ x: () => {} }, { x: () => {} })).toBe(false);
+    });
   });
-});
 
-describe("state/management/reportState: changeDeliveryMethods", () => {
-  test("should clear unused methods", async () => {
-    global.structuredClone = (val: unknown) => {
-      return JSON.parse(JSON.stringify(val));
-    };
+  describe("state/management/reportState: mergeAnswers", () => {
+    test("Adds answers to a question", () => {
+      // Jest is garbage
+      global.structuredClone = (val: unknown) => {
+        return JSON.parse(JSON.stringify(val));
+      };
 
-    const state = buildState(testReport, false) as HcbsReportState;
-    const response = changeDeliveryMethods("LTSS-1", "MLTSS", state);
-    const ffs = response.report?.pages.find(
-      (page) => page.id === MeasureTemplateName["FFS-1"]
-    ) as MeasurePageTemplate;
+      const state = buildState(testReport, false) as HcbsReportState;
 
-    expect(ffs!.status).toBe(PageStatus.NOT_STARTED);
+      const answers = { elements: [null, { answer: "ANSWERED" }] };
+      const result = mergeAnswers(answers, state);
+
+      const page = result?.report?.pages[1] as FormPageTemplate;
+      const elements = page?.elements!;
+      const question = elements[1] as TextboxTemplate;
+      expect(page.status).toEqual(PageStatus.IN_PROGRESS);
+      expect(question.answer).toEqual("ANSWERED");
+    });
   });
-  test("should ignore used methods", async () => {
-    global.structuredClone = (val: unknown) => {
-      return JSON.parse(JSON.stringify(val));
-    };
 
-    const state = buildState(testReport, false) as HcbsReportState;
-    const response = changeDeliveryMethods("LTSS-1", "FFS", state);
-    const ffs = response.report?.pages.find(
-      (page) => page.id === MeasureTemplateName["FFS-1"]
-    ) as MeasurePageTemplate;
+  describe("state/management/reportState: substitute", () => {
+    test("substitute the measure", () => {
+      const response = substitute(testReport, mockMeasureTemplateNotReporting);
+      const measure = response.report.pages[4] as MeasurePageTemplate;
+      expect(measure.required).toBe(false);
+    });
+  });
 
-    expect(ffs!.status).toBe(PageStatus.IN_PROGRESS);
+  describe("state/management/reportState: resetMeasure", () => {
+    test("reset measure", async () => {
+      global.structuredClone = (val: unknown) => {
+        return JSON.parse(JSON.stringify(val));
+      };
+
+      const state = buildState(testReport, false) as HcbsReportState;
+      const response = resetMeasure("LTSS-1", state);
+      const measure = response!.report!.pages[4] as MeasurePageTemplate;
+      const reportingRadio = measure.elements[0] as RadioTemplate;
+      const question = measure.elements[1] as TextboxTemplate;
+
+      expect(measure.status).toBe(PageStatus.NOT_STARTED);
+      expect(reportingRadio.answer).toBeFalsy();
+      expect(question.answer).toBeFalsy();
+    });
+  });
+
+  describe("state/management/reportState: clearMeasure", () => {
+    test("clear measure", async () => {
+      global.structuredClone = (val: unknown) => {
+        return JSON.parse(JSON.stringify(val));
+      };
+
+      const state = buildState(testReport, false) as HcbsReportState;
+      const response = clearMeasure("LTSS-1", state, {
+        ["measure-reporting-radio"]: "no",
+      });
+      const measure = response!.report!.pages[4] as MeasurePageTemplate;
+      const reportingRadio = measure.elements[0] as RadioTemplate;
+      const question = measure.elements[1] as TextboxTemplate;
+
+      expect(measure.status).toBe(PageStatus.IN_PROGRESS);
+      expect(reportingRadio.answer).toBe("no");
+      expect(question.answer).toBeFalsy();
+    });
+  });
+
+  describe("state/management/reportState: markPageComplete", () => {
+    test("complete measure", async () => {
+      global.structuredClone = (val: unknown) => {
+        return JSON.parse(JSON.stringify(val));
+      };
+
+      const state = buildState(testReport, false) as HcbsReportState;
+      const response = markPageComplete("LTSS-1", state);
+      const measure = response!.report!.pages[4] as MeasurePageTemplate;
+
+      expect(measure.status).toBe(PageStatus.COMPLETE);
+    });
+  });
+
+  describe("state/management/reportState: saveReport", () => {
+    test("updates store on success", async () => {
+      const state = buildState(testReport, false) as HcbsReportState;
+      const result = await saveReport(state);
+      expect(result?.lastSavedTime).toBeTruthy();
+    });
+  });
+
+  describe("state/management/reportState: changeDeliveryMethods", () => {
+    test("should clear unused methods", async () => {
+      global.structuredClone = (val: unknown) => {
+        return JSON.parse(JSON.stringify(val));
+      };
+
+      const state = buildState(testReport, false) as HcbsReportState;
+      const response = changeDeliveryMethods("LTSS-1", "MLTSS", state);
+      const ffs = response.report?.pages.find(
+        (page) => page.id === MeasureTemplateName["FFS-1"]
+      ) as MeasurePageTemplate;
+
+      expect(ffs!.status).toBe(PageStatus.NOT_STARTED);
+    });
+    test("should ignore used methods", async () => {
+      global.structuredClone = (val: unknown) => {
+        return JSON.parse(JSON.stringify(val));
+      };
+
+      const state = buildState(testReport, false) as HcbsReportState;
+      const response = changeDeliveryMethods("LTSS-1", "FFS", state);
+      const ffs = response.report?.pages.find(
+        (page) => page.id === MeasureTemplateName["FFS-1"]
+      ) as MeasurePageTemplate;
+
+      expect(ffs!.status).toBe(PageStatus.IN_PROGRESS);
+    });
   });
 });

--- a/services/ui-src/src/utils/state/reportLogic/reportActions.ts
+++ b/services/ui-src/src/utils/state/reportLogic/reportActions.ts
@@ -80,6 +80,27 @@ export const deepMerge = (obj1: any, obj2: any) => {
   return clone1;
 };
 
+export const deepEquals = (obj1: any, obj2: any): boolean => {
+  if (typeof obj1 !== typeof obj2) {
+    return false;
+  } else if (Array.isArray(obj1)) {
+    return (
+      obj1.length === obj2.length &&
+      obj1.every((el, i) => deepEquals(el, obj2[i]))
+    );
+  } else if (!!obj1 && !!obj2 && typeof obj1 === "object") {
+    const entries1 = Object.entries(obj1);
+    return (
+      entries1.length === Object.entries(obj2).length &&
+      entries1.every(([key, val]) => deepEquals(val, obj2[key]))
+    );
+  } else if (typeof obj1 === "number" && isNaN(obj1) && isNaN(obj2)) {
+    return true;
+  } else {
+    return obj1 === obj2;
+  }
+};
+
 export const mergeAnswers = (answers: any, state: HcbsReportState) => {
   if (!state.report || !state.currentPageId) {
     return {};
@@ -90,6 +111,11 @@ export const mergeAnswers = (answers: any, state: HcbsReportState) => {
   );
 
   const result = deepMerge(report.pages[pageIndex], answers);
+
+  // If this action didn't change any values, don't dirty the status
+  if (deepEquals(report.pages[pageIndex], result)) {
+    return {};
+  }
 
   // Handle status dirtying
   if ("status" in result) {


### PR DESCRIPTION
### Description
This should address [the issue Rocio noted](https://github.com/Enterprise-CMCS/macpro-mdct-hcbs/pull/321#pullrequestreview-3073369325) on #321. Specifically: tabbing through a completed measure page, without changing any values, puts the measure back into "In Progress" status.

It was caused because several report components call their `onChange` handler on blur. This resulted in a store action, which assumed that the values had changed, and therefore changed the page status.

I still believe that calling onChange within those components is a good idea; it's a really neat way to make sure that the validation/error message is up-to-date without writing any additional code. Which leaves two options: Either make every component's onChange handler smart enough to not call `updateElement` unless its answer has changed, or check for those changes at a higher level.

I chose to check for changes at the higher level, because it removes the possibility that a future component author will forget/neglect to implement their own dirty check, and be bit by this same bug. This may have performance implications; a deep equality check of the entire page may end up being a lot of work to do on every keystroke. On the other hand, it may not. If it does, one option for optimization would be to move that check into Page.tsx. Then, we would only need a deep equality check of the element in question. If that still ends up being too much work, we may need to revisit my decision and implement those checks within the individual onChange handlers.


### Related ticket(s)
N/A

---
### How to test
https://d1lv5kgr2qqxkx.cloudfront.net/

1. Complete a measure. Change an input. Confirm that the measure is no longer completed.
2. Complete the measure again. Tab through it without changing anything, and confirm that the measure is still completed.
3. Repeat steps 1 and 2 for a measure details page. Confirm that the parent measure's status behaves as expected.

### Important updates
n/a

---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- ~[ ] I have updated relevant documentation, if necessary~
