### PR TITLE
[HCBS] pageView firing twice fix

### DIFF
--- a/services/ui-src/src/components/app/App.tsx
+++ b/services/ui-src/src/components/app/App.tsx
@@ -14,7 +14,6 @@ import { Container, Divider, Flex, Heading, Stack } from "@chakra-ui/react";
 import { ErrorBoundary } from "react-error-boundary";
 import {
   fireTealiumPageView,
-  isApparentReportPage,
   makeMediaQueryClasses,
   UserContext,
   useStore,
@@ -31,12 +30,7 @@ export const App = () => {
 
   // fire tealium page view on route change
   useEffect(() => {
-    fireTealiumPageView(
-      user,
-      window.location.href,
-      pathname,
-      isApparentReportPage(pathname)
-    );
+    fireTealiumPageView(user, window.location.href, pathname);
   }, [key]);
 
   const authenticatedRoutes = (

--- a/services/ui-src/src/utils/other/routing.ts
+++ b/services/ui-src/src/utils/other/routing.ts
@@ -1,4 +1,4 @@
-import { LiteReport, MeasurePageTemplate, Report, ReportType } from "types";
+import { LiteReport, MeasurePageTemplate, Report } from "types";
 
 export const reportBasePath = (report: Report | LiteReport) => {
   return `/report/${report.type}/${report.state}/${report.id}`;
@@ -10,25 +10,4 @@ export const measurePrevPage = (report: Report, pageId: string) => {
     (measure) => measure.id === pageId
   ) as MeasurePageTemplate;
   return measure?.required ? "req-measure-result" : "optional-measure-result";
-};
-
-/**
- * WARNING: You probably want ReportContext.isReportPage instead.
- * This function is called from outside the ReportContext,
- * so it can only make a best guess.
- */
-export const isApparentReportPage = (pathname: string): boolean => {
-  const yes = Object.values(ReportType).some((reportType) => {
-    const prefix = `/${reportType.toLowerCase()}/`;
-    /*
-     * Report pages look like "/wp/some-path", or "/sar/some-other-path"
-     * Two exceptions are the Get Started page, and the root (Dashboard) page for that report type.
-     */
-    return (
-      pathname.startsWith(prefix) &&
-      !pathname.startsWith(`/${prefix}/get-started`) &&
-      pathname.length > prefix.length
-    );
-  });
-  return yes;
 };


### PR DESCRIPTION
### Description
During a validation call with BlastX Consulting, it was found that "pageView" was being fired twice. For some reason, it was firing at login before being authenticated and once again upon logging in.

### Related ticket(s)
CMDCT-5066

---

### How to test

1. Checkout branch locally: **hcbs-tea2**
2. Login to HCBS
3. Check Network Tab
4. Copy and paste into the filter to view utag specific network activity: `/utag|digitalgov|interact/`
5. And confirm that interact... only fires once (PageView)
     <img width="1088" height="808" alt="Screenshot 2025-09-19 at 12 22 56 PM" src="https://github.com/user-attachments/assets/9e980159-6b3d-4022-9ecd-637bee7b5333" />