### PR TITLE
[HCBS] Add captions to tables

### DIFF
--- a/services/app-api/forms/2026/qms/qms.ts
+++ b/services/app-api/forms/2026/qms/qms.ts
@@ -83,6 +83,7 @@ export const qmsReportTemplate: ReportWithMeasuresTemplate = {
         {
           type: ElementType.MeasureTable,
           id: "required-measures",
+          caption: "Required Measure Results",
           measureDisplay: "required",
         },
       ],
@@ -117,6 +118,7 @@ export const qmsReportTemplate: ReportWithMeasuresTemplate = {
         {
           type: ElementType.MeasureTable,
           id: "optional-measures",
+          caption: "Optional Measure Results",
           measureDisplay: "optional",
         },
       ],

--- a/services/app-api/forms/2026/wwl/wwlElements.ts
+++ b/services/app-api/forms/2026/wwl/wwlElements.ts
@@ -6,6 +6,7 @@ import {
 } from "../../../types/reports";
 
 export const addOtherEligibilityTableVerbiage = {
+  caption: "Other Eligibility",
   fieldLabels: {
     title:
       "What other eligibility requirement does your state use for this waiting list?",

--- a/services/app-api/types/reports.ts
+++ b/services/app-api/types/reports.ts
@@ -628,6 +628,7 @@ export enum MeasureSpecification {
 export type MeasureTableTemplate = {
   id: string;
   type: ElementType.MeasureTable;
+  caption: string;
   measureDisplay: "required" | "optional";
 };
 

--- a/services/app-api/types/reports.ts
+++ b/services/app-api/types/reports.ts
@@ -281,7 +281,7 @@ export type PageElement =
   | RadioTemplate
   | CheckboxTemplate
   | ButtonLinkTemplate
-  | MeasureTableTemplate
+  | MeasureTableTemplateWithCaption
   | MeasureResultsNavigationTableTemplate
   | StatusTableTemplate
   | MeasureDetailsTemplate
@@ -297,6 +297,10 @@ export type PageElement =
   | SubmissionParagraphTemplate
   | EligibilityTableTemplate
   | ListInputTemplate;
+
+export type MeasureTableTemplateWithCaption = MeasureTableTemplate & {
+  caption: string;
+};
 
 export type HideCondition = {
   controllerElementId: string;

--- a/services/app-api/types/reports.ts
+++ b/services/app-api/types/reports.ts
@@ -281,7 +281,7 @@ export type PageElement =
   | RadioTemplate
   | CheckboxTemplate
   | ButtonLinkTemplate
-  | MeasureTableTemplateWithCaption
+  | MeasureTableTemplate
   | MeasureResultsNavigationTableTemplate
   | StatusTableTemplate
   | MeasureDetailsTemplate
@@ -297,10 +297,6 @@ export type PageElement =
   | SubmissionParagraphTemplate
   | EligibilityTableTemplate
   | ListInputTemplate;
-
-export type MeasureTableTemplateWithCaption = MeasureTableTemplate & {
-  caption: string;
-};
 
 export type HideCondition = {
   controllerElementId: string;

--- a/services/app-api/types/reports.ts
+++ b/services/app-api/types/reports.ts
@@ -643,6 +643,7 @@ export type EligibilityTableItem = {
 export type EligibilityTableTemplate = {
   type: ElementType.EligibilityTable;
   id: string;
+  caption: string;
   fieldLabels: {
     title: string;
     description: string;

--- a/services/app-api/utils/reportValidation.ts
+++ b/services/app-api/utils/reportValidation.ts
@@ -274,6 +274,7 @@ const measureTableTemplateSchema = object().shape({
 const eligibilityTableSchema = object().shape({
   type: string().required().matches(new RegExp(ElementType.EligibilityTable)),
   id: string().required(),
+  caption: string().required(),
   fieldLabels: object().shape({
     title: string().required(),
     description: string().required(),

--- a/services/app-api/utils/reportValidation.ts
+++ b/services/app-api/utils/reportValidation.ts
@@ -268,6 +268,7 @@ const measureTableTemplateSchema = object().shape({
   type: string().required().matches(new RegExp(ElementType.MeasureTable)),
   id: string().required(),
   measureDisplay: string().oneOf(["required", "optional"]).required(),
+  caption: string().required(),
 });
 
 const eligibilityTableSchema = object().shape({
@@ -636,6 +637,7 @@ const reportValidateSchema = object().shape({
   year: number().required(),
   submissionCount: number().required(),
   archived: boolean().required(),
+  caption: string().notRequired(),
   options: optionsSchema,
   pages: pagesSchema,
 });

--- a/services/app-api/utils/reportValidation.ts
+++ b/services/app-api/utils/reportValidation.ts
@@ -637,7 +637,6 @@ const reportValidateSchema = object().shape({
   year: number().required(),
   submissionCount: number().required(),
   archived: boolean().required(),
-  caption: string().notRequired(),
   options: optionsSchema,
   pages: pagesSchema,
 });

--- a/services/ui-src/src/components/component-inventory/elementObject.tsx
+++ b/services/ui-src/src/components/component-inventory/elementObject.tsx
@@ -380,6 +380,7 @@ export const elementObject: {
           type: ElementType.MeasureTable,
           id: "id-measure-table",
           measureDisplay: "required",
+          caption: "Required Measure Results",
         }}
       />,
     ],

--- a/services/ui-src/src/components/component-inventory/elementObject.tsx
+++ b/services/ui-src/src/components/component-inventory/elementObject.tsx
@@ -671,6 +671,7 @@ export const elementObject: {
         element={{
           type: ElementType.EligibilityTable,
           id: "id-eligibility-table",
+          caption: "Other Eligibility",
           fieldLabels: {
             title: "title",
             description: "description",

--- a/services/ui-src/src/components/component-inventory/pdfElementSectionHelpers.tsx
+++ b/services/ui-src/src/components/component-inventory/pdfElementSectionHelpers.tsx
@@ -174,6 +174,7 @@ export const EligibilityTableSection: FormPageTemplate = {
     {
       type: ElementType.EligibilityTable,
       id: "add-other-eligibility-table",
+      caption: "Other Eligibility",
       fieldLabels: {
         title: "title",
         description: "description",

--- a/services/ui-src/src/components/export/ExportedReportElements.test.tsx
+++ b/services/ui-src/src/components/export/ExportedReportElements.test.tsx
@@ -36,6 +36,9 @@ const section = {
 };
 
 describe("Test ExportedReportElements", () => {
+  beforeEach(() => {
+    section.elements = [];
+  });
   test("Test render SubHeader element", () => {
     const element = renderElements(section, {
       id: "mock-sub-header",

--- a/services/ui-src/src/components/export/ExportedReportElements.test.tsx
+++ b/services/ui-src/src/components/export/ExportedReportElements.test.tsx
@@ -63,10 +63,10 @@ describe("Test ExportedReportElements", () => {
     const element = renderElements(section, mockNDR);
     render(element);
     expect(
-      screen.getByText(
+      screen.getAllByText(
         "Performance Rate : Person uses the same environments as people without disabilities"
-      )
-    ).toBeInTheDocument();
+      ).length
+    ).toBeGreaterThan(0);
     expect(screen.getByRole("row", { name: "Numerator 5" })).toBeVisible();
     expect(screen.getByRole("row", { name: "Denominator 3" })).toBeVisible();
     expect(screen.getByRole("row", { name: /Rate .* 1\.67/ })).toBeVisible();
@@ -76,10 +76,12 @@ describe("Test ExportedReportElements", () => {
     const element = renderElements(section, mockedNDREnhanced);
     render(element);
 
-    expect(screen.getByText("test label: assessment 1")).toBeInTheDocument();
     expect(
-      screen.getByText("Performance Rates Denominator")
-    ).toBeInTheDocument();
+      screen.getAllByText("test label: assessment 1").length
+    ).toBeGreaterThan(0);
+    expect(
+      screen.getAllByText("Performance Rates Denominator").length
+    ).toBeGreaterThan(0);
     expect(screen.getAllByText("2")).toHaveLength(2);
     expect(screen.getAllByText("Not answered")).toHaveLength(1);
   });

--- a/services/ui-src/src/components/export/ExportedReportElements.test.tsx
+++ b/services/ui-src/src/components/export/ExportedReportElements.test.tsx
@@ -66,7 +66,7 @@ describe("Test ExportedReportElements", () => {
       screen.getAllByText(
         "Performance Rate : Person uses the same environments as people without disabilities"
       ).length
-    ).toBeGreaterThan(0);
+    ).toBe(2);
     expect(screen.getByRole("row", { name: "Numerator 5" })).toBeVisible();
     expect(screen.getByRole("row", { name: "Denominator 3" })).toBeVisible();
     expect(screen.getByRole("row", { name: /Rate .* 1\.67/ })).toBeVisible();

--- a/services/ui-src/src/components/export/ExportedReportElements.tsx
+++ b/services/ui-src/src/components/export/ExportedReportElements.tsx
@@ -63,11 +63,11 @@ export const renderElements = (
     case ElementType.ReadmissionRate:
       return ReadmissionRateExport(element);
     case ElementType.NdrBasic:
-      return NDRBasicExport(element);
+      return NDRBasicExport(element, section.title);
     case ElementType.MeasureDetails:
       return MeasureDetailsExport(section);
     case ElementType.EligibilityTable:
-      return EligibilityTableElementExport(element);
+      return EligibilityTableElementExport(element, section.title);
   }
 
   if (!("answer" in element)) {

--- a/services/ui-src/src/components/export/ExportedReportTable.tsx
+++ b/services/ui-src/src/components/export/ExportedReportTable.tsx
@@ -27,7 +27,7 @@ export type ReportTableType = {
 
 interface Props {
   rows: ReportTableType[];
-  caption?: string;
+  caption: string;
 }
 
 export const ExportedReportTable = ({ rows, caption }: Props) => {
@@ -77,7 +77,7 @@ export const ExportRateTable = (
         <Heading as="h5" variant="h5" className="performance-rate-header">
           {data?.label}
         </Heading>
-        <ExportedReportTable rows={data?.rows} />
+        <ExportedReportTable rows={data?.rows} caption={data.label} />
       </Box>
     )
   );

--- a/services/ui-src/src/components/export/ExportedReportTable.tsx
+++ b/services/ui-src/src/components/export/ExportedReportTable.tsx
@@ -1,14 +1,15 @@
 import {
+  Box,
+  Heading,
   Table,
+  TableCaption,
   Thead,
   Th,
   Tr,
-  Tbody,
   Td,
+  Tbody,
   Text,
-  Heading,
-  Box,
-  TableCaption,
+  VisuallyHidden,
 } from "@chakra-ui/react";
 import { notAnsweredText } from "../../constants";
 import { ElementType } from "types";
@@ -21,6 +22,7 @@ export type ReportTableType = {
   helperText?: string;
   type?: ElementType;
   required?: boolean;
+  caption?: string;
 };
 
 interface Props {
@@ -37,7 +39,9 @@ export const ExportedReportTable = ({ rows, caption }: Props) => {
 
   return (
     <Table variant="export">
-      <TableCaption>{caption}</TableCaption>
+      <TableCaption>
+        <VisuallyHidden>{caption}</VisuallyHidden>
+      </TableCaption>
       <Thead>
         <Tr>
           <Th>Indicator</Th>

--- a/services/ui-src/src/components/export/ExportedReportTable.tsx
+++ b/services/ui-src/src/components/export/ExportedReportTable.tsx
@@ -8,6 +8,7 @@ import {
   Text,
   Heading,
   Box,
+  TableCaption,
 } from "@chakra-ui/react";
 import { notAnsweredText } from "../../constants";
 import { ElementType } from "types";
@@ -24,9 +25,10 @@ export type ReportTableType = {
 
 interface Props {
   rows: ReportTableType[];
+  caption?: string;
 }
 
-export const ExportedReportTable = ({ rows }: Props) => {
+export const ExportedReportTable = ({ rows, caption }: Props) => {
   const getTextColor = (element: ReportTableType) => {
     return element.response === notAnsweredText && element.required
       ? "palette.error_darker"
@@ -35,6 +37,7 @@ export const ExportedReportTable = ({ rows }: Props) => {
 
   return (
     <Table variant="export">
+      <TableCaption>{caption}</TableCaption>
       <Thead>
         <Tr>
           <Th>Indicator</Th>

--- a/services/ui-src/src/components/export/ExportedReportTable.tsx
+++ b/services/ui-src/src/components/export/ExportedReportTable.tsx
@@ -69,7 +69,8 @@ export const ExportedReportTable = ({ rows, caption }: Props) => {
 };
 
 export const ExportRateTable = (
-  tableData: { label: string; rows: ReportTableType[] }[]
+  tableData: { label: string; rows: ReportTableType[] }[],
+  caption?: string
 ) => {
   return tableData.map(
     (data: { label: string; rows: ReportTableType[] }, idx) => (
@@ -77,7 +78,10 @@ export const ExportRateTable = (
         <Heading as="h5" variant="h5" className="performance-rate-header">
           {data?.label}
         </Heading>
-        <ExportedReportTable rows={data?.rows} caption={data.label} />
+        <ExportedReportTable
+          rows={data?.rows}
+          caption={caption || data.label}
+        />
       </Box>
     )
   );

--- a/services/ui-src/src/components/export/ExportedReportWrapper.test.tsx
+++ b/services/ui-src/src/components/export/ExportedReportWrapper.test.tsx
@@ -1,6 +1,12 @@
 import { render, screen } from "@testing-library/react";
 import { ExportedReportWrapper } from "./ExportedReportWrapper";
-import { ElementType, FormPageTemplate, PageElement, PageType } from "types";
+import {
+  ElementType,
+  FormPageTemplate,
+  MeasurePageTemplate,
+  PageElement,
+  PageType,
+} from "types";
 
 const elements: PageElement[] = [
   {
@@ -107,5 +113,74 @@ describe("ExportedReportWrapper", () => {
     // The choice IDs should not render anywhere
     expect(screen.queryByText("bananah")).not.toBeInTheDocument();
     expect(screen.queryByText("bananya")).not.toBeInTheDocument();
+  });
+
+  it("should assign sectionTitle as caption to the first table element when no SubHeader precedes it", () => {
+    const elements: PageElement[] = [
+      {
+        type: ElementType.Textbox,
+        id: "first-field",
+        label: "First field",
+        required: true,
+        answer: "Some answer",
+      },
+    ];
+    const { container } = render(
+      <ExportedReportWrapper section={{ ...section, elements }} />
+    );
+    const caption = container.querySelector("caption");
+    expect(caption).toHaveTextContent("mock-title");
+  });
+
+  it("should use SubHeader text as caption on a non-measure page", () => {
+    const elements: PageElement[] = [
+      {
+        type: ElementType.SubHeader,
+        id: "sub-header",
+        text: "My Section Header",
+      },
+      {
+        type: ElementType.Textbox,
+        id: "field-after-subheader",
+        label: "A field",
+        required: true,
+        answer: "Some answer",
+      },
+    ];
+    const { container } = render(
+      <ExportedReportWrapper section={{ ...section, elements }} />
+    );
+    const caption = container.querySelector("caption");
+    expect(caption).toHaveTextContent("My Section Header");
+  });
+
+  it("should prefix caption with measure title on a measure page", () => {
+    const measureSection: MeasurePageTemplate = {
+      id: "mock-measure-id",
+      title: "LTSS-1: Comprehensive Assessment and Update",
+      type: PageType.Measure,
+      cmitId: "mock-cmit",
+      elements: [
+        {
+          type: ElementType.SubHeader,
+          id: "sub-header",
+          text: "Measure Information",
+        },
+        {
+          type: ElementType.Textbox,
+          id: "measure-field",
+          label: "A measure field",
+          required: true,
+          answer: "Some answer",
+        },
+      ],
+    };
+    const { container } = render(
+      <ExportedReportWrapper section={measureSection} />
+    );
+    const caption = container.querySelector("caption");
+    expect(caption).toHaveTextContent(
+      "LTSS-1: Comprehensive Assessment and Update: Measure Information"
+    );
   });
 });

--- a/services/ui-src/src/components/export/ExportedReportWrapper.tsx
+++ b/services/ui-src/src/components/export/ExportedReportWrapper.tsx
@@ -94,6 +94,11 @@ export const ExportedReportWrapper = ({ section }: Props) => {
   // Track SubHeader to use as caption for the pdf tables.
   const sectionTitle =
     "title" in section ? (section.title as string) : undefined;
+  const buildCaption = (subheader: string) =>
+    sectionTitle && section.type === "measure"
+      ? `${sectionTitle}: ${subheader}`
+      : subheader;
+
   let pendingCaption: string | undefined = sectionTitle;
   let tableGroupActive = false;
 
@@ -104,7 +109,7 @@ export const ExportedReportWrapper = ({ section }: Props) => {
       if (!isTableEl) {
         tableGroupActive = false;
         if (element.type === ElementType.SubHeader && "text" in element) {
-          pendingCaption = element.text as string;
+          pendingCaption = buildCaption(element.text as string);
         }
       }
 

--- a/services/ui-src/src/components/export/ExportedReportWrapper.tsx
+++ b/services/ui-src/src/components/export/ExportedReportWrapper.tsx
@@ -4,6 +4,7 @@ import {
   FormPageTemplate,
   MeasurePageTemplate,
   PageElement,
+  PageType,
   ParentPageTemplate,
   ReviewSubmitTemplate,
 } from "types";
@@ -92,33 +93,27 @@ export const ExportedReportWrapper = ({ section }: Props) => {
   const expandedElements = expandCheckedChildren(stateReportingFiltered);
 
   // Track SubHeader to use as caption for the pdf tables.
-  const sectionTitle =
-    "title" in section ? (section.title as string) : undefined;
-  const buildCaption = (subheader: string) =>
-    sectionTitle && section.type === "measure"
-      ? `${sectionTitle}: ${subheader}`
-      : subheader;
+  let mostRecentSubheader: string | undefined = undefined;
 
-  let pendingCaption: string | undefined = sectionTitle;
-  let tableGroupActive = false;
+  const determineCaption = (element: PageElement) => {
+    if (!shouldUseTable(element.type)) {
+      return undefined;
+    } else if (mostRecentSubheader === undefined) {
+      return section.title;
+    } else if (section.type === PageType.Measure) {
+      return `${section.title}: ${mostRecentSubheader}`;
+    } else {
+      return mostRecentSubheader;
+    }
+  };
 
   // Only the first element of a table group gets the caption
   const elements =
     expandedElements?.map((element) => {
-      const isTableEl = shouldUseTable(element.type as ElementType);
-
-      // Set the pending caption if the element is a table element and there is not an active table group
-      if (!isTableEl) {
-        tableGroupActive = false;
-        if (element.type === ElementType.SubHeader && "text" in element) {
-          pendingCaption = buildCaption(element.text as string);
-        }
+      const caption = determineCaption(element);
+      if (element.type === ElementType.SubHeader) {
+        mostRecentSubheader = element.text;
       }
-
-      // The caption is either the pending caption or the section title
-      const caption =
-        isTableEl && !tableGroupActive ? pendingCaption : undefined;
-      if (isTableEl) tableGroupActive = true;
 
       return {
         indicator: "label" in element ? (element.label ?? "") : "",

--- a/services/ui-src/src/components/export/ExportedReportWrapper.tsx
+++ b/services/ui-src/src/components/export/ExportedReportWrapper.tsx
@@ -1,5 +1,6 @@
 import { Flex } from "@chakra-ui/react";
 import {
+  ElementType,
   FormPageTemplate,
   MeasurePageTemplate,
   PageElement,
@@ -14,7 +15,13 @@ export const renderReportTable = (elements: ReportTableType[] | undefined) => {
   const filteredElements = elements?.filter((element) => element.indicator);
   if (filteredElements?.length == 0) return;
 
-  return <ExportedReportTable rows={filteredElements!}></ExportedReportTable>;
+  const caption = elements?.[0]?.caption;
+  return (
+    <ExportedReportTable
+      rows={filteredElements!}
+      caption={caption}
+    ></ExportedReportTable>
+  );
 };
 
 export const renderReportDisplay = (
@@ -84,14 +91,34 @@ export const ExportedReportWrapper = ({ section }: Props) => {
 
   const expandedElements = expandCheckedChildren(stateReportingFiltered);
 
+  // Track SubHeader to use as caption for the pdf tables.
+  const sectionTitle =
+    "title" in section ? (section.title as string) : undefined;
+  let pendingCaption: string | undefined = sectionTitle;
+  let tableGroupActive = false;
+
   const elements =
     expandedElements?.map((element) => {
+      const isTableEl = shouldUseTable(element.type as ElementType);
+
+      if (!isTableEl) {
+        tableGroupActive = false;
+        if (element.type === ElementType.SubHeader && "text" in element) {
+          pendingCaption = element.text as string;
+        }
+      }
+
+      const caption =
+        isTableEl && !tableGroupActive ? pendingCaption : undefined;
+      if (isTableEl) tableGroupActive = true;
+
       return {
         indicator: "label" in element ? (element.label ?? "") : "",
         helperText: getHelperText(element),
         response: renderElements(section as MeasurePageTemplate, element),
         type: element.type ?? "",
         required: "required" in element ? element.required : false,
+        caption,
       };
     }) ?? [];
 

--- a/services/ui-src/src/components/export/ExportedReportWrapper.tsx
+++ b/services/ui-src/src/components/export/ExportedReportWrapper.tsx
@@ -102,10 +102,12 @@ export const ExportedReportWrapper = ({ section }: Props) => {
   let pendingCaption: string | undefined = sectionTitle;
   let tableGroupActive = false;
 
+  // Only the first element of a table group gets the caption
   const elements =
     expandedElements?.map((element) => {
       const isTableEl = shouldUseTable(element.type as ElementType);
 
+      // Set the pending caption if the element is a table element and there is not an active table group
       if (!isTableEl) {
         tableGroupActive = false;
         if (element.type === ElementType.SubHeader && "text" in element) {
@@ -113,6 +115,7 @@ export const ExportedReportWrapper = ({ section }: Props) => {
         }
       }
 
+      // The caption is either the pending caption or the section title
       const caption =
         isTableEl && !tableGroupActive ? pendingCaption : undefined;
       if (isTableEl) tableGroupActive = true;

--- a/services/ui-src/src/components/export/ExportedReportWrapper.tsx
+++ b/services/ui-src/src/components/export/ExportedReportWrapper.tsx
@@ -19,7 +19,7 @@ export const renderReportTable = (elements: ReportTableType[] | undefined) => {
   return (
     <ExportedReportTable
       rows={filteredElements!}
-      caption={caption}
+      caption={caption!}
     ></ExportedReportTable>
   );
 };

--- a/services/ui-src/src/components/pages/Dashboard/DashboardTable.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardTable.tsx
@@ -12,8 +12,8 @@ import {
   Spinner,
 } from "@chakra-ui/react";
 import { Table } from "components";
-import { NavigateFunction, useNavigate } from "react-router-dom";
-import { LiteReport, ReportStatus } from "types";
+import { NavigateFunction, useNavigate, useParams } from "react-router-dom";
+import { getReportName, LiteReport, ReportStatus } from "types";
 import {
   formatMonthDayYear,
   releaseReport,
@@ -277,9 +277,9 @@ export const DashboardTable = ({
   ];
   if (showReportSubmissionsColumn) headers.push("#");
   headers.push("");
-
+  const { reportType } = useParams();
   const tableContent = {
-    caption: "Quality Measure Reports",
+    caption: `${getReportName(reportType)}s`,
     headRow: headers,
   };
 

--- a/services/ui-src/src/components/pages/Export/ExportedReportPage.test.tsx
+++ b/services/ui-src/src/components/pages/Export/ExportedReportPage.test.tsx
@@ -73,9 +73,11 @@ describe("ExportedReportPage", () => {
   });
   it("ExportReportPage is visible", () => {
     render(<ExportedReportPage></ExportedReportPage>);
-    expect(
-      screen.getByText("Colorado Quality Measure Set Report for: mock-title")
-    ).toBeInTheDocument();
+    const elements = screen.getAllByText(
+      "Colorado Quality Measure Set Report for: mock-title"
+    );
+    expect(elements.length).toBeGreaterThan(0);
+    elements.forEach((element) => expect(element).toBeInTheDocument());
   });
 
   it("Should not render filtered sections", () => {

--- a/services/ui-src/src/components/pages/Export/ExportedReportPage.test.tsx
+++ b/services/ui-src/src/components/pages/Export/ExportedReportPage.test.tsx
@@ -76,8 +76,7 @@ describe("ExportedReportPage", () => {
     const elements = screen.getAllByText(
       "Colorado Quality Measure Set Report for: mock-title"
     );
-    expect(elements.length).toBeGreaterThan(0);
-    elements.forEach((element) => expect(element).toBeInTheDocument());
+    expect(elements.length).toBe(2);
   });
 
   it("Should not render filtered sections", () => {

--- a/services/ui-src/src/components/pages/Export/ExportedReportPage.tsx
+++ b/services/ui-src/src/components/pages/Export/ExportedReportPage.tsx
@@ -96,9 +96,9 @@ export const reportTitle = (report: Report) => {
 export const reportDetails = (report: Report) => {
   return (
     <Table variant={"reportDetails"}>
-      <VisuallyHidden>
-        <TableCaption>{reportTitle(report)}</TableCaption>
-      </VisuallyHidden>
+      <TableCaption>
+        <VisuallyHidden>{reportTitle(report)}</VisuallyHidden>
+      </TableCaption>
       <Thead>
         <Tr>
           <Th>Reporting year</Th>

--- a/services/ui-src/src/components/pages/Export/ExportedReportPage.tsx
+++ b/services/ui-src/src/components/pages/Export/ExportedReportPage.tsx
@@ -12,6 +12,8 @@ import {
   Th,
   Thead,
   Tr,
+  TableCaption,
+  VisuallyHidden,
 } from "@chakra-ui/react";
 import { formatMonthDayYear, useStore } from "utils";
 import {
@@ -94,6 +96,9 @@ export const reportTitle = (report: Report) => {
 export const reportDetails = (report: Report) => {
   return (
     <Table variant={"reportDetails"}>
+      <VisuallyHidden>
+        <TableCaption>{reportTitle(report)}</TableCaption>
+      </VisuallyHidden>
       <Thead>
         <Tr>
           <Th>Reporting year</Th>
@@ -140,7 +145,10 @@ export const reportSubmissionSetUp = (report: Report) => {
       <Heading as="h2" variant="h2">
         Submission Set Up
       </Heading>
-      <ExportedReportTable rows={rows}></ExportedReportTable>
+      <ExportedReportTable
+        rows={rows}
+        caption="Submission Set Up"
+      ></ExportedReportTable>
     </Box>
   );
 };

--- a/services/ui-src/src/components/rates/types/NDRBasic.tsx
+++ b/services/ui-src/src/components/rates/types/NDRBasic.tsx
@@ -252,7 +252,7 @@ export const NDRBasic = (props: PageElementProps<NdrBasicTemplate>) => {
 };
 
 //The pdf rendering of NDRBasic component
-export const NDRBasicExport = (element: NdrBasicTemplate) => {
+export const NDRBasicExport = (element: NdrBasicTemplate, caption?: string) => {
   const label = element.label ?? "";
 
   const minimum =
@@ -296,7 +296,7 @@ export const NDRBasicExport = (element: NdrBasicTemplate) => {
     },
     ...children,
   ];
-  return <>{ExportRateTable([{ label, rows }])}</>;
+  return <>{ExportRateTable([{ label, rows }], caption)}</>;
 };
 
 const formatRateForExport = (

--- a/services/ui-src/src/components/rates/types/NDREnhanced.tsx
+++ b/services/ui-src/src/components/rates/types/NDREnhanced.tsx
@@ -241,6 +241,7 @@ export const NDREnhancedExport = (element: NdrEnhancedTemplate) => {
             response: element?.answer?.denominator,
           },
         ]}
+        caption="Performance Rates Denominator"
       />
       {ExportRateTable(buildData)}
     </>

--- a/services/ui-src/src/components/rates/types/NDRFields.tsx
+++ b/services/ui-src/src/components/rates/types/NDRFields.tsx
@@ -267,6 +267,7 @@ export const NDRFieldExport = (element: NdrFieldsTemplate) => {
                 response: build.denominator,
               },
             ]}
+            caption={`Performance Rates: ${build.label}`}
           />
           {build.rates?.map((rate) =>
             ExportRateTable([{ label: rate.fieldLabel, rows: rate.rate }])

--- a/services/ui-src/src/components/report/MeasureResultsNavigationTable.tsx
+++ b/services/ui-src/src/components/report/MeasureResultsNavigationTable.tsx
@@ -1,12 +1,14 @@
 import {
   Button,
   Table,
+  TableCaption,
   Tbody,
   Td,
   Th,
   Thead,
   Tr,
   Text,
+  VisuallyHidden,
 } from "@chakra-ui/react";
 import { useStore } from "utils";
 import { TableStatusIcon } from "components/tables/TableStatusIcon";
@@ -114,6 +116,9 @@ export const MeasureResultsNavigationTableElement = (
   });
   return (
     <Table variant="measure">
+      <TableCaption>
+        <VisuallyHidden>{currentPage.title} Measure Details</VisuallyHidden>
+      </TableCaption>
       <Thead>
         <Tr>
           <Th>Status</Th>

--- a/services/ui-src/src/components/report/MeasureTable.test.tsx
+++ b/services/ui-src/src/components/report/MeasureTable.test.tsx
@@ -64,6 +64,7 @@ const mockTemplate: MeasureTableTemplate = {
   type: ElementType.MeasureTable,
   id: "mock-table-id",
   measureDisplay: "required",
+  caption: "Required Measure Results",
 };
 
 jest.mock("./MeasureReplacementModal", () => ({

--- a/services/ui-src/src/components/report/MeasureTable.tsx
+++ b/services/ui-src/src/components/report/MeasureTable.tsx
@@ -84,11 +84,6 @@ export const MeasureTableElement = (
     return measure.status ?? PageStatus.NOT_STARTED;
   };
 
-  const caption =
-    table.measureDisplay === "required"
-      ? "Required Measure Results"
-      : "Optional Measure Results";
-
   const errorMessage = (measure: MeasurePageTemplate) => {
     //TO DO: clean up when report check code is ready
     if (
@@ -150,7 +145,7 @@ export const MeasureTableElement = (
   return (
     <Table variant="measure">
       <TableCaption>
-        <VisuallyHidden>{caption}</VisuallyHidden>
+        <VisuallyHidden>{table.caption}</VisuallyHidden>
       </TableCaption>
       <Thead>
         <Tr>

--- a/services/ui-src/src/components/report/MeasureTable.tsx
+++ b/services/ui-src/src/components/report/MeasureTable.tsx
@@ -9,6 +9,7 @@ import {
   Tr,
   Text,
   Link,
+  TableCaption,
   Flex,
 } from "@chakra-ui/react";
 import { MeasureReplacementModal, TableStatusIcon } from "components";
@@ -82,6 +83,11 @@ export const MeasureTableElement = (
     return measure.status ?? PageStatus.NOT_STARTED;
   };
 
+  const getCaption = (measureDisplay: string) =>
+    measureDisplay === "required"
+      ? "Required Measure Results"
+      : "Optional Measure Results";
+
   const errorMessage = (measure: MeasurePageTemplate) => {
     //TO DO: clean up when report check code is ready
     if (
@@ -142,6 +148,7 @@ export const MeasureTableElement = (
   });
   return (
     <Table variant="measure">
+      <TableCaption>{getCaption(table.measureDisplay)}</TableCaption>
       <Thead>
         <Tr>
           <Th>Status</Th>

--- a/services/ui-src/src/components/report/MeasureTable.tsx
+++ b/services/ui-src/src/components/report/MeasureTable.tsx
@@ -84,8 +84,8 @@ export const MeasureTableElement = (
     return measure.status ?? PageStatus.NOT_STARTED;
   };
 
-  const getCaption = (measureDisplay: string) =>
-    measureDisplay === "required"
+  const caption =
+    table.measureDisplay === "required"
       ? "Required Measure Results"
       : "Optional Measure Results";
 
@@ -149,9 +149,9 @@ export const MeasureTableElement = (
   });
   return (
     <Table variant="measure">
-      <VisuallyHidden>
-        <TableCaption>{getCaption(table.measureDisplay)}</TableCaption>
-      </VisuallyHidden>
+      <TableCaption>
+        <VisuallyHidden>{caption}</VisuallyHidden>
+      </TableCaption>
       <Thead>
         <Tr>
           <Th>Status</Th>

--- a/services/ui-src/src/components/report/MeasureTable.tsx
+++ b/services/ui-src/src/components/report/MeasureTable.tsx
@@ -11,6 +11,7 @@ import {
   Link,
   TableCaption,
   Flex,
+  VisuallyHidden,
 } from "@chakra-ui/react";
 import { MeasureReplacementModal, TableStatusIcon } from "components";
 import {
@@ -148,7 +149,9 @@ export const MeasureTableElement = (
   });
   return (
     <Table variant="measure">
-      <TableCaption>{getCaption(table.measureDisplay)}</TableCaption>
+      <VisuallyHidden>
+        <TableCaption>{getCaption(table.measureDisplay)}</TableCaption>
+      </VisuallyHidden>
       <Thead>
         <Tr>
           <Th>Status</Th>

--- a/services/ui-src/src/components/report/Page.test.tsx
+++ b/services/ui-src/src/components/report/Page.test.tsx
@@ -133,16 +133,19 @@ const elements: PageElement[] = [
     type: ElementType.MeasureTable,
     measureDisplay: "required",
     id: "",
+    caption: "Required Measure Results",
   },
   {
     type: ElementType.MeasureTable,
     measureDisplay: "required",
     id: "",
+    caption: "Required Measure Results",
   },
   {
     type: ElementType.MeasureTable,
     id: "",
     measureDisplay: "optional",
+    caption: "Optional Measure Results",
   },
   {
     type: ElementType.StatusTable,

--- a/services/ui-src/src/components/report/StatusTable.tsx
+++ b/services/ui-src/src/components/report/StatusTable.tsx
@@ -12,6 +12,7 @@ import {
   Tr,
   Text,
   Spinner,
+  TableCaption,
 } from "@chakra-ui/react";
 import { postSubmitReport, useStore } from "utils";
 import editIconPrimary from "assets/icons/edit/icon_edit_primary.svg";
@@ -86,11 +87,11 @@ export const StatusTableElement = () => {
   return (
     <>
       <Table variant="status">
+        <TableCaption>Review & Submit</TableCaption>
         <Thead>
           <Tr>
             <Th>Section</Th>
             <Th>Status</Th>
-            <Th>Actions</Th>
           </Tr>
         </Thead>
         <Tbody>{rows}</Tbody>

--- a/services/ui-src/src/components/report/StatusTable.tsx
+++ b/services/ui-src/src/components/report/StatusTable.tsx
@@ -13,6 +13,7 @@ import {
   Text,
   Spinner,
   TableCaption,
+  VisuallyHidden,
 } from "@chakra-ui/react";
 import { postSubmitReport, useStore } from "utils";
 import editIconPrimary from "assets/icons/edit/icon_edit_primary.svg";
@@ -87,7 +88,9 @@ export const StatusTableElement = () => {
   return (
     <>
       <Table variant="status">
-        <TableCaption>Review & Submit</TableCaption>
+        <VisuallyHidden>
+          <TableCaption>Review & Submit</TableCaption>
+        </VisuallyHidden>
         <Thead>
           <Tr>
             <Th>Section</Th>

--- a/services/ui-src/src/components/report/StatusTable.tsx
+++ b/services/ui-src/src/components/report/StatusTable.tsx
@@ -95,7 +95,7 @@ export const StatusTableElement = () => {
           <Tr>
             <Th>Section</Th>
             <Th>Status</Th>
-            <Th>Action</Th>
+            <Th>Actions</Th>
           </Tr>
         </Thead>
         <Tbody>{rows}</Tbody>

--- a/services/ui-src/src/components/report/StatusTable.tsx
+++ b/services/ui-src/src/components/report/StatusTable.tsx
@@ -88,9 +88,9 @@ export const StatusTableElement = () => {
   return (
     <>
       <Table variant="status">
-        <VisuallyHidden>
-          <TableCaption>Review & Submit</TableCaption>
-        </VisuallyHidden>
+        <TableCaption>
+          <VisuallyHidden>Review & Submit</VisuallyHidden>
+        </TableCaption>
         <Thead>
           <Tr>
             <Th>Section</Th>

--- a/services/ui-src/src/components/report/StatusTable.tsx
+++ b/services/ui-src/src/components/report/StatusTable.tsx
@@ -95,6 +95,7 @@ export const StatusTableElement = () => {
           <Tr>
             <Th>Section</Th>
             <Th>Status</Th>
+            <Th>Action</Th>
           </Tr>
         </Thead>
         <Tbody>{rows}</Tbody>

--- a/services/ui-src/src/components/report/WwlComponents/EligibilityTable.test.tsx
+++ b/services/ui-src/src/components/report/WwlComponents/EligibilityTable.test.tsx
@@ -53,7 +53,7 @@ describe("<EligibilityTableElement />", () => {
 
     test("EligibilityTableElement is visible", () => {
       render(<EligibilityTableWrapper template={mockedElement} />);
-      expect(screen.getByText("Other Eligibility")).toBeVisible();
+      expect(screen.getAllByText("Other Eligibility")[0]).toBeVisible();
       expect(screen.getByText("mockTitle1")).toBeVisible();
     });
 

--- a/services/ui-src/src/components/report/WwlComponents/EligibilityTable.test.tsx
+++ b/services/ui-src/src/components/report/WwlComponents/EligibilityTable.test.tsx
@@ -141,8 +141,9 @@ describe("<EligibilityTableElement />", () => {
   describe("EligibilityTableElementExport", () => {
     it("should render export table", () => {
       render(EligibilityTableElementExport(mockedElement));
-      expect(screen.getAllByText("mockTitle1").length).toBe(2);
-      expect(screen.getAllByText("mockTitle1")[0]).toBeVisible();
+      const mockTitleElements = screen.getAllByText("mockTitle1");
+      expect(mockTitleElements).toHaveLength(2);
+      expect(mockTitleElements[0]).toBeVisible();
       expect(
         screen.getByRole("cell", {
           name: mockedElement.fieldLabels.description,

--- a/services/ui-src/src/components/report/WwlComponents/EligibilityTable.test.tsx
+++ b/services/ui-src/src/components/report/WwlComponents/EligibilityTable.test.tsx
@@ -141,7 +141,7 @@ describe("<EligibilityTableElement />", () => {
   describe("EligibilityTableElementExport", () => {
     it("should render export table", () => {
       render(EligibilityTableElementExport(mockedElement));
-      expect(screen.getByText("mockTitle1")).toBeVisible();
+      expect(screen.getAllByText("mockTitle1").length).toBeGreaterThan(0);
       expect(
         screen.getByRole("cell", {
           name: mockedElement.fieldLabels.description,

--- a/services/ui-src/src/components/report/WwlComponents/EligibilityTable.test.tsx
+++ b/services/ui-src/src/components/report/WwlComponents/EligibilityTable.test.tsx
@@ -141,7 +141,8 @@ describe("<EligibilityTableElement />", () => {
   describe("EligibilityTableElementExport", () => {
     it("should render export table", () => {
       render(EligibilityTableElementExport(mockedElement));
-      expect(screen.getAllByText("mockTitle1").length).toBeGreaterThan(0);
+      expect(screen.getAllByText("mockTitle1").length).toBe(2);
+      expect(screen.getAllByText("mockTitle1")[0]).toBeVisible();
       expect(
         screen.getByRole("cell", {
           name: mockedElement.fieldLabels.description,

--- a/services/ui-src/src/components/report/WwlComponents/EligibilityTable.test.tsx
+++ b/services/ui-src/src/components/report/WwlComponents/EligibilityTable.test.tsx
@@ -11,6 +11,7 @@ import {
 const mockedElement: EligibilityTableTemplate = {
   id: "mock-id",
   type: ElementType.EligibilityTable,
+  caption: "Other Eligibility",
   fieldLabels: {
     title: "title",
     description: "description",

--- a/services/ui-src/src/components/report/WwlComponents/EligibilityTable.tsx
+++ b/services/ui-src/src/components/report/WwlComponents/EligibilityTable.tsx
@@ -317,11 +317,11 @@ export const EligibilityTableElement = (
 
 //The pdf rendering of EligibilityTableElement component
 export const EligibilityTableElementExport = (
-  element: EligibilityTableTemplate
+  element: EligibilityTableTemplate,
+  sectionTitle?: string
 ) => {
   const { fieldLabels } = element;
   const exportElements = element.answer?.map((eligibility) => {
-    const label = eligibility.title;
     const rows = [
       {
         indicator: fieldLabels.description,
@@ -340,11 +340,11 @@ export const EligibilityTableElementExport = (
         response: eligibility.eligibilityUpdate,
       },
     ];
-    return { label, rows };
+    return ExportRateTable([{ label: eligibility.title, rows }], sectionTitle);
   });
 
   if (!exportElements) return <></>;
-  return <>{ExportRateTable(exportElements)}</>;
+  return <>{exportElements}</>;
 };
 
 const sx = {

--- a/services/ui-src/src/components/report/WwlComponents/EligibilityTable.tsx
+++ b/services/ui-src/src/components/report/WwlComponents/EligibilityTable.tsx
@@ -34,7 +34,7 @@ export const EligibilityTableElement = (
   props: PageElementProps<EligibilityTableTemplate>
 ) => {
   const { element, updateElement } = props;
-  const { fieldLabels, modalInstructions, frequencyOptions } = element;
+  const { fieldLabels, caption, modalInstructions, frequencyOptions } = element;
 
   const initialValues = {
     title: "",
@@ -191,7 +191,7 @@ export const EligibilityTableElement = (
     <Fragment>
       <Table variant="measure">
         <TableCaption>
-          <VisuallyHidden>Other Eligibility</VisuallyHidden>
+          <VisuallyHidden>{caption}</VisuallyHidden>
         </TableCaption>
         <Thead>
           <Tr>

--- a/services/ui-src/src/components/report/WwlComponents/EligibilityTable.tsx
+++ b/services/ui-src/src/components/report/WwlComponents/EligibilityTable.tsx
@@ -190,9 +190,9 @@ export const EligibilityTableElement = (
   return (
     <Fragment>
       <Table variant="measure">
-        <VisuallyHidden>
-          <TableCaption>Other Eligibility</TableCaption>
-        </VisuallyHidden>
+        <TableCaption>
+          <VisuallyHidden>Other Eligibility</VisuallyHidden>
+        </TableCaption>
         <Thead>
           <Tr>
             <Th>Other Eligibility</Th>

--- a/services/ui-src/src/components/report/WwlComponents/EligibilityTable.tsx
+++ b/services/ui-src/src/components/report/WwlComponents/EligibilityTable.tsx
@@ -1,6 +1,7 @@
 import {
   Button,
   Table,
+  TableCaption,
   Tbody,
   Td,
   Th,
@@ -17,6 +18,7 @@ import {
   ModalFooter,
   Box,
   Flex,
+  VisuallyHidden,
 } from "@chakra-ui/react";
 import { EligibilityTableTemplate, EligibilityTableItem } from "types";
 import { PageElementProps } from "../Elements";
@@ -188,6 +190,9 @@ export const EligibilityTableElement = (
   return (
     <Fragment>
       <Table variant="measure">
+        <VisuallyHidden>
+          <TableCaption>Other Eligibility</TableCaption>
+        </VisuallyHidden>
         <Thead>
           <Tr>
             <Th>Other Eligibility</Th>

--- a/services/ui-src/src/types/report.ts
+++ b/services/ui-src/src/types/report.ts
@@ -362,6 +362,7 @@ export type EligibilityTableItem = {
 export type EligibilityTableTemplate = {
   type: ElementType.EligibilityTable;
   id: string;
+  caption: string;
   fieldLabels: {
     title: string;
     description: string;

--- a/services/ui-src/src/types/report.ts
+++ b/services/ui-src/src/types/report.ts
@@ -347,6 +347,7 @@ export type AccordionTemplate = {
 export type MeasureTableTemplate = {
   type: ElementType.MeasureTable;
   id: string;
+  caption: string;
   measureDisplay: "required" | "optional";
 };
 


### PR DESCRIPTION
### Description
- Several `<table>`'s were missing a `<caption>`.
- This PR adds captions to several tables with Chakra-UI: `<TableCaption>` and `<VisuallyHidden>`



Pages that have tables missing captions:
> /report/QMS/`<state>`/`<id>`/req-measure-result
> /report/QMS/`<state>`/`<id>`/LTSS-1
> /report/QMS/`<state>`/`<id>`/LTSS-2
> /report/QMS/`<state>`/`<id>`/LTSS-6
> /report/QMS/`<state>`/`<id>`/LTSS-7
> /report/QMS/`<state>`/`<id>`/LTSS-8
> /report/QMS/`<state>`/`<id>`/POM-1
> /report/QMS/`<state>`/`<id>`/POM-2
> /report/QMS/`<state>`/`<id>`/POM-3
> /report/QMS/`<state>`/`<id>`/POM-4
> /report/QMS/`<state>`/`<id>`/POM-5
> /report/QMS/`<state>`/`<id>`/optional-measure-result
> /report/QMS/`<state>`/`<id>`/FASI-1
> /report/QMS/`<state>`/`<id>`/FASI-2
> /report/QMS/`<state>`/`<id>`/HCBS-10
> /report/QMS/`<state>`/`<id>`/LTSS-3
> /report/QMS/`<state>`/`<id>`/LTSS-4
> /report/QMS/`<state>`/`<id>`/MLTSS-5
> /report/QMS/`<state>`/`<id>`/MLTSS
> /report/QMS/`<state>`/`<id>`/POM-6
> /report/QMS/`<state>`/`<id>`/POM-7
> /report/QMS/`<state>`/`<id>`/review-submit
> /report/QMS/`<state>`/`<id>`/export

#### Solution:

- Add a `<caption>` to tables that meaningfully describe the table content. (Captions can be the same as their nearest heading.)
- Captions are useful for people who use screen readers to navigate directly to tables


### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-5624

---
### How to test

1. Login as a state user
2. Update Voiceover settings to mute speech to avoid stimulation overload, if needed.

     <img width="845" height="519" alt="Voiceover utility menu to select mute speech checkbox" src="https://github.com/user-attachments/assets/f1dd06a5-20f4-4c90-8e1b-da1daf4e6170" />
3. Open [deployed environment](https://d1q0y5vrx0094h.cloudfront.net/) in Safari
4. Navigate to tables
    a. Dashboard Table of each report
    b. Required Measure Results table
    c. Optional Measure Results table
    d. Each Measure page per the "Description" (Jira ticket)
    d. Review & Submit table
    e. PDF view (this one has the most tables)   
5. Toggle Voiceover On (This image shows it toggled off - for the record)
     
    <img width="694" height="315" alt="Voiceover toggled off" src="https://github.com/user-attachments/assets/7bdef805-ad64-4ad6-bf68-df45cde3aa31" />

6. Press keys `Ctrl` + `Option `+ `U`. 
7. This will open a menu.  Press right arrow until you see a table menu. 

Best case scenario ⭐ 
This is an example of the tables being defined with more than just the number of columns and rows
<img width="1090" height="916" alt="PDF view with table captions - rotor view example" src="https://github.com/user-attachments/assets/005655a2-1110-46ac-bd72-346eea14ac2b" />


### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
