### PR TITLE
CMDCT-5166, CMDCT-4999 -  PCP dashboard and new report modal

### DIFF
--- a/services/ui-src/src/components/modals/AddEditReportModal.test.tsx
+++ b/services/ui-src/src/components/modals/AddEditReportModal.test.tsx
@@ -185,7 +185,7 @@ describe("Test AddEditReportModal types", () => {
     { type: ReportType.QMS, text: "Quality Measure Set Report" },
     { type: ReportType.TACM, text: "TACM Report" },
     { type: ReportType.CI, text: "Critical Incident Report" },
-    { type: ReportType.PCP, text: "Person-Centered Planning" },
+    { type: ReportType.PCP, text: "Person-Centered Planning Report" },
   ])("$type report type renders a title", ({ type, text }) => {
     render(
       <RouterWrappedComponent>

--- a/services/ui-src/src/components/modals/AddFormOptions/PcpOptions.tsx
+++ b/services/ui-src/src/components/modals/AddFormOptions/PcpOptions.tsx
@@ -1,7 +1,7 @@
 export default {
   verbiage: {
-    reportName: "Person-Centered Planning",
-    yearSelect: "Select the person centered planning reporting year",
+    reportName: "Person-Centered Planning Report",
+    yearSelect: "Select the person-centered planning reporting year",
     shortName: "PCP",
     sampleName: "HCBS PCP Report for 2026",
   },

--- a/services/ui-src/src/components/modals/AddFormOptions/TacmOptions.tsx
+++ b/services/ui-src/src/components/modals/AddFormOptions/TacmOptions.tsx
@@ -1,7 +1,7 @@
 export default {
   verbiage: {
     reportName: "TACM Report",
-    yearSelect: "Select the TACM measurement year.",
+    yearSelect: "Select the TACM measurement year",
     shortName: "TACM",
     sampleName: "HCBS TACM Report for 2026",
   },


### PR DESCRIPTION
<!-- This file is managed by macpro-mdct-core so if you'd like to change it let's do it there -->

### Description
- Changed wording to match content doc for PCP new report modal
- Dashboard wording was already correct

<!-- Detailed description of changes and related context -->

### Related ticket(s)

<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->

CMDCT-5166
CMDCT-4999

---

### How to test
- Login: https://d3mpbewmzz7ui8.cloudfront.net/
- Go to PCP report dashboard, verify the wording matches the story CMDCT-5166
- Click to create a new PCP report, verify the wording matches the story CMDCT-4999

<!-- Step-by-step instructions on how to test, if necessary -->

### Notes

<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->

---

### Pre-review checklist

<!-- Complete the following steps before opening for review -->

- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

---

### Pre-merge checklist

<!-- Complete the following steps before merging -->

#### Review

- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security

_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.

---

<!-- If deploying to val or prod, click 'Preview' and select template -->

_convert to a different template: [test → val](?expand=1&template=test-to-val-deployment.md)_ | _[val → prod](?expand=1&template=val-to-prod-deployment.md)_
