### PR TITLE
CMDCT-4836 - PDF - Filter out Optional Fields/Not Started Optional Measures

### DIFF
--- a/services/app-api/forms/2026/elements.ts
+++ b/services/app-api/forms/2026/elements.ts
@@ -208,6 +208,7 @@ export const additionalNotesField: TextAreaBoxTemplate = {
     controllerElementId: "measure-reporting-radio",
     answer: "no",
   },
+  required: false,
 };
 
 export const measureDeliveryMethodsSubheader = [

--- a/services/app-api/forms/2026/elements.ts
+++ b/services/app-api/forms/2026/elements.ts
@@ -279,6 +279,7 @@ export const whichProgramsWaivers = [
     type: ElementType.TextAreaField,
     id: "measure-programs-text",
     label: "Which programs and waivers are included?",
+    required: false,
     helperText:
       "Please specify all the 1915(c) waivers, 1915(i), (j) and (k) State plan benefits and/or 1115 demonstrations that include HCBS that you are including in this report (or measure). Include the program name and control numbers in your response.",
   } as TextAreaBoxTemplate,

--- a/services/ui-src/src/components/export/ExportedReportWrapper.test.tsx
+++ b/services/ui-src/src/components/export/ExportedReportWrapper.test.tsx
@@ -22,6 +22,14 @@ const elements: PageElement[] = [
     helperText:
       "What is the reporting period Start Date applicable to the measure results?",
   },
+  {
+    type: ElementType.Textbox,
+    id: "",
+    label: "Additional comments",
+    answer: "",
+    required: false,
+    helperText: "Enter any additional comments",
+  },
 ];
 
 const section: FormPageTemplate = {
@@ -36,5 +44,10 @@ describe("ExportedReportWrapper", () => {
   it("ExportedReportWrapper is visible", () => {
     render(<ExportedReportWrapper section={section}></ExportedReportWrapper>);
     expect(screen.getByText("Contact title")).toBeInTheDocument();
+  });
+
+  it("Unanswered optional fields are not rendered", () => {
+    render(<ExportedReportWrapper section={section}></ExportedReportWrapper>);
+    expect(screen.queryByText("Additional comments")).not.toBeInTheDocument();
   });
 });

--- a/services/ui-src/src/components/export/ExportedReportWrapper.tsx
+++ b/services/ui-src/src/components/export/ExportedReportWrapper.tsx
@@ -24,8 +24,20 @@ export const renderReportDisplay = (
 };
 
 export const ExportedReportWrapper = ({ section }: Props) => {
+  // Remove empty elements which are optional
+  const filteredElements = section.elements?.filter((element: any) => {
+    const hasAnswer =
+      Object.prototype.hasOwnProperty.call(element, "answer") &&
+      element.answer !== undefined &&
+      element.answer !== "";
+    if (!hasAnswer && element.required === false) {
+      return false;
+    }
+    return true;
+  });
+
   const elements =
-    section.elements?.map(
+    filteredElements?.map(
       (element: {
         label?: string;
         helperText?: string;

--- a/services/ui-src/src/components/export/ExportedReportWrapper.tsx
+++ b/services/ui-src/src/components/export/ExportedReportWrapper.tsx
@@ -25,13 +25,14 @@ export const renderReportDisplay = (
 
 export const ExportedReportWrapper = ({ section }: Props) => {
   // Remove empty elements which are optional
-  const filteredElements = section.elements?.filter((element: any) => {
+  const filteredElements = section.elements?.filter((element) => {
     const hasAnswer =
-      element.answer && element.answer !== undefined && element.answer !== "";
-    if (!hasAnswer && element.required === false) {
-      return false;
-    }
-    return true;
+      "answer" in element &&
+      element.answer !== undefined &&
+      element.answer !== "";
+    const isRequired = !("required" in element) || element.required === false;
+
+    return hasAnswer || isRequired;
   });
 
   const elements =

--- a/services/ui-src/src/components/export/ExportedReportWrapper.tsx
+++ b/services/ui-src/src/components/export/ExportedReportWrapper.tsx
@@ -24,14 +24,12 @@ export const renderReportDisplay = (
 };
 
 export const ExportedReportWrapper = ({ section }: Props) => {
-  // Remove empty elements which are optional
   const filteredElements = section.elements?.filter((element) => {
     const hasAnswer =
       "answer" in element &&
       element.answer !== undefined &&
       element.answer !== "";
-    const isRequired = !("required" in element) || element.required === false;
-
+    const isRequired = !("required" in element) || element.required !== false;
     return hasAnswer || isRequired;
   });
 

--- a/services/ui-src/src/components/export/ExportedReportWrapper.tsx
+++ b/services/ui-src/src/components/export/ExportedReportWrapper.tsx
@@ -27,9 +27,7 @@ export const ExportedReportWrapper = ({ section }: Props) => {
   // Remove empty elements which are optional
   const filteredElements = section.elements?.filter((element: any) => {
     const hasAnswer =
-      Object.prototype.hasOwnProperty.call(element, "answer") &&
-      element.answer !== undefined &&
-      element.answer !== "";
+      element.answer && element.answer !== undefined && element.answer !== "";
     if (!hasAnswer && element.required === false) {
       return false;
     }

--- a/services/ui-src/src/components/pages/Export/ExportedReportPage.test.tsx
+++ b/services/ui-src/src/components/pages/Export/ExportedReportPage.test.tsx
@@ -1,6 +1,7 @@
 import { screen, render } from "@testing-library/react";
 import { useStore } from "utils";
 import { ExportedReportPage } from "./ExportedReportPage";
+import { PageType, PageStatus } from "types";
 
 jest.mock("utils", () => ({
   ...jest.requireActual("utils"),
@@ -16,6 +17,20 @@ const report = {
     { childPageIds: ["1", "2"] },
     { title: "Section 1", id: "id-1" },
     { title: "Section 2", id: "id-2" },
+    { title: "Section 3", id: "review-submit" },
+    {
+      title: "Section 4",
+      id: "id-4",
+      type: PageType.Measure,
+      required: false,
+      status: PageStatus.NOT_STARTED,
+    },
+    {
+      title: "Section 5",
+      id: "id-5",
+      type: PageType.MeasureResults,
+      status: PageStatus.NOT_STARTED,
+    },
   ],
   lastEdited: 1751987780396,
   lastEditedBy: "last edited",
@@ -40,5 +55,20 @@ describe("ExportedReportPage", () => {
     expect(
       screen.getByText("Colorado Quality Measure Set Report for: mock-title")
     ).toBeInTheDocument();
+  });
+
+  it("Should not render filtered sections", () => {
+    render(<ExportedReportPage></ExportedReportPage>);
+    expect(screen.queryByText("Section 3")).not.toBeInTheDocument();
+  });
+
+  it("Should not render optional measures which are not started", () => {
+    render(<ExportedReportPage></ExportedReportPage>);
+    expect(screen.queryByText("Section 4")).not.toBeInTheDocument();
+  });
+
+  it("Should not render measure results which are not started", () => {
+    render(<ExportedReportPage></ExportedReportPage>);
+    expect(screen.queryByText("Section 5")).not.toBeInTheDocument();
   });
 });

--- a/services/ui-src/src/components/pages/Export/ExportedReportPage.tsx
+++ b/services/ui-src/src/components/pages/Export/ExportedReportPage.tsx
@@ -144,65 +144,46 @@ export const renderReportSections = (
     | ReviewSubmitTemplate
   )[]
 ) => {
-  // recursively render sections
-  const renderSection = (
-    section:
-      | ParentPageTemplate
-      | FormPageTemplate
-      | MeasurePageTemplate
-      | ReviewSubmitTemplate
-  ) => {
+  const shouldRender = (section: typeof reportPages[number]) => {
+    if (
+      section.id === "review-submit" ||
+      section.id === "root" ||
+      section.id === "req-measure-result" ||
+      section.id === "optional-measure-result"
+    ) {
+      return false;
+    }
+
+    if (
+      section.type === PageType.Measure &&
+      (section as MeasurePageTemplate).required === false &&
+      (section as MeasurePageTemplate).status === PageStatus.NOT_STARTED
+    ) {
+      return false;
+    }
+
+    if (
+      section.type === PageType.MeasureResults &&
+      (section as FormPageTemplate).status === PageStatus.NOT_STARTED
+    ) {
+      return false;
+    }
+
+    return true;
+  };
+
+  return reportPages.filter(shouldRender).map((section, idx) => {
     const showHeader =
       section.type != "measure" && section.type != "measureResults";
     return (
-      <Box key={section.id}>
-        {/* if section does not have children and has content to render, render it */}
+      <Box key={`${section.id}.${idx}`}>
         <Flex flexDirection="column">
           {showHeader && <Heading variant="subHeader">{section.title}</Heading>}
           <ExportedReportWrapper section={section} />
         </Flex>
       </Box>
     );
-  };
-
-  return reportPages
-    .filter((section) => {
-      if (
-        section.id === "review-submit" ||
-        section.id === "root" ||
-        section.id === "req-measure-result" ||
-        section.id === "optional-measure-result"
-      ) {
-        return false;
-      }
-
-      if (
-        section.type === PageType.Measure &&
-        (section as MeasurePageTemplate).required === false &&
-        (section as MeasurePageTemplate).status === PageStatus.NOT_STARTED
-      ) {
-        return false;
-      }
-
-      if (
-        section.type === PageType.MeasureResults &&
-        (section as FormPageTemplate).status === PageStatus.NOT_STARTED
-      ) {
-        return false;
-      }
-
-      return true;
-    })
-    .map(
-      (
-        section:
-          | ParentPageTemplate
-          | FormPageTemplate
-          | MeasurePageTemplate
-          | ReviewSubmitTemplate,
-        idx
-      ) => <Box key={`${section.id}.${idx}`}>{renderSection(section)}</Box>
-    );
+  });
 };
 
 export const sx = {

--- a/services/ui-src/src/components/pages/Export/ExportedReportPage.tsx
+++ b/services/ui-src/src/components/pages/Export/ExportedReportPage.tsx
@@ -18,10 +18,12 @@ import {
   FormPageTemplate,
   getReportName,
   MeasurePageTemplate,
+  PageType,
   ParentPageTemplate,
   Report,
   ReportType,
   ReviewSubmitTemplate,
+  PageStatus,
 } from "types";
 import { ExportedReportBanner, ExportedReportWrapper } from "components";
 import { StateNames } from "../../../constants";
@@ -152,7 +154,6 @@ export const renderReportSections = (
   ) => {
     const showHeader =
       section.type != "measure" && section.type != "measureResults";
-
     return (
       <Box key={section.id}>
         {/* if section does not have children and has content to render, render it */}
@@ -165,13 +166,26 @@ export const renderReportSections = (
   };
 
   return reportPages
-    .filter(
-      (section) =>
-        section.id !== "review-submit" &&
-        section.id !== "root" &&
-        section.id != "req-measure-result" &&
-        section.id != "optional-measure-result"
-    )
+    .filter((section) => {
+      // filter sections not part of the report
+      if (
+        section.id === "review-submit" ||
+        section.id === "root" ||
+        section.id === "req-measure-result" ||
+        section.id === "optional-measure-result"
+      ) {
+        return false;
+      }
+      // filter optional measures which are not started
+      if (
+        section.type === PageType.Measure &&
+        (section as MeasurePageTemplate).required === false &&
+        (section as MeasurePageTemplate).status === PageStatus.NOT_STARTED
+      ) {
+        return false;
+      }
+      return true;
+    })
     .map(
       (
         section:

--- a/services/ui-src/src/components/pages/Export/ExportedReportPage.tsx
+++ b/services/ui-src/src/components/pages/Export/ExportedReportPage.tsx
@@ -167,7 +167,6 @@ export const renderReportSections = (
 
   return reportPages
     .filter((section) => {
-      // filter sections not part of the report
       if (
         section.id === "review-submit" ||
         section.id === "root" ||
@@ -176,7 +175,7 @@ export const renderReportSections = (
       ) {
         return false;
       }
-      // filter optional measures which are not started
+
       if (
         section.type === PageType.Measure &&
         (section as MeasurePageTemplate).required === false &&
@@ -184,6 +183,14 @@ export const renderReportSections = (
       ) {
         return false;
       }
+
+      if (
+        section.type === PageType.MeasureResults &&
+        (section as FormPageTemplate).status === PageStatus.NOT_STARTED
+      ) {
+        return false;
+      }
+
       return true;
     })
     .map(


### PR DESCRIPTION
### Description
<!-- Detailed description of changes and related context -->
- PDF view will now filter out empty optional measures, sections, and elements
- Note: There will be a future story that will add the "required: false" to any element thats currently not labeled (and should be false).


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-4836

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
- Login: https://d3e7j0jha4u8as.cloudfront.net/
- Create a new QMS report
- In first required measure LTSS-1 fill out the "Additional notes" textArea, select one of the "Measure Delivery Methods" and fill out a part of the delivery method
- Go back and into the first Optional Measure FASI-1, fill out same things as the point above
- Go to submit page and click to Review PDF.
- Verify that you can only see the Additional Comment that are filled out, measure delivery methods that are started, and optional measures that are started


### Important updates
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Author checklist
<!-- Complete the following steps before opening for review -->

- [x] I have performed a self-review of my code
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
---

<!-- If deploying to val or prod, click 'Preview' and select template -->
_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
