### PR TITLE
Rename NDR components

### DIFF
--- a/docs/ReportSchema.md
+++ b/docs/ReportSchema.md
@@ -154,7 +154,7 @@ Here is the complete list of element types, roughly categorized:
   - `ndr`: A set of three numeric fields: numerator, denominator, and rate.
     - Rate is auto-calculated as soon as numerator and denominator are entered.
     - Answer is an object of type `{ numerator: number, denominator: number, rate: number }`.
-  - `ndrBasic`: Similar to NDR, with the same answer shape.
+  - `performanceNdr`: Similar to NDR, with the same answer shape.
     May have additional properties:
     - `multiplier`: May be applied to the rate during auto-calculation.
       For example, percentage rates would have `multiplier: 100`

--- a/docs/ReportSchema.md
+++ b/docs/ReportSchema.md
@@ -82,6 +82,7 @@ Element objects have varying shapes, but some fields are common:
 - `type` (string): Indicates this element's role, and dictates its shape.
 - `id` (string): An identifier. Should always be unique _within a page_,
   but IDs may be reused for elements on different pages.
+  - One exception is divider elements; these always have `id: "divider"`.
 - `answer` (varies, optional): If this element accepts user input,
   that input will be stored in the `answer` property.
   - Different elements have different answer types: string, number, object...

--- a/docs/ReportSchema.md
+++ b/docs/ReportSchema.md
@@ -166,13 +166,13 @@ Here is the complete list of element types, roughly categorized:
     - The `assessments` property is an array of `{ id: string, label: string }`
       corresponding to the numerators.
     - Answer is an object of type `{ denominator: number, rates: { numerator: number, rate: number }[] }`
-  - `ndrFields`: A collection of rates sets with shared denominators.
-    - The `fields` property is an array of `{ id: string, label: string }`
+  - `multiCategoryNdr`: A collection of rates sets with shared denominators.
+    - The `categories` property is an array of `{ id: string, label: string }`
       corresponding to the denominators.
     - The `assessments` property works just like in `multiRateNdr`.
     - Answer is an array of objects, each of which is the same shape
       as the answer for an `multiRateNdr` element.
-    - For example, if there are two `fields` and three `assessments`,
+    - For example, if there are two `categories` and three `assessments`,
       there will be six rates in all.
       In this case, the answer will be an array containing two objects,
       each of which will have a `rates` property containing three objects.

--- a/docs/ReportSchema.md
+++ b/docs/ReportSchema.md
@@ -162,16 +162,16 @@ Here is the complete list of element types, roughly categorized:
       If it does not, the user will be shown a warning.
     - `conditionalChildren`: Just like `checkedChildren` for a radio option.
       Shown only if `rate < minPerformanceLevel`.
-  - `ndrEnhanced`: A set of rates with a shared denominator.
+  - `multiRateNdr`: A set of rates with a shared denominator.
     - The `assessments` property is an array of `{ id: string, label: string }`
       corresponding to the numerators.
     - Answer is an object of type `{ denominator: number, rates: { numerator: number, rate: number }[] }`
   - `ndrFields`: A collection of rates sets with shared denominators.
     - The `fields` property is an array of `{ id: string, label: string }`
       corresponding to the denominators.
-    - The `assessments` property works just like in `ndrEnhanced`.
+    - The `assessments` property works just like in `multiRateNdr`.
     - Answer is an array of objects, each of which is the same shape
-      as the answer for an `ndrEnhanced` element.
+      as the answer for an `multiRateNdr` element.
     - For example, if there are two `fields` and three `assessments`,
       there will be six rates in all.
       In this case, the answer will be an array containing two objects,

--- a/services/app-api/forms/2026/ci/ci.ts
+++ b/services/app-api/forms/2026/ci/ci.ts
@@ -75,7 +75,7 @@ export const ciReportTemplate: ReportBase = {
           text: "HCBS INCID-1: Critical Incidents for Which an Investigation Was Initiated Within State-Specified Timeframes",
         },
         {
-          type: ElementType.NdrBasic,
+          type: ElementType.PerformanceNdr,
           id: "critical-incident-rate",
           required: true,
           hintText: {
@@ -108,7 +108,7 @@ export const ciReportTemplate: ReportBase = {
           text: "HCBS INCID-2: Critical Incidents for Which the State Determined the Resolution Within State-Specified Timeframes",
         },
         {
-          type: ElementType.NdrBasic,
+          type: ElementType.PerformanceNdr,
           id: "critical-incident-rate",
           required: true,
           hintText: {
@@ -141,7 +141,7 @@ export const ciReportTemplate: ReportBase = {
           text: "HCBS INCID-3: Critical Incidents Requiring Corrective Action for Which the Required Corrective Action Was Completed Within State-Specified Timeframes",
         },
         {
-          type: ElementType.NdrBasic,
+          type: ElementType.PerformanceNdr,
           id: "critical-incident-rate",
           required: true,
           hintText: {

--- a/services/app-api/forms/2026/elements.ts
+++ b/services/app-api/forms/2026/elements.ts
@@ -88,7 +88,7 @@ export const stateSamplingMethologyQuestion: RadioTemplate = {
       checkedChildren: [
         {
           type: ElementType.TextAreaField,
-          id: "sampling-approach-used",
+          id: "sampling-approach-used-probability",
           label: "Describe the sampling approach used",
           required: true,
         },
@@ -119,7 +119,7 @@ export const stateSamplingMethologyQuestion: RadioTemplate = {
       checkedChildren: [
         {
           type: ElementType.TextAreaField,
-          id: "sampling-approach-used",
+          id: "sampling-approach-used-other",
           label:
             "Please provide a detailed description of the alternative sampling methodology. If this measure aggregates results from multiple programs that used different methodologies, specify which method was used for each program and how the results were combined.",
           required: true,

--- a/services/app-api/forms/2026/pcp/pcpElements.ts
+++ b/services/app-api/forms/2026/pcp/pcpElements.ts
@@ -1,8 +1,8 @@
-import { ElementType, NdrBasicTemplate } from "../../../types/reports";
+import { ElementType, PerformanceNdrTemplate } from "../../../types/reports";
 import { minPerformanceExplanationField } from "../elements";
 
-export const beneficiariesRate: NdrBasicTemplate = {
-  type: ElementType.NdrBasic,
+export const beneficiariesRate: PerformanceNdrTemplate = {
+  type: ElementType.PerformanceNdr,
   id: "beneficiaries-rate",
   required: true,
   hintText: {
@@ -19,8 +19,8 @@ export const beneficiariesRate: NdrBasicTemplate = {
   conditionalChildren: [minPerformanceExplanationField],
 };
 
-export const beneficiariesReviewedRate: NdrBasicTemplate = {
-  type: ElementType.NdrBasic,
+export const beneficiariesReviewedRate: PerformanceNdrTemplate = {
+  type: ElementType.PerformanceNdr,
   id: "pcp-2-rate",
   required: true,
   hintText: {

--- a/services/app-api/forms/2026/qms/measureTemplates.ts
+++ b/services/app-api/forms/2026/qms/measureTemplates.ts
@@ -815,7 +815,7 @@ export const measureTemplates: Record<
       divider,
       {
         type: ElementType.MultiRateNdr,
-        id: "measure-rates",
+        id: "measure-rates-transmitted",
         required: true,
         assessments: [
           {
@@ -826,7 +826,7 @@ export const measureTemplates: Record<
       },
       {
         type: ElementType.MultiRateNdr,
-        id: "measure-rates",
+        id: "measure-rates-refused",
         label: "Exclusion Rate",
         required: true,
         assessments: [
@@ -870,7 +870,7 @@ export const measureTemplates: Record<
       divider,
       {
         type: ElementType.MultiRateNdr,
-        id: "measure-rates",
+        id: "measure-rates-transmitted",
         required: true,
         assessments: [
           {
@@ -881,7 +881,7 @@ export const measureTemplates: Record<
       },
       {
         type: ElementType.MultiRateNdr,
-        id: "measure-rates",
+        id: "measure-rates-refused",
         label: "Exclusion Rate",
         required: true,
         assessments: [
@@ -1081,7 +1081,7 @@ export const measureTemplates: Record<
       waiverListInputField,
       {
         type: ElementType.MultiRateNdr,
-        id: "measure-rates",
+        id: "measure-rates-assessed",
         required: true,
         assessments: [
           {
@@ -1096,7 +1096,7 @@ export const measureTemplates: Record<
       },
       {
         type: ElementType.MultiRateNdr,
-        id: "measure-rates",
+        id: "measure-rates-refused",
         required: true,
         label: "Exclusion Rate",
         assessments: [

--- a/services/app-api/forms/2026/qms/measureTemplates.ts
+++ b/services/app-api/forms/2026/qms/measureTemplates.ts
@@ -814,7 +814,7 @@ export const measureTemplates: Record<
       waiverListInputField,
       divider,
       {
-        type: ElementType.NdrEnhanced,
+        type: ElementType.MultiRateNdr,
         id: "measure-rates",
         required: true,
         assessments: [
@@ -825,7 +825,7 @@ export const measureTemplates: Record<
         ],
       },
       {
-        type: ElementType.NdrEnhanced,
+        type: ElementType.MultiRateNdr,
         id: "measure-rates",
         label: "Exclusion Rate",
         required: true,
@@ -869,7 +869,7 @@ export const measureTemplates: Record<
       waiverListInputField,
       divider,
       {
-        type: ElementType.NdrEnhanced,
+        type: ElementType.MultiRateNdr,
         id: "measure-rates",
         required: true,
         assessments: [
@@ -880,7 +880,7 @@ export const measureTemplates: Record<
         ],
       },
       {
-        type: ElementType.NdrEnhanced,
+        type: ElementType.MultiRateNdr,
         id: "measure-rates",
         label: "Exclusion Rate",
         required: true,
@@ -1038,7 +1038,7 @@ export const measureTemplates: Record<
       ...whichProgramsWaivers,
       waiverListInputField,
       {
-        type: ElementType.NdrEnhanced,
+        type: ElementType.MultiRateNdr,
         id: "measure-rates",
         required: true,
         assessments: [
@@ -1080,7 +1080,7 @@ export const measureTemplates: Record<
       ...whichProgramsWaivers,
       waiverListInputField,
       {
-        type: ElementType.NdrEnhanced,
+        type: ElementType.MultiRateNdr,
         id: "measure-rates",
         required: true,
         assessments: [
@@ -1095,7 +1095,7 @@ export const measureTemplates: Record<
         ],
       },
       {
-        type: ElementType.NdrEnhanced,
+        type: ElementType.MultiRateNdr,
         id: "measure-rates",
         required: true,
         label: "Exclusion Rate",

--- a/services/app-api/forms/2026/qms/qmsElements.ts
+++ b/services/app-api/forms/2026/qms/qmsElements.ts
@@ -9,7 +9,7 @@ import {
   MeasureFooterTemplate,
   MeasureResultsNavigationTableTemplate,
   MultiRateNdrTemplate,
-  NdrFieldsTemplate,
+  MultiCategoryNdrTemplate,
   NdrTemplate,
   PageElement,
   RadioTemplate,
@@ -372,8 +372,8 @@ export const performanceRatePOM: NdrTemplate = {
 };
 
 // Rates for LTSS-6
-export const performanceRateTermStay: NdrFieldsTemplate = {
-  type: ElementType.NdrFields,
+export const performanceRateTermStay: MultiCategoryNdrTemplate = {
+  type: ElementType.MultiCategoryNdr,
   id: "measure-rates",
   assessments: [
     { id: "year-1", label: "18 to 64 Years" },
@@ -381,7 +381,7 @@ export const performanceRateTermStay: NdrFieldsTemplate = {
     { id: "year-3", label: "75 to 84 Years" },
     { id: "year-4", label: "85 years or older" },
   ],
-  fields: [
+  categories: [
     { id: "short-term", label: "Short Term Stay" },
     { id: "med-term", label: "Medium Term Stay" },
     { id: "long-term", label: "Long Term Stay" },
@@ -446,15 +446,15 @@ export const performanceRateFacilityTransitions: LengthOfStayRateTemplate = {
 };
 
 // Rates for HCBS-10
-export const performanceRateSelfDirection: NdrFieldsTemplate = {
-  type: ElementType.NdrFields,
+export const performanceRateSelfDirection: MultiCategoryNdrTemplate = {
+  type: ElementType.MultiCategoryNdr,
   id: "measure-rates",
   required: true,
   assessments: [
     { id: "self-direction-offer", label: "Self-Direction Offer" },
     { id: "self-direction-opt-in", label: "Self-Direction Opt-In" },
   ],
-  fields: [
+  categories: [
     { id: "self-label", label: "Total" },
     { id: "18-to-64-years", label: "18 to 64 Years" },
     { id: "65-years-or-older", label: "65 years or older" },

--- a/services/app-api/forms/2026/qms/qmsElements.ts
+++ b/services/app-api/forms/2026/qms/qmsElements.ts
@@ -8,7 +8,7 @@ import {
   MeasureDetailsTemplate,
   MeasureFooterTemplate,
   MeasureResultsNavigationTableTemplate,
-  NdrEnhancedTemplate,
+  MultiRateNdrTemplate,
   NdrFieldsTemplate,
   NdrTemplate,
   PageElement,
@@ -262,8 +262,8 @@ export const measureFooter: MeasureFooterTemplate = {
 };
 
 //Rates for LTSS-1
-export const performanceRatesAssessmentElements: NdrEnhancedTemplate = {
-  type: ElementType.NdrEnhanced,
+export const performanceRatesAssessmentElements: MultiRateNdrTemplate = {
+  type: ElementType.MultiRateNdr,
   id: "measure-rates",
   required: true,
   assessments: [
@@ -278,8 +278,8 @@ export const performanceRatesAssessmentElements: NdrEnhancedTemplate = {
   ],
 };
 
-export const exclusionRatesAssessmentElements: NdrEnhancedTemplate = {
-  type: ElementType.NdrEnhanced,
+export const exclusionRatesAssessmentElements: MultiRateNdrTemplate = {
+  type: ElementType.MultiRateNdr,
   id: "measure-rates",
   label: "Exclusion Rate",
   required: true,
@@ -296,8 +296,8 @@ export const exclusionRatesAssessmentElements: NdrEnhancedTemplate = {
 };
 
 //Rates for LTSS-2
-export const performanceRatesPersonPlanElements: NdrEnhancedTemplate = {
-  type: ElementType.NdrEnhanced,
+export const performanceRatesPersonPlanElements: MultiRateNdrTemplate = {
+  type: ElementType.MultiRateNdr,
   id: "measure-rates",
   required: true,
   assessments: [
@@ -312,8 +312,8 @@ export const performanceRatesPersonPlanElements: NdrEnhancedTemplate = {
   ],
 };
 
-export const exclusionRatesPersonPlanElements: NdrEnhancedTemplate = {
-  type: ElementType.NdrEnhanced,
+export const exclusionRatesPersonPlanElements: MultiRateNdrTemplate = {
+  type: ElementType.MultiRateNdr,
   id: "measure-rates",
   label: "Exclusion Rate",
   required: true,
@@ -330,8 +330,8 @@ export const exclusionRatesPersonPlanElements: NdrEnhancedTemplate = {
 };
 
 //Rates for LTSS-4
-export const performanceRatesReassessmentPlanElements: NdrEnhancedTemplate = {
-  type: ElementType.NdrEnhanced,
+export const performanceRatesReassessmentPlanElements: MultiRateNdrTemplate = {
+  type: ElementType.MultiRateNdr,
   id: "measure-rates",
   required: true,
   assessments: [
@@ -346,8 +346,8 @@ export const performanceRatesReassessmentPlanElements: NdrEnhancedTemplate = {
   ],
 };
 
-export const exclusionRatesPatientPlanElements: NdrEnhancedTemplate = {
-  type: ElementType.NdrEnhanced,
+export const exclusionRatesPatientPlanElements: MultiRateNdrTemplate = {
+  type: ElementType.MultiRateNdr,
   id: "measure-rates",
   label: "Exclusion Rate",
   required: true,

--- a/services/app-api/forms/2026/qms/qmsElements.ts
+++ b/services/app-api/forms/2026/qms/qmsElements.ts
@@ -264,7 +264,7 @@ export const measureFooter: MeasureFooterTemplate = {
 //Rates for LTSS-1
 export const performanceRatesAssessmentElements: MultiRateNdrTemplate = {
   type: ElementType.MultiRateNdr,
-  id: "measure-rates",
+  id: "measure-rates-assessment",
   required: true,
   assessments: [
     {
@@ -280,7 +280,7 @@ export const performanceRatesAssessmentElements: MultiRateNdrTemplate = {
 
 export const exclusionRatesAssessmentElements: MultiRateNdrTemplate = {
   type: ElementType.MultiRateNdr,
-  id: "measure-rates",
+  id: "measure-rates-exclusion",
   label: "Exclusion Rate",
   required: true,
   assessments: [
@@ -298,7 +298,7 @@ export const exclusionRatesAssessmentElements: MultiRateNdrTemplate = {
 //Rates for LTSS-2
 export const performanceRatesPersonPlanElements: MultiRateNdrTemplate = {
   type: ElementType.MultiRateNdr,
-  id: "measure-rates",
+  id: "measure-rates-performance",
   required: true,
   assessments: [
     {
@@ -314,7 +314,7 @@ export const performanceRatesPersonPlanElements: MultiRateNdrTemplate = {
 
 export const exclusionRatesPersonPlanElements: MultiRateNdrTemplate = {
   type: ElementType.MultiRateNdr,
-  id: "measure-rates",
+  id: "measure-rates-exclusion",
   label: "Exclusion Rate",
   required: true,
   assessments: [
@@ -332,7 +332,7 @@ export const exclusionRatesPersonPlanElements: MultiRateNdrTemplate = {
 //Rates for LTSS-4
 export const performanceRatesReassessmentPlanElements: MultiRateNdrTemplate = {
   type: ElementType.MultiRateNdr,
-  id: "measure-rates",
+  id: "measure-rates-reassessment",
   required: true,
   assessments: [
     {
@@ -348,7 +348,7 @@ export const performanceRatesReassessmentPlanElements: MultiRateNdrTemplate = {
 
 export const exclusionRatesPatientPlanElements: MultiRateNdrTemplate = {
   type: ElementType.MultiRateNdr,
-  id: "measure-rates",
+  id: "measure-rates-exclusion",
   label: "Exclusion Rate",
   required: true,
   assessments: [

--- a/services/app-api/forms/2026/tacm/tacmElements.ts
+++ b/services/app-api/forms/2026/tacm/tacmElements.ts
@@ -1,6 +1,6 @@
 import {
   ElementType,
-  NdrBasicTemplate,
+  PerformanceNdrTemplate,
   TextAreaBoxTemplate,
 } from "../../../types/reports";
 
@@ -14,8 +14,8 @@ export const conversionOfServiceUnitsField: TextAreaBoxTemplate = {
 };
 
 // Rates for Homemaker for HAPC-1 measure
-export const homemakerRate: NdrBasicTemplate = {
-  type: ElementType.NdrBasic,
+export const homemakerRate: PerformanceNdrTemplate = {
+  type: ElementType.PerformanceNdr,
   id: "homemaker-1-rate",
   required: true,
   label: "Homemaker",
@@ -32,8 +32,8 @@ export const homemakerRate: NdrBasicTemplate = {
 };
 
 // Rates for Homemaker for HAPC-2 measure
-export const homemakerHAPCH2Rate: NdrBasicTemplate = {
-  type: ElementType.NdrBasic,
+export const homemakerHAPCH2Rate: PerformanceNdrTemplate = {
+  type: ElementType.PerformanceNdr,
   id: "homemaker-2-rate",
   required: true,
   label: "Homemaker",
@@ -50,8 +50,8 @@ export const homemakerHAPCH2Rate: NdrBasicTemplate = {
 };
 
 // Rates for Home Health Aide or HAPCH-1 measure
-export const homeHealthAideRate: NdrBasicTemplate = {
-  type: ElementType.NdrBasic,
+export const homeHealthAideRate: PerformanceNdrTemplate = {
+  type: ElementType.PerformanceNdr,
   id: "home-health-aide-1-rate",
   required: true,
   label: "Home Health Aide",
@@ -68,8 +68,8 @@ export const homeHealthAideRate: NdrBasicTemplate = {
 };
 
 // Rates for Home Health Aide for HAPCH-2 measure
-export const homeHealthAideHAPCH2Rate: NdrBasicTemplate = {
-  type: ElementType.NdrBasic,
+export const homeHealthAideHAPCH2Rate: PerformanceNdrTemplate = {
+  type: ElementType.PerformanceNdr,
   id: "home-health-aide-2-rate",
   required: true,
   label: "Home Health Aide",
@@ -86,8 +86,8 @@ export const homeHealthAideHAPCH2Rate: NdrBasicTemplate = {
 };
 
 // Rates for Personal Care for HAPCH-1 measure
-export const personalCareRate: NdrBasicTemplate = {
-  type: ElementType.NdrBasic,
+export const personalCareRate: PerformanceNdrTemplate = {
+  type: ElementType.PerformanceNdr,
   id: "personal-care-1-rate",
   required: true,
   label: "Personal Care",
@@ -104,8 +104,8 @@ export const personalCareRate: NdrBasicTemplate = {
 };
 
 // Rates for Personal Care for HAPCH-2 measure
-export const personalCareHAPCH2Rate: NdrBasicTemplate = {
-  type: ElementType.NdrBasic,
+export const personalCareHAPCH2Rate: PerformanceNdrTemplate = {
+  type: ElementType.PerformanceNdr,
   id: "personal-care-2-rate",
   required: true,
   label: "Personal Care",
@@ -122,8 +122,8 @@ export const personalCareHAPCH2Rate: NdrBasicTemplate = {
 };
 
 // Rates for Habilitation for HAPCH-1 measure
-export const habilitationRate: NdrBasicTemplate = {
-  type: ElementType.NdrBasic,
+export const habilitationRate: PerformanceNdrTemplate = {
+  type: ElementType.PerformanceNdr,
   id: "habilitation-1-rate",
   required: true,
   label: "Habilitation",
@@ -140,8 +140,8 @@ export const habilitationRate: NdrBasicTemplate = {
 };
 
 // Rates for Habilitation for HAPCH-2 measure
-export const habilitationHAPCH2Rate: NdrBasicTemplate = {
-  type: ElementType.NdrBasic,
+export const habilitationHAPCH2Rate: PerformanceNdrTemplate = {
+  type: ElementType.PerformanceNdr,
   id: "habilitation-2-rate",
   required: true,
   label: "Habilitation",

--- a/services/app-api/forms/2026/wwl/wwl.ts
+++ b/services/app-api/forms/2026/wwl/wwl.ts
@@ -289,7 +289,7 @@ export const wwlReportTemplate: ReportBase = {
             "<p><b>Step 2.</b> Sum the waiting list days for all beneficiaries calculated in Step 1 to obtain the total number of days all beneficiaries newly enrolled or newly receiving HCBS were on the waiting list.</p>",
         },
         {
-          type: ElementType.NdrBasic,
+          type: ElementType.PerformanceNdr,
           id: "amount-of-time-rate",
           required: true,
           hintText: {

--- a/services/app-api/handlers/reports/buildReport.test.ts
+++ b/services/app-api/handlers/reports/buildReport.test.ts
@@ -1,4 +1,10 @@
-import { ReportOptions, ReportType } from "../../types/reports";
+import { booleanCombinations } from "../../testing/setupJest";
+import {
+  PageElement,
+  ReportOptions,
+  ReportType,
+  ReportBase,
+} from "../../types/reports";
 import { User } from "../../types/types";
 import { StateAbbr } from "../../utils/constants";
 import { validateReportPayload } from "../../utils/reportValidation";
@@ -8,12 +14,12 @@ jest.mock("../../utils/reportValidation", () => ({
   validateReportPayload: jest.fn().mockImplementation(async (rpt) => rpt),
 }));
 
-describe("Test create report handler", () => {
+describe("Build Report", () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  test("Test Successful create", async () => {
+  it("should successfully create a report", async () => {
     const state = "PA" as StateAbbr;
     const user = {
       fullName: "James Holden",
@@ -38,14 +44,8 @@ describe("Test create report handler", () => {
     expect(report.lastEditedBy).toBe("James Holden");
     expect(report.lastEditedByEmail).toBe("james.holden@test.com");
   });
-});
 
-describe("Test validation error", () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
-
-  test("Test that a validation failure throws invalid request error", async () => {
+  it("should throw an error when validation fails", async () => {
     // Manually throw validation error
     (validateReportPayload as jest.Mock).mockImplementationOnce(() => {
       throw new Error("you be havin some validatin errors");
@@ -66,4 +66,76 @@ describe("Test validation error", () => {
       await buildReport(ReportType.QMS, state, reportOptions, user);
     }).rejects.toThrow("Invalid request");
   });
+
+  it("should always have unique element IDs within a page", async () => {
+    const nonQmsReportTypes = Object.values(ReportType).filter(
+      (rt) => rt !== ReportType.QMS
+    );
+    const qmsOptionCombinations = [...booleanCombinations(4)].map(
+      ([a, b, c, d]) => ({ cahps: a, nciidd: b, nciad: c, pom: d })
+    );
+
+    const reportTypesAndOptions = [
+      // Every non-QMS report takes no options, so always has the same pages.
+      ...nonQmsReportTypes.map((type) => ({ type, opts: {} })),
+      // QMS needs to be built with different options to get all possible pages.
+      ...qmsOptionCombinations.map((opts) => ({ type: ReportType.QMS, opts })),
+    ];
+
+    for (const { type, opts } of reportTypesAndOptions) {
+      const options = {
+        name: "mock-report",
+        year: 2026,
+        options: opts,
+      };
+      const user = {
+        fullName: "Mock User",
+        email: "mock.user@test.com",
+      } as User;
+      const report = await buildReport(type, "CO", options, user);
+
+      assertReportHasUniqueElementIds(report);
+    }
+  });
 });
+
+function assertReportHasUniqueElementIds(report: ReportBase) {
+  for (const page of report.pages) {
+    if (!page.elements) continue;
+    const ids = [...iteratePageElements(page.elements)].map((el) => el.id);
+    const duplicates = Object.entries(Object_groupBy(ids, (id) => id))
+      .filter(([id, ids]) => ids.length > 1 && id !== "divider")
+      .map(([id, _ids]) => id);
+    if (duplicates.length > 0) {
+      console.dir(page, { depth: 10 });
+      throw new Error(
+        `Page ${page.id} of report type ${report.type} has multiple elements with this/these id/s: ${duplicates}`
+      );
+    }
+  }
+}
+
+/** Visit every element, recursing into checkedChildren as needed. */
+function* iteratePageElements(elements: PageElement[]): Generator<PageElement> {
+  for (const element of elements) {
+    yield element;
+    if ("choices" in element) {
+      for (const choice of element.choices) {
+        if (choice.checkedChildren) {
+          yield* iteratePageElements(choice.checkedChildren);
+        }
+      }
+    }
+  }
+}
+
+/** Ponyfill for `Object.groupBy()`. Please delete me soon. */
+function Object_groupBy<T>(arr: T[], selector: (el: T) => string) {
+  const groups: Record<string, T[]> = {};
+  for (const element of arr) {
+    const key = selector(element);
+    groups[key] ??= [];
+    groups[key].push(element);
+  }
+  return groups;
+}

--- a/services/app-api/testing/setupJest.ts
+++ b/services/app-api/testing/setupJest.ts
@@ -32,3 +32,28 @@ jest.mock("../libs/debug-lib", () => {
     flush: jest.fn(),
   };
 });
+
+/**
+ * Generate every combination of the given number of boolean values.
+ *
+ * Technically it's every _permutation_, but who's counting?
+ * @example
+ * for (let combo of booleanCombinations(2)) {
+ *  console.log(combo);
+ * }
+ * // [true, true]
+ * // [true, false]
+ * // [false, true]
+ * // [false, false]
+ */
+export function* booleanCombinations(count: number): Generator<boolean[]> {
+  if (count <= 1) {
+    yield [true];
+    yield [false];
+  } else {
+    for (let combo of booleanCombinations(count - 1)) {
+      yield [true, ...combo];
+      yield [false, ...combo];
+    }
+  }
+}

--- a/services/app-api/types/reports.ts
+++ b/services/app-api/types/reports.ts
@@ -260,7 +260,7 @@ export enum ElementType {
   LengthOfStayRate = "lengthOfStay",
   ReadmissionRate = "readmissionRate",
   NdrFields = "ndrFields",
-  NdrEnhanced = "ndrEnhanced",
+  MultiRateNdr = "multiRateNdr",
   Ndr = "ndr",
   PerformanceNdr = "performanceNdr",
   StatusAlert = "statusAlert",
@@ -293,7 +293,7 @@ export type PageElement =
   | LengthOfStayRateTemplate
   | ReadmissionRateTemplate
   | NdrFieldsTemplate
-  | NdrEnhancedTemplate
+  | MultiRateNdrTemplate
   | NdrTemplate
   | PerformanceNdrTemplate
   | StatusAlertTemplate
@@ -548,9 +548,9 @@ export type NdrFieldsTemplate = {
   required: boolean;
 };
 
-export type NdrEnhancedTemplate = {
+export type MultiRateNdrTemplate = {
   id: string;
-  type: ElementType.NdrEnhanced;
+  type: ElementType.MultiRateNdr;
   label?: string;
   helperText?: string;
   assessments: { label: string; id: string }[];

--- a/services/app-api/types/reports.ts
+++ b/services/app-api/types/reports.ts
@@ -262,7 +262,7 @@ export enum ElementType {
   NdrFields = "ndrFields",
   NdrEnhanced = "ndrEnhanced",
   Ndr = "ndr",
-  NdrBasic = "ndrBasic",
+  PerformanceNdr = "performanceNdr",
   StatusAlert = "statusAlert",
   Divider = "divider",
   SubmissionParagraph = "submissionParagraph",
@@ -295,7 +295,7 @@ export type PageElement =
   | NdrFieldsTemplate
   | NdrEnhancedTemplate
   | NdrTemplate
-  | NdrBasicTemplate
+  | PerformanceNdrTemplate
   | StatusAlertTemplate
   | DividerTemplate
   | SubmissionParagraphTemplate
@@ -521,13 +521,6 @@ export type ReadmissionRateTemplate = {
   errors?: Record<ReadmissionRateField, string>;
 };
 
-export const RateInputFieldNames = {
-  numerator: "numerator",
-  denominator: "denominator",
-} as const;
-export type RateInputFieldName =
-  (typeof RateInputFieldNames)[keyof typeof RateInputFieldNames];
-
 export type RateType = {
   id: string;
   numerator: number | undefined;
@@ -573,9 +566,9 @@ export type NdrTemplate = {
   required: boolean;
 };
 
-export type NdrBasicTemplate = {
+export type PerformanceNdrTemplate = {
   id: string;
-  type: ElementType.NdrBasic;
+  type: ElementType.PerformanceNdr;
   label?: string;
   answer?: RateData;
   hintText?: {

--- a/services/app-api/types/reports.ts
+++ b/services/app-api/types/reports.ts
@@ -259,7 +259,7 @@ export enum ElementType {
   MeasureFooter = "measureFooter",
   LengthOfStayRate = "lengthOfStay",
   ReadmissionRate = "readmissionRate",
-  NdrFields = "ndrFields",
+  MultiCategoryNdr = "multiCategoryNdr",
   MultiRateNdr = "multiRateNdr",
   Ndr = "ndr",
   PerformanceNdr = "performanceNdr",
@@ -292,7 +292,7 @@ export type PageElement =
   | MeasureFooterTemplate
   | LengthOfStayRateTemplate
   | ReadmissionRateTemplate
-  | NdrFieldsTemplate
+  | MultiCategoryNdrTemplate
   | MultiRateNdrTemplate
   | NdrTemplate
   | PerformanceNdrTemplate
@@ -538,11 +538,11 @@ export type RateSetData = {
   rates: RateType[];
 };
 
-export type NdrFieldsTemplate = {
+export type MultiCategoryNdrTemplate = {
   id: string;
-  type: ElementType.NdrFields;
+  type: ElementType.MultiCategoryNdr;
   assessments: { label: string; id: string }[];
-  fields: { label: string; id: string; autoCalc?: boolean }[];
+  categories: { label: string; id: string; autoCalc?: boolean }[];
   multiplier?: number;
   answer?: RateSetData[];
   required: boolean;

--- a/services/app-api/utils/reportValidation.ts
+++ b/services/app-api/utils/reportValidation.ts
@@ -184,8 +184,8 @@ const pageElementSchema = lazy((value: PageElement): Schema => {
       return ReadmissionRateSchema;
     case ElementType.NdrFields:
       return ndrFieldsRateSchema;
-    case ElementType.NdrEnhanced:
-      return ndrEnhancedRateSchema;
+    case ElementType.MultiRateNdr:
+      return multiRateNdrSchema;
     case ElementType.Ndr:
       return ndrRateSchema;
     case ElementType.PerformanceNdr:
@@ -434,8 +434,8 @@ const ndrFieldsRateSchema = object().shape({
     .notRequired(),
 });
 
-const ndrEnhancedRateSchema = object().shape({
-  type: string().required().matches(new RegExp(ElementType.NdrEnhanced)),
+const multiRateNdrSchema = object().shape({
+  type: string().required().matches(new RegExp(ElementType.MultiRateNdr)),
   id: string().required(),
   label: string().notRequired(),
   helperText: string().notRequired(),

--- a/services/app-api/utils/reportValidation.ts
+++ b/services/app-api/utils/reportValidation.ts
@@ -183,7 +183,7 @@ const pageElementSchema = lazy((value: PageElement): Schema => {
     case ElementType.ReadmissionRate:
       return ReadmissionRateSchema;
     case ElementType.MultiCategoryNdr:
-      return ndrFieldsRateSchema;
+      return multiCategoryNdrSchema;
     case ElementType.MultiRateNdr:
       return multiRateNdrSchema;
     case ElementType.Ndr:
@@ -396,7 +396,7 @@ const ReadmissionRateSchema = object().shape({
     .notRequired(),
 });
 
-const ndrFieldsRateSchema = object().shape({
+const multiCategoryNdrSchema = object().shape({
   type: string().required().matches(new RegExp(ElementType.MultiCategoryNdr)),
   id: string().required(),
   assessments: array()

--- a/services/app-api/utils/reportValidation.ts
+++ b/services/app-api/utils/reportValidation.ts
@@ -188,8 +188,8 @@ const pageElementSchema = lazy((value: PageElement): Schema => {
       return ndrEnhancedRateSchema;
     case ElementType.Ndr:
       return ndrRateSchema;
-    case ElementType.NdrBasic:
-      return ndrRateBasicSchema;
+    case ElementType.PerformanceNdr:
+      return performanceNdrSchema;
     case ElementType.StatusAlert:
       return statusAlertSchema;
     case ElementType.Divider:
@@ -476,8 +476,8 @@ const ndrRateSchema = object().shape({
     .notRequired(),
 });
 
-const ndrRateBasicSchema = object().shape({
-  type: string().required().matches(new RegExp(ElementType.NdrBasic)),
+const performanceNdrSchema = object().shape({
+  type: string().required().matches(new RegExp(ElementType.PerformanceNdr)),
   id: string().required(),
   label: string().notRequired(),
   required: boolean().required(),

--- a/services/app-api/utils/reportValidation.ts
+++ b/services/app-api/utils/reportValidation.ts
@@ -182,7 +182,7 @@ const pageElementSchema = lazy((value: PageElement): Schema => {
       return lengthOfStayRateSchema;
     case ElementType.ReadmissionRate:
       return ReadmissionRateSchema;
-    case ElementType.NdrFields:
+    case ElementType.MultiCategoryNdr:
       return ndrFieldsRateSchema;
     case ElementType.MultiRateNdr:
       return multiRateNdrSchema;
@@ -397,7 +397,7 @@ const ReadmissionRateSchema = object().shape({
 });
 
 const ndrFieldsRateSchema = object().shape({
-  type: string().required().matches(new RegExp(ElementType.NdrFields)),
+  type: string().required().matches(new RegExp(ElementType.MultiCategoryNdr)),
   id: string().required(),
   assessments: array()
     .of(
@@ -407,7 +407,7 @@ const ndrFieldsRateSchema = object().shape({
       })
     )
     .required(),
-  fields: array()
+  categories: array()
     .of(
       object().shape({
         id: string().required(),

--- a/services/app-api/utils/tests/sanitize.test.ts
+++ b/services/app-api/utils/tests/sanitize.test.ts
@@ -1,4 +1,5 @@
 import { buildReport } from "../../handlers/reports/buildReport";
+import { booleanCombinations } from "../../testing/setupJest";
 import { ReportType } from "../../types/reports";
 import { User } from "../../types/types";
 import { sanitizeArray, sanitizeObject, sanitizeString } from "../sanitize";
@@ -131,27 +132,3 @@ describe("Test sanitizeObject is friendly to the markup embedded in our report t
     }
   });
 });
-
-/**
- * Generate every combination of the given number of boolean values.
- *
- * @example
- * for (let combo of booleanCombinations(2)) {
- *  console.log(combo);
- * }
- * // [true, true]
- * // [true, false]
- * // [false, true]
- * // [false, false]
- */
-function* booleanCombinations(count: number): Generator<boolean[]> {
-  if (count <= 1) {
-    yield [true];
-    yield [false];
-  } else {
-    for (let combo of booleanCombinations(count - 1)) {
-      yield [true, ...combo];
-      yield [false, ...combo];
-    }
-  }
-}

--- a/services/database/scripts/renameNdrComponents.ts
+++ b/services/database/scripts/renameNdrComponents.ts
@@ -21,7 +21,7 @@ main();
  * and since we don't want this rename to break all existing reports,
  * this is not a mere code change; we need to modify existing report data.
  *
- * The components being renamed are some of our multi-input components.
+ * The components being renamed are some of our multi-input components:
  *
  * | Before          | After            | What is it                          |
  * |-----------------|------------------|-------------------------------------|
@@ -31,6 +31,8 @@ main();
  * | NDRFields       | MultiCategoryNdr | Many Ds, each with many NR pairs    |
  * | LengthOfStay    | [no rename]      | Actual vs Expected counts and rates |
  * | ReadmissionRate | [no rename]      | Observed vs Expected readmissions   |
+ *
+ * NDRFieldsTemplate.fields is also renamed, to MultiCategoryNdr.categories.
  */
 
 const client = createClient();
@@ -95,6 +97,10 @@ function updateComponentNames(report: Report) {
     for (const element of iterateElements(page.elements)) {
       if (element.type in NEW_NAMES) {
         element.type = NEW_NAMES[element.type];
+        if (element.type === "multiCategoryNdr") {
+          element.categories = element.fields;
+          delete element.fields;
+        }
         isChanged = true;
       }
     }
@@ -175,6 +181,8 @@ type Report = {
 /** An element on a report page. Imitates the real type used in the app. */
 type PageElement = {
   type: string;
+  fields?: unknown;
+  categories?: unknown;
   choices?: {
     checkedChildren?: PageElement[];
   }[];

--- a/services/database/scripts/renameNdrComponents.ts
+++ b/services/database/scripts/renameNdrComponents.ts
@@ -1,0 +1,181 @@
+import { createClient } from "./utils";
+import {
+  paginateScan,
+  BatchWriteCommand,
+  BatchWriteCommandInput,
+} from "@aws-sdk/lib-dynamodb";
+
+main();
+
+/*
+ * ENVIRONMENT VARIABLES TO SET:
+ * STAGE: "main", "val", or "production" as appropriate.
+ * AWS auth variables as usual.
+ */
+
+/*
+ * This migration will rename various report components for clarity.
+ *
+ * Since component names get baked into reports,
+ * (or at least their `type` fields do, which correspond to their names),
+ * and since we don't want this rename to break all existing reports,
+ * this is not a mere code change; we need to modify existing report data.
+ *
+ * The components being renamed are some of our multi-input components.
+ *
+ * | Before          | After            | What is it                          |
+ * |-----------------|------------------|-------------------------------------|
+ * | NDR             | [no rename]      | A Numerator, Denominator, and Rate  |
+ * | NDRBasic        | PerformanceNdr   | NDR + a performance target          |
+ * | NDREnhanced     | MultiRateNdr     | One D, with many NR pairs           |
+ * | NDRFields       | MultiCategoryNdr | Many Ds, each with many NR pairs    |
+ * | LengthOfStay    | [no rename]      | Actual vs Expected counts and rates |
+ * | ReadmissionRate | [no rename]      | Observed vs Expected readmissions   |
+ */
+
+const client = createClient();
+const logPrefix = () => new Date().toISOString() + " | ";
+
+async function main() {
+  console.info(`${logPrefix()}Updating reports...`);
+  let updatedCount = 0;
+
+  try {
+    for await (const batch of createBatches(reportsToUpdate())) {
+      await sendBatch(batch);
+      updatedCount += Object.values(batch.RequestItems).flat().length;
+    }
+
+    console.info(`${logPrefix()}Success. Updated ${updatedCount} reports.`);
+  } catch (error) {
+    console.error(error);
+    console.info(`${logPrefix()}Updated at least ${updatedCount} reports.`);
+  }
+}
+
+/** Find all reports of all types, and collect the ones that need updating */
+async function* reportsToUpdate() {
+  const reportTypes = ["qms", "tacm", "ci", "pcp", "wwl"];
+  for (const reportType of reportTypes) {
+    const tableName = `${process.env.STAGE}-${reportType}-reports`;
+    for await (const report of scanReports(tableName)) {
+      const needsUpdate = updateComponentNames(report);
+      if (needsUpdate) {
+        yield { tableName, Item: report };
+      }
+    }
+  }
+}
+
+/** Find all reports in a given Dynamo table */
+async function* scanReports(TableName: string) {
+  console.info(`${logPrefix}Scanning table ${TableName}...`);
+  let pageNumber = 0;
+  for await (const page of paginateScan({ client }, { TableName })) {
+    pageNumber += 1;
+    console.debug(`${logPrefix}${TableName} page ${pageNumber}...`);
+    yield* (page.Items ?? []) as Report[];
+  }
+}
+
+/**
+ * Modify a report's component names in-place.
+ * @returns `true` if a change was made, `false` otherwise.
+ */
+function updateComponentNames(report: Report) {
+  const NEW_NAMES: Record<string, string> = {
+    ndrBasic: "performanceNdr",
+    ndrEnhanced: "multiRateNdr",
+    ndrFields: "multiCategoryNdr",
+  };
+
+  let isChanged = false;
+
+  for (const page of report.pages ?? []) {
+    for (const element of iterateElements(page.elements)) {
+      if (element.type in NEW_NAMES) {
+        element.type = NEW_NAMES[element.type];
+        isChanged = true;
+      }
+    }
+  }
+
+  return isChanged;
+}
+
+/**
+ * Find all PageElements in the given array.
+ * Recurse into checkedChildren as needed.
+ */
+function* iterateElements(elements: PageElement[] | undefined) {
+  for (const element of elements ?? []) {
+    yield element;
+    for (const choice of element.choices ?? []) {
+      iterateElements(choice.checkedChildren);
+    }
+  }
+}
+
+/**
+ * Collect reports that need to be updated into batches of <= 25 items.
+ *
+ * Note: this can handle reports of different types,
+ * because a BatchWriteCommand can touch multiple tables.
+ */
+async function* createBatches(
+  iterator: AsyncGenerator<{ tableName: string; Item: Report }>
+) {
+  let batchNumber = 0;
+  let currentBatchSize = 0;
+  let RequestItems: Record<string, { PutRequest: { Item: any } }[]> = {};
+
+  for await (const { tableName, Item } of iterator) {
+    RequestItems[tableName] ??= [];
+    RequestItems[tableName].push({ PutRequest: { Item } });
+    currentBatchSize += 1;
+
+    if (currentBatchSize === 25) {
+      batchNumber += 1;
+      console.debug(`Saving batch ${batchNumber}...`);
+
+      yield { RequestItems };
+      RequestItems = {};
+    }
+  }
+
+  if (currentBatchSize > 0) {
+    yield { RequestItems };
+  }
+}
+
+/** Send a BatchWriteCommand containing the given reports. */
+async function sendBatch(params: BatchWriteCommandInput) {
+  console.trace(JSON.stringify(params, null, 2));
+
+  const command = new BatchWriteCommand(params);
+  const response = await client.send(command);
+
+  const unprocessedIds = Object.entries(response.UnprocessedItems ?? {}).map(
+    ([table, reqs]) => reqs.map((req) => `${table}:${req.PutRequest!.Item!.id}`)
+  );
+  if (unprocessedIds.length > 0) {
+    const message = `Batch write failed! The following reports were not updated: ${unprocessedIds.join(", ")}`;
+    throw new Error(message);
+  }
+}
+
+/** An HCBS report. Imitates the real type used in the app. */
+type Report = {
+  id: string;
+  pages: {
+    elements?: PageElement[];
+  }[];
+};
+
+/** An element on a report page. Imitates the real type used in the app. */
+type PageElement = {
+  type: string;
+  choices?: {
+    checkedChildren?: PageElement[];
+  }[];
+};

--- a/services/ui-src/src/components/component-inventory/elementObject.tsx
+++ b/services/ui-src/src/components/component-inventory/elementObject.tsx
@@ -15,7 +15,7 @@ import {
   MeasureFooterElement,
   Fields,
   ReadmissionRate,
-  NDRFields,
+  MultiCategoryNdr,
   MultiRateNdr,
   NDR,
   PerformanceNdr,
@@ -47,7 +47,7 @@ import {
   textAreaSection,
   numberFieldSection,
   radioFieldSection,
-  ndrFieldsSection,
+  multiCategoryNdrSection,
   multiRateNdrSection,
   ndrSection,
   performanceNdrSection,
@@ -491,29 +491,29 @@ export const elementObject: {
     ],
     pdfVariants: [<ExportedReportWrapper section={readmissionRateSection} />],
   },
-  [ElementType.NdrFields]: {
-    description: "Numerator/Denominator Fields to gather performance rates",
-    id: "id-ndr-fields",
+  [ElementType.MultiCategoryNdr]: {
+    description: "Multiple Denominators, each with multiple Numerators + Rates",
+    id: "id-multi-category-ndr",
     variants: [
-      <NDRFields
+      <MultiCategoryNdr
         updateElement={logNewElement}
         element={{
-          type: ElementType.NdrFields,
+          type: ElementType.MultiCategoryNdr,
           id: "measure-rates",
           assessments: [
             { id: "assessment-1", label: "First Assessment" },
             { id: "assessment-2", label: "Second Assessment" },
           ],
-          fields: [
-            { id: "field-1", label: "First Field" },
-            { id: "field-2", label: "Second Field" },
+          categories: [
+            { id: "category-1", label: "First Category" },
+            { id: "category-2", label: "Second Category" },
           ],
           required: true,
           multiplier: 1000,
         }}
       />,
     ],
-    pdfVariants: [<ExportedReportWrapper section={ndrFieldsSection} />],
+    pdfVariants: [<ExportedReportWrapper section={multiCategoryNdrSection} />],
   },
   [ElementType.MultiRateNdr]: {
     description: "Multiple Numerator + Rate fields with a shared Denominator",

--- a/services/ui-src/src/components/component-inventory/elementObject.tsx
+++ b/services/ui-src/src/components/component-inventory/elementObject.tsx
@@ -13,7 +13,7 @@ import {
   StatusTableElement,
   MeasureDetailsElement,
   MeasureFooterElement,
-  Fields,
+  LengthOfStay,
   ReadmissionRate,
   MultiCategoryNdr,
   MultiRateNdr,
@@ -444,7 +444,7 @@ export const elementObject: {
       "Numerator/Denominator Fields to gather LengthOfStayRate performance rates",
     id: "id-length-of-stay-rate",
     variants: [
-      <Fields
+      <LengthOfStay
         updateElement={logNewElement}
         element={{
           type: ElementType.LengthOfStayRate,

--- a/services/ui-src/src/components/component-inventory/elementObject.tsx
+++ b/services/ui-src/src/components/component-inventory/elementObject.tsx
@@ -18,7 +18,7 @@ import {
   NDRFields,
   NDREnhanced,
   NDR,
-  NDRBasic,
+  PerformanceNdr,
   StatusAlert,
   CheckboxField,
   EligibilityTableElement,
@@ -50,7 +50,7 @@ import {
   ndrFieldsSection,
   ndrEnhancedSection,
   ndrSection,
-  ndrBasicSection,
+  performanceNdrSection,
   lengthOfStayRateSection,
   readmissionRateSection,
   measureDetailsSection,
@@ -552,15 +552,15 @@ export const elementObject: {
     ],
     pdfVariants: [<ExportedReportWrapper section={ndrSection} />],
   },
-  [ElementType.NdrBasic]: {
+  [ElementType.PerformanceNdr]: {
     description:
-      "Basic and minimum target Numerator/Denominator Fields to gather performance rates",
-    id: "id-ndr-basic",
+      "Numerator/Denominator Fields to gather targeted performance rates",
+    id: "id-performance-ndr",
     variants: [
-      <NDRBasic
+      <PerformanceNdr
         updateElement={logNewElement}
         element={{
-          type: ElementType.NdrBasic,
+          type: ElementType.PerformanceNdr,
           id: "measure-rates",
           label: "Label",
           required: true,
@@ -573,10 +573,10 @@ export const elementObject: {
           displayRateAsPercent: true,
         }}
       />,
-      <NDRBasic
+      <PerformanceNdr
         updateElement={logNewElement}
         element={{
-          type: ElementType.NdrBasic,
+          type: ElementType.PerformanceNdr,
           id: "measure-rates",
           label: "Label",
           required: true,
@@ -591,7 +591,7 @@ export const elementObject: {
         }}
       />,
     ],
-    pdfVariants: [<ExportedReportWrapper section={ndrBasicSection} />],
+    pdfVariants: [<ExportedReportWrapper section={performanceNdrSection} />],
   },
   [ElementType.StatusAlert]: {
     description: "Different Alert Types",

--- a/services/ui-src/src/components/component-inventory/elementObject.tsx
+++ b/services/ui-src/src/components/component-inventory/elementObject.tsx
@@ -16,7 +16,7 @@ import {
   Fields,
   ReadmissionRate,
   NDRFields,
-  NDREnhanced,
+  MultiRateNdr,
   NDR,
   PerformanceNdr,
   StatusAlert,
@@ -48,7 +48,7 @@ import {
   numberFieldSection,
   radioFieldSection,
   ndrFieldsSection,
-  ndrEnhancedSection,
+  multiRateNdrSection,
   ndrSection,
   performanceNdrSection,
   lengthOfStayRateSection,
@@ -515,15 +515,14 @@ export const elementObject: {
     ],
     pdfVariants: [<ExportedReportWrapper section={ndrFieldsSection} />],
   },
-  [ElementType.NdrEnhanced]: {
-    description:
-      "Enhanced Numerator/Denominator Fields to gather performance rates",
-    id: "id-ndr-enhanced",
+  [ElementType.MultiRateNdr]: {
+    description: "Multiple Numerator + Rate fields with a shared Denominator",
+    id: "id-multi-rate-ndr",
     variants: [
-      <NDREnhanced
+      <MultiRateNdr
         updateElement={logNewElement}
         element={{
-          type: ElementType.NdrEnhanced,
+          type: ElementType.MultiRateNdr,
           id: "measure-rates",
           assessments: [
             { id: "assessment-1", label: "First Assessment" },
@@ -534,7 +533,7 @@ export const elementObject: {
         }}
       />,
     ],
-    pdfVariants: [<ExportedReportWrapper section={ndrEnhancedSection} />],
+    pdfVariants: [<ExportedReportWrapper section={multiRateNdrSection} />],
   },
   [ElementType.Ndr]: {
     description: "Numerator/Denominator Fields to gather performance rates",

--- a/services/ui-src/src/components/component-inventory/pdfElementSectionHelpers.tsx
+++ b/services/ui-src/src/components/component-inventory/pdfElementSectionHelpers.tsx
@@ -177,13 +177,13 @@ export const ndrSection: FormPageTemplate = {
   ],
 };
 
-export const ndrBasicSection: FormPageTemplate = {
-  id: "mock-ndrBasic-id",
-  navTitle: "mock-ndrBasic-title",
+export const performanceNdrSection: FormPageTemplate = {
+  id: "mock-performanceNdr-id",
+  navTitle: "mock-performanceNdr-title",
   type: PageType.Standard,
   elements: [
     {
-      type: ElementType.NdrBasic,
+      type: ElementType.PerformanceNdr,
       id: "measure-rates",
       label: "Label",
       required: true,

--- a/services/ui-src/src/components/component-inventory/pdfElementSectionHelpers.tsx
+++ b/services/ui-src/src/components/component-inventory/pdfElementSectionHelpers.tsx
@@ -123,21 +123,21 @@ export const checkboxFieldSection: FormPageTemplate = {
   ],
 };
 
-export const ndrFieldsSection: FormPageTemplate = {
-  id: "mock-ndrFields-id",
-  navTitle: "mock-ndrFields-title",
+export const multiCategoryNdrSection: FormPageTemplate = {
+  id: "mock-multiCategoryNdr-id",
+  navTitle: "mock-multiCategoryNdr-title",
   type: PageType.Standard,
   elements: [
     {
-      type: ElementType.NdrFields,
+      type: ElementType.MultiCategoryNdr,
       id: "measure-rates",
       assessments: [
         { id: "assessment-1", label: "First Assessment" },
         { id: "assessment-2", label: "Second Assessment" },
       ],
-      fields: [
-        { id: "field-1", label: "First Field" },
-        { id: "field-2", label: "Second Field" },
+      categories: [
+        { id: "category-1", label: "First Category" },
+        { id: "category-2", label: "Second Category" },
       ],
       required: true,
       multiplier: 1000,

--- a/services/ui-src/src/components/component-inventory/pdfElementSectionHelpers.tsx
+++ b/services/ui-src/src/components/component-inventory/pdfElementSectionHelpers.tsx
@@ -145,13 +145,13 @@ export const ndrFieldsSection: FormPageTemplate = {
   ],
 };
 
-export const ndrEnhancedSection: FormPageTemplate = {
-  id: "mock-ndrEnhanced-id",
-  navTitle: "mock-ndrEnhanced-title",
+export const multiRateNdrSection: FormPageTemplate = {
+  id: "mock-multiRateNdr-id",
+  navTitle: "mock-multiRateNdr-title",
   type: PageType.Standard,
   elements: [
     {
-      type: ElementType.NdrEnhanced,
+      type: ElementType.MultiRateNdr,
       id: "measure-rates",
       assessments: [
         { id: "assessment-1", label: "First Assessment" },

--- a/services/ui-src/src/components/export/ExportedReportElements.test.tsx
+++ b/services/ui-src/src/components/export/ExportedReportElements.test.tsx
@@ -13,7 +13,7 @@ import {
   mockLengthOfStayFields,
   mockReadmissionRateFields,
   mockNDR,
-  mockNDRBasics,
+  mockPerformanceNdr,
   mockNDRFields,
 } from "utils/testing/mockRates";
 
@@ -110,9 +110,9 @@ describe("Test ExportedReportElements", () => {
     expect(screen.getByText("Expected Readmission Rate")).toBeInTheDocument();
     expect(screen.getAllByText("Not answered")).toHaveLength(9);
   });
-  test("Test render NDR Basic element", () => {
-    section.elements.push(mockNDRBasics);
-    const element = renderElements(section, mockNDRBasics);
+  test("Test render Performance NDR element", () => {
+    section.elements.push(mockPerformanceNdr);
+    const element = renderElements(section, mockPerformanceNdr);
     render(element);
     expect(screen.getByText("Result")).toBeInTheDocument();
     expect(screen.getAllByText("Not answered")).toHaveLength(2);

--- a/services/ui-src/src/components/export/ExportedReportElements.test.tsx
+++ b/services/ui-src/src/components/export/ExportedReportElements.test.tsx
@@ -9,7 +9,7 @@ import {
   PageType,
 } from "types";
 import {
-  mockedNDREnhanced,
+  mockedMultiRateNdr,
   mockLengthOfStayFields,
   mockReadmissionRateFields,
   mockNDR,
@@ -74,9 +74,9 @@ describe("Test ExportedReportElements", () => {
     expect(screen.getByRole("row", { name: "Denominator 3" })).toBeVisible();
     expect(screen.getByRole("row", { name: /Rate .* 1\.67/ })).toBeVisible();
   });
-  test("Test render NDR Enhanced element", () => {
-    section.elements.push(mockedNDREnhanced);
-    const element = renderElements(section, mockedNDREnhanced);
+  test("Test render Multi-Rate NDR element", () => {
+    section.elements.push(mockedMultiRateNdr);
+    const element = renderElements(section, mockedMultiRateNdr);
     render(element);
 
     expect(

--- a/services/ui-src/src/components/export/ExportedReportElements.test.tsx
+++ b/services/ui-src/src/components/export/ExportedReportElements.test.tsx
@@ -14,7 +14,7 @@ import {
   mockReadmissionRateFields,
   mockNDR,
   mockPerformanceNdr,
-  mockNDRFields,
+  mockMultiCategoryNdr,
 } from "utils/testing/mockRates";
 
 const section = {
@@ -88,9 +88,9 @@ describe("Test ExportedReportElements", () => {
     expect(screen.getAllByText("2")).toHaveLength(2);
     expect(screen.getAllByText("Not answered")).toHaveLength(1);
   });
-  test("Test render NDR Fields element", () => {
-    section.elements.push(mockNDRFields);
-    const element = renderElements(section, mockNDRFields);
+  test("Test render Multi-Category NDR element", () => {
+    section.elements.push(mockMultiCategoryNdr);
+    const element = renderElements(section, mockMultiCategoryNdr);
     render(element);
 
     expect(screen.getAllByText("Denominator (Assessment 1)")).toHaveLength(2);

--- a/services/ui-src/src/components/export/ExportedReportElements.tsx
+++ b/services/ui-src/src/components/export/ExportedReportElements.tsx
@@ -7,7 +7,7 @@ import { NDRExport } from "components/rates/types/NDR";
 import { notAnsweredText } from "../../constants";
 import { NDREnhancedExport } from "components/rates/types/NDREnhanced";
 import { NDRFieldExport } from "components/rates/types/NDRFields";
-import { NDRBasicExport } from "components/rates/types/NDRBasic";
+import { PerformanceNdrExport } from "components/rates/types/PerformanceNdr";
 import { EligibilityTableElementExport } from "components/report/WwlComponents/EligibilityTable";
 import { CheckboxExport } from "components/fields/CheckboxField";
 import { ListInputExport } from "components/fields/ListInput";
@@ -31,7 +31,7 @@ const renderElementList = [
   ElementType.Ndr,
   ElementType.LengthOfStayRate,
   ElementType.ReadmissionRate,
-  ElementType.NdrBasic,
+  ElementType.PerformanceNdr,
   ElementType.MeasureDetails,
   ElementType.SubHeader,
   ElementType.EligibilityTable,
@@ -66,8 +66,8 @@ export const renderElements = (
       return FieldsExport(element);
     case ElementType.ReadmissionRate:
       return ReadmissionRateExport(element);
-    case ElementType.NdrBasic:
-      return NDRBasicExport(element, section.navTitle);
+    case ElementType.PerformanceNdr:
+      return PerformanceNdrExport(element, section.navTitle);
     case ElementType.MeasureDetails:
       return MeasureDetailsExport(section);
     case ElementType.EligibilityTable:

--- a/services/ui-src/src/components/export/ExportedReportElements.tsx
+++ b/services/ui-src/src/components/export/ExportedReportElements.tsx
@@ -1,7 +1,7 @@
 import { Heading } from "@chakra-ui/react";
 import { MeasureDetailsExport } from "components/report/MeasureDetails";
 import { ElementType, MeasurePageTemplate, PageElement } from "types";
-import { FieldsExport } from "components/rates/types/Fields";
+import { LengthOfStayExport } from "components/rates/types/LengthOfStay";
 import { ReadmissionRateExport } from "components/rates/types/ReadmissionRate";
 import { NDRExport } from "components/rates/types/NDR";
 import { notAnsweredText } from "../../constants";
@@ -63,7 +63,7 @@ export const renderElements = (
     case ElementType.Ndr:
       return NDRExport(element);
     case ElementType.LengthOfStayRate:
-      return FieldsExport(element);
+      return LengthOfStayExport(element);
     case ElementType.ReadmissionRate:
       return ReadmissionRateExport(element);
     case ElementType.PerformanceNdr:

--- a/services/ui-src/src/components/export/ExportedReportElements.tsx
+++ b/services/ui-src/src/components/export/ExportedReportElements.tsx
@@ -5,7 +5,7 @@ import { FieldsExport } from "components/rates/types/Fields";
 import { ReadmissionRateExport } from "components/rates/types/ReadmissionRate";
 import { NDRExport } from "components/rates/types/NDR";
 import { notAnsweredText } from "../../constants";
-import { NDREnhancedExport } from "components/rates/types/NDREnhanced";
+import { MultiRateNdrExport } from "components/rates/types/MultiRateNdr";
 import { NDRFieldExport } from "components/rates/types/NDRFields";
 import { PerformanceNdrExport } from "components/rates/types/PerformanceNdr";
 import { EligibilityTableElementExport } from "components/report/WwlComponents/EligibilityTable";
@@ -26,7 +26,7 @@ const tableElementList = [
 
 const renderElementList = [
   ...tableElementList,
-  ElementType.NdrEnhanced,
+  ElementType.MultiRateNdr,
   ElementType.NdrFields,
   ElementType.Ndr,
   ElementType.LengthOfStayRate,
@@ -56,8 +56,8 @@ export const renderElements = (
           {element.text}
         </Heading>
       );
-    case ElementType.NdrEnhanced:
-      return NDREnhancedExport(element);
+    case ElementType.MultiRateNdr:
+      return MultiRateNdrExport(element);
     case ElementType.NdrFields:
       return NDRFieldExport(element);
     case ElementType.Ndr:

--- a/services/ui-src/src/components/export/ExportedReportElements.tsx
+++ b/services/ui-src/src/components/export/ExportedReportElements.tsx
@@ -6,7 +6,7 @@ import { ReadmissionRateExport } from "components/rates/types/ReadmissionRate";
 import { NDRExport } from "components/rates/types/NDR";
 import { notAnsweredText } from "../../constants";
 import { MultiRateNdrExport } from "components/rates/types/MultiRateNdr";
-import { NDRFieldExport } from "components/rates/types/NDRFields";
+import { MultiCategoryNdrExport } from "components/rates/types/MultiCategoryNdr";
 import { PerformanceNdrExport } from "components/rates/types/PerformanceNdr";
 import { EligibilityTableElementExport } from "components/report/WwlComponents/EligibilityTable";
 import { CheckboxExport } from "components/fields/CheckboxField";
@@ -27,7 +27,7 @@ const tableElementList = [
 const renderElementList = [
   ...tableElementList,
   ElementType.MultiRateNdr,
-  ElementType.NdrFields,
+  ElementType.MultiCategoryNdr,
   ElementType.Ndr,
   ElementType.LengthOfStayRate,
   ElementType.ReadmissionRate,
@@ -58,8 +58,8 @@ export const renderElements = (
       );
     case ElementType.MultiRateNdr:
       return MultiRateNdrExport(element);
-    case ElementType.NdrFields:
-      return NDRFieldExport(element);
+    case ElementType.MultiCategoryNdr:
+      return MultiCategoryNdrExport(element);
     case ElementType.Ndr:
       return NDRExport(element);
     case ElementType.LengthOfStayRate:

--- a/services/ui-src/src/components/index.ts
+++ b/services/ui-src/src/components/index.ts
@@ -50,7 +50,7 @@ export { NotificationsPage } from "./pages/Admin/NotificationsPage";
 // report
 export { Fields } from "../components/rates/types/Fields";
 export { ReadmissionRate } from "../components/rates/types/ReadmissionRate";
-export { NDRFields } from "../components/rates/types/NDRFields";
+export { MultiCategoryNdr } from "./rates/types/MultiCategoryNdr";
 export { MultiRateNdr } from "../components/rates/types/MultiRateNdr";
 export { NDR } from "../components/rates/types/NDR";
 export { PerformanceNdr } from "./rates/types/PerformanceNdr";

--- a/services/ui-src/src/components/index.ts
+++ b/services/ui-src/src/components/index.ts
@@ -51,7 +51,7 @@ export { NotificationsPage } from "./pages/Admin/NotificationsPage";
 export { Fields } from "../components/rates/types/Fields";
 export { ReadmissionRate } from "../components/rates/types/ReadmissionRate";
 export { NDRFields } from "../components/rates/types/NDRFields";
-export { NDREnhanced } from "../components/rates/types/NDREnhanced";
+export { MultiRateNdr } from "../components/rates/types/MultiRateNdr";
 export { NDR } from "../components/rates/types/NDR";
 export { PerformanceNdr } from "./rates/types/PerformanceNdr";
 export { MeasureDetailsElement } from "./report/MeasureDetails";

--- a/services/ui-src/src/components/index.ts
+++ b/services/ui-src/src/components/index.ts
@@ -48,7 +48,7 @@ export { NotFoundPage } from "./pages/NotFound/NotFoundPage";
 export { ProfilePage } from "./pages/Profile/ProfilePage";
 export { NotificationsPage } from "./pages/Admin/NotificationsPage";
 // report
-export { Fields } from "../components/rates/types/Fields";
+export { LengthOfStay } from "./rates/types/LengthOfStay";
 export { ReadmissionRate } from "../components/rates/types/ReadmissionRate";
 export { MultiCategoryNdr } from "./rates/types/MultiCategoryNdr";
 export { MultiRateNdr } from "../components/rates/types/MultiRateNdr";

--- a/services/ui-src/src/components/index.ts
+++ b/services/ui-src/src/components/index.ts
@@ -53,7 +53,7 @@ export { ReadmissionRate } from "../components/rates/types/ReadmissionRate";
 export { NDRFields } from "../components/rates/types/NDRFields";
 export { NDREnhanced } from "../components/rates/types/NDREnhanced";
 export { NDR } from "../components/rates/types/NDR";
-export { NDRBasic } from "../components/rates/types/NDRBasic";
+export { PerformanceNdr } from "./rates/types/PerformanceNdr";
 export { MeasureDetailsElement } from "./report/MeasureDetails";
 export { MeasureFooterElement } from "./report/MeasureFooter";
 export { MeasureReplacementModal } from "./report/MeasureReplacementModal";

--- a/services/ui-src/src/components/rates/types/LengthOfStay.test.tsx
+++ b/services/ui-src/src/components/rates/types/LengthOfStay.test.tsx
@@ -1,5 +1,5 @@
 import { act, render, screen } from "@testing-library/react";
-import { Fields } from "./Fields";
+import { LengthOfStay } from "./LengthOfStay";
 import userEvent from "@testing-library/user-event";
 import {
   ElementType,
@@ -38,11 +38,11 @@ const LengthOfStayWrapper = ({
     updateSpy(updatedElement);
     setElement({ ...element, ...updatedElement });
   };
-  return <Fields element={element} updateElement={onChange} />;
+  return <LengthOfStay element={element} updateElement={onChange} />;
 };
 
-describe("<Fields />", () => {
-  describe("Test Fields component", () => {
+describe("<LengthOfStay />", () => {
+  describe("Test LengthOfStay component", () => {
     beforeEach(() => {
       jest.clearAllMocks();
     });

--- a/services/ui-src/src/components/rates/types/LengthOfStay.tsx
+++ b/services/ui-src/src/components/rates/types/LengthOfStay.tsx
@@ -16,7 +16,9 @@ import {
 import { ExportRateTable } from "components/export/ExportedReportTable";
 import { ErrorMessages } from "../../../constants";
 
-export const Fields = (props: PageElementProps<LengthOfStayRateTemplate>) => {
+export const LengthOfStay = (
+  props: PageElementProps<LengthOfStayRateTemplate>
+) => {
   const { disabled, updateElement } = props;
   const { labels, answer } = props.element;
 
@@ -215,8 +217,8 @@ export const Fields = (props: PageElementProps<LengthOfStayRateTemplate>) => {
   );
 };
 
-//The pdf rendering of Fields component
-export const FieldsExport = (element: LengthOfStayRateTemplate) => {
+//The pdf rendering of LengthOfStay component
+export const LengthOfStayExport = (element: LengthOfStayRateTemplate) => {
   const label = "Performance Rates";
   const rows = [
     {

--- a/services/ui-src/src/components/rates/types/MultiCategoryNdr.test.tsx
+++ b/services/ui-src/src/components/rates/types/MultiCategoryNdr.test.tsx
@@ -1,21 +1,21 @@
 import { act, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { ElementType, NdrFieldsTemplate } from "types";
+import { ElementType, MultiCategoryNdrTemplate } from "types";
 import { testA11y } from "utils/testing/commonTests";
-import { NDRFields } from "./NDRFields";
+import { MultiCategoryNdr } from "./MultiCategoryNdr";
 import { useState } from "react";
 import { ErrorMessages } from "../../../constants";
 
-const mockElementTemplate: NdrFieldsTemplate = {
+const mockElementTemplate: MultiCategoryNdrTemplate = {
   id: "mock-perf-id",
-  type: ElementType.NdrFields,
+  type: ElementType.MultiCategoryNdr,
   assessments: [
     { id: "year-1", label: "18 to 64 Years" },
     { id: "year-2", label: "65 to 74 Years" },
     { id: "year-3", label: "75 to 84 Years" },
     { id: "year-4", label: "85 years or older" },
   ],
-  fields: [
+  categories: [
     { id: "short-term", label: "Short Term Stay" },
     { id: "med-term", label: "Medium Term Stay" },
     { id: "long-term", label: "Long Term Stay" },
@@ -25,24 +25,28 @@ const mockElementTemplate: NdrFieldsTemplate = {
 };
 const updateSpy = jest.fn();
 
-const NdrFieldsWrapper = ({ template }: { template: NdrFieldsTemplate }) => {
+const MultiCategoryNdrWrapper = ({
+  template,
+}: {
+  template: MultiCategoryNdrTemplate;
+}) => {
   const [element, setElement] = useState(template);
   const onChange = (updatedElement: Partial<typeof element>) => {
     updateSpy(updatedElement);
     setElement({ ...element, ...updatedElement });
   };
-  return <NDRFields element={element} updateElement={onChange} />;
+  return <MultiCategoryNdr element={element} updateElement={onChange} />;
 };
 
-describe("<NDRFields />", () => {
-  describe("Test NDRFields component", () => {
+describe("<MultiCategoryNdr />", () => {
+  describe("Test MultiCategoryNdr component", () => {
     beforeEach(() => {
       jest.clearAllMocks();
     });
 
-    test("NDRFields is visible", () => {
-      render(<NdrFieldsWrapper template={mockElementTemplate} />);
-      const { assessments, fields } = mockElementTemplate;
+    test("MultiCategoryNdr is visible", () => {
+      render(<MultiCategoryNdrWrapper template={mockElementTemplate} />);
+      const { assessments, categories } = mockElementTemplate;
 
       for (const assess of assessments) {
         expect(
@@ -50,15 +54,15 @@ describe("<NDRFields />", () => {
             name: `Denominator (${assess.label})`,
           })
         ).toHaveLength(4);
-        for (const field of fields) {
+        for (const category of categories) {
           expect(
             screen.getByRole("textbox", {
-              name: `Numerator: ${field.label} (${assess.label})`,
+              name: `Numerator: ${category.label} (${assess.label})`,
             })
           ).toBeInTheDocument();
           expect(
             screen.getByRole("textbox", {
-              name: `${field.label} Rate (${assess.label})`,
+              name: `${category.label} Rate (${assess.label})`,
             })
           ).toBeInTheDocument();
         }
@@ -66,8 +70,8 @@ describe("<NDRFields />", () => {
     });
 
     test("Rate should calculate", async () => {
-      render(<NdrFieldsWrapper template={mockElementTemplate} />);
-      const { assessments, fields } = mockElementTemplate;
+      render(<MultiCategoryNdrWrapper template={mockElementTemplate} />);
+      const { assessments, categories } = mockElementTemplate;
 
       if (assessments && assessments.length > 0) {
         const denom = screen.getAllByRole("textbox", {
@@ -77,20 +81,20 @@ describe("<NDRFields />", () => {
         expect(denom).toHaveValue("1");
 
         const num = screen.getByRole("textbox", {
-          name: `Numerator: ${fields?.[0].label} (${assessments[0].label})`,
+          name: `Numerator: ${categories?.[0].label} (${assessments[0].label})`,
         });
         await act(async () => await userEvent.type(num, "1"));
         expect(num).toHaveValue("1");
 
         const rate = screen.getByRole("textbox", {
-          name: `${fields?.[0].label} Rate (${assessments[0].label})`,
+          name: `${categories?.[0].label} Rate (${assessments[0].label})`,
         });
         expect(rate).toHaveValue("1000");
       }
     });
 
     test("Error should show if the denominator is 0", async () => {
-      render(<NdrFieldsWrapper template={mockElementTemplate} />);
+      render(<MultiCategoryNdrWrapper template={mockElementTemplate} />);
       const { assessments } = mockElementTemplate;
 
       if (assessments && assessments.length > 0) {
@@ -113,8 +117,8 @@ describe("<NDRFields />", () => {
   });
 
   test("Rate should be 0 if both numerator and denominator are 0", async () => {
-    render(<NdrFieldsWrapper template={mockElementTemplate} />);
-    const { assessments, fields } = mockElementTemplate;
+    render(<MultiCategoryNdrWrapper template={mockElementTemplate} />);
+    const { assessments, categories } = mockElementTemplate;
 
     if (assessments && assessments.length > 0) {
       const denom = screen.getAllByRole("textbox", {
@@ -124,17 +128,17 @@ describe("<NDRFields />", () => {
       expect(denom).toHaveValue("0");
 
       const num = screen.getByRole("textbox", {
-        name: `Numerator: ${fields?.[0].label} (${assessments[0].label})`,
+        name: `Numerator: ${categories?.[0].label} (${assessments[0].label})`,
       });
       await act(async () => await userEvent.type(num, "0"));
       expect(num).toHaveValue("0");
 
       const rate = screen.getByRole("textbox", {
-        name: `${fields?.[0].label} Rate (${assessments[0].label})`,
+        name: `${categories?.[0].label} Rate (${assessments[0].label})`,
       });
       expect(rate).toHaveValue("0.00");
     }
   });
 
-  testA11y(<NdrFieldsWrapper template={mockElementTemplate} />);
+  testA11y(<MultiCategoryNdrWrapper template={mockElementTemplate} />);
 });

--- a/services/ui-src/src/components/rates/types/MultiCategoryNdr.tsx
+++ b/services/ui-src/src/components/rates/types/MultiCategoryNdr.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import { Box, Divider, Heading, Stack } from "@chakra-ui/react";
 import { TextField as CmsdsTextField } from "@cmsgov/design-system";
-import { NdrFieldsTemplate } from "types";
+import { MultiCategoryNdrTemplate } from "types";
 import {
   parseNumber,
   removeNoise,
@@ -26,16 +26,18 @@ const FieldNames = {
 } as const;
 type FieldName = (typeof FieldNames)[keyof typeof FieldNames];
 
-export const NDRFields = (props: PageElementProps<NdrFieldsTemplate>) => {
+export const MultiCategoryNdr = (
+  props: PageElementProps<MultiCategoryNdrTemplate>
+) => {
   const { disabled, element, updateElement } = props;
-  const { assessments, answer, multiplier = 1, fields } = element;
+  const { assessments, answer, multiplier = 1, categories } = element;
 
   const stringifyAnswer = (newAnswer: typeof answer) => {
     return assessments.map((assessment, i) => ({
       id: assessment.id,
       denominator: stringifyInput(newAnswer?.[i].denominator),
-      rates: fields.map((field, j) => ({
-        id: `${assessment.id}.${field.id}`,
+      rates: categories.map((category, j) => ({
+        id: `${assessment.id}.${category.id}`,
         numerator: stringifyInput(newAnswer?.[i].rates[j].numerator),
         rate: stringifyResult(newAnswer?.[i].rates[j].rate),
       })),
@@ -179,16 +181,16 @@ export const NDRFields = (props: PageElementProps<NdrFieldsTemplate>) => {
                 disabled={disabled}
               ></CmsdsTextField>
 
-              {fields.map((field, fieldIndex) => {
-                const rateObject = rateSet.rates[fieldIndex];
-                const errorObject = errorSet.rates[fieldIndex];
+              {categories.map((category, catIndex) => {
+                const rateObject = rateSet.rates[catIndex];
+                const errorObject = errorSet.rates[catIndex];
 
                 return (
-                  <Stack key={`${assess.id}.${field.id}`} gap="2rem">
-                    <Heading variant="nestedHeading">{field.label}</Heading>
+                  <Stack key={`${assess.id}.${category.id}`} gap="2rem">
+                    <Heading variant="nestedHeading">{category.label}</Heading>
                     <CmsdsTextField
-                      label={`Numerator: ${field.label} (${assess.label})`}
-                      name={`${assessIndex}.rates.${fieldIndex}.${FieldNames.numerator}`}
+                      label={`Numerator: ${category.label} (${assess.label})`}
+                      name={`${assessIndex}.rates.${catIndex}.${FieldNames.numerator}`}
                       onChange={onChangeHandler}
                       onBlur={onChangeHandler}
                       value={rateObject.numerator}
@@ -197,13 +199,13 @@ export const NDRFields = (props: PageElementProps<NdrFieldsTemplate>) => {
                     ></CmsdsTextField>
                     <CmsdsTextField
                       label={`Denominator (${assess.label})`}
-                      name={`${assessIndex}.rates.${fieldIndex}.denominator`}
+                      name={`${assessIndex}.rates.${catIndex}.denominator`}
                       value={rateSet.denominator}
                       disabled
                     ></CmsdsTextField>
                     <CmsdsTextField
-                      label={`${field.label} Rate (${assess.label})`}
-                      name={`${assessIndex}.rates.${fieldIndex}.rate`}
+                      label={`${category.label} Rate (${assess.label})`}
+                      name={`${assessIndex}.rates.${catIndex}.rate`}
                       hint="Auto-calculates"
                       value={rateObject.rate}
                       disabled
@@ -220,19 +222,19 @@ export const NDRFields = (props: PageElementProps<NdrFieldsTemplate>) => {
   );
 };
 
-//The pdf rendering of NDRField component
-export const NDRFieldExport = (element: NdrFieldsTemplate) => {
+//The pdf rendering of MultiCategoryNdr component
+export const MultiCategoryNdrExport = (element: MultiCategoryNdrTemplate) => {
   const buildData = element.assessments?.map((assess) => {
     const data = element.answer?.find((item) =>
       item.rates[0].id.includes(assess.id)
     );
-    const rates = element.fields.map((field) => {
-      const rate = data?.rates.find((rate) => rate.id.includes(field.id));
+    const rates = element.categories.map((category) => {
+      const rate = data?.rates.find((rate) => rate.id.includes(category.id));
       return {
-        fieldLabel: field.label,
+        fieldLabel: category.label,
         rate: [
           {
-            indicator: `Numerator: ${field.label} (${assess.label})`,
+            indicator: `Numerator: ${category.label} (${assess.label})`,
             response: rate?.numerator,
           },
           {
@@ -241,7 +243,7 @@ export const NDRFieldExport = (element: NdrFieldsTemplate) => {
             helperText: "Auto-calculates",
           },
           {
-            indicator: `${field.label} Rate (${assess.label})`,
+            indicator: `${category.label} Rate (${assess.label})`,
             response: stringifyResult(rate?.rate),
             helperText: "Auto-calculates",
           },

--- a/services/ui-src/src/components/rates/types/MultiRateNdr.test.tsx
+++ b/services/ui-src/src/components/rates/types/MultiRateNdr.test.tsx
@@ -1,14 +1,14 @@
 import { act, render, screen } from "@testing-library/react";
-import { NDREnhanced } from "./NDREnhanced";
+import { MultiRateNdr } from "./MultiRateNdr";
 import userEvent from "@testing-library/user-event";
-import { ElementType, NdrEnhancedTemplate } from "types";
+import { ElementType, MultiRateNdrTemplate } from "types";
 import { testA11y } from "utils/testing/commonTests";
 import { useState } from "react";
 import { ErrorMessages } from "../../../constants";
 
-const mockedElement: NdrEnhancedTemplate = {
+const mockedElement: MultiRateNdrTemplate = {
   id: "mock-perf-id",
-  type: ElementType.NdrEnhanced,
+  type: ElementType.MultiRateNdr,
   label: "test label",
   helperText: "helper text",
   required: true,
@@ -19,14 +19,14 @@ const updateSpy = jest.fn();
 const NdrEnhancedWrapper = ({
   template,
 }: {
-  template: NdrEnhancedTemplate;
+  template: MultiRateNdrTemplate;
 }) => {
   const [element, setElement] = useState(template);
   const onChange = (updatedElement: Partial<typeof element>) => {
     updateSpy(updatedElement);
     setElement({ ...element, ...updatedElement });
   };
-  return <NDREnhanced element={element} updateElement={onChange} />;
+  return <MultiRateNdr element={element} updateElement={onChange} />;
 };
 
 describe("<NDREnhanced />", () => {

--- a/services/ui-src/src/components/rates/types/MultiRateNdr.tsx
+++ b/services/ui-src/src/components/rates/types/MultiRateNdr.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import { Divider, Heading, Stack, Text } from "@chakra-ui/react";
 import { TextField as CmsdsTextField } from "@cmsgov/design-system";
-import { NdrEnhancedTemplate } from "types";
+import { MultiRateNdrTemplate } from "types";
 import {
   parseNumber,
   removeNoise,
@@ -26,7 +26,7 @@ const FieldNames = {
 } as const;
 type FieldName = (typeof FieldNames)[keyof typeof FieldNames];
 
-export const NDREnhanced = (props: PageElementProps<NdrEnhancedTemplate>) => {
+export const MultiRateNdr = (props: PageElementProps<MultiRateNdrTemplate>) => {
   const { disabled, element, updateElement } = props;
   const { assessments, answer, helperText, label } = element;
 
@@ -201,7 +201,7 @@ export const NDREnhanced = (props: PageElementProps<NdrEnhancedTemplate>) => {
 };
 
 //The pdf rendering of NDREnchanced component
-export const NDREnhancedExport = (element: NdrEnhancedTemplate) => {
+export const MultiRateNdrExport = (element: MultiRateNdrTemplate) => {
   const label = element.label ?? "Performance Rates";
 
   const buildData = element.assessments?.map(

--- a/services/ui-src/src/components/rates/types/MultiRateNdr.tsx
+++ b/services/ui-src/src/components/rates/types/MultiRateNdr.tsx
@@ -200,7 +200,7 @@ export const MultiRateNdr = (props: PageElementProps<MultiRateNdrTemplate>) => {
   );
 };
 
-//The pdf rendering of NDREnchanced component
+//The pdf rendering of a MultiRateNdr component
 export const MultiRateNdrExport = (element: MultiRateNdrTemplate) => {
   const label = element.label ?? "Performance Rates";
 

--- a/services/ui-src/src/components/rates/types/NDR.tsx
+++ b/services/ui-src/src/components/rates/types/NDR.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import { Divider, Heading, Stack } from "@chakra-ui/react";
 import { TextField as CmsdsTextField } from "@cmsgov/design-system";
-import { NdrTemplate, RateInputFieldName, RateInputFieldNames } from "types";
+import { NdrTemplate } from "types";
 import {
   parseNumber,
   removeNoise,
@@ -11,6 +11,12 @@ import {
 import { PageElementProps } from "components/report/Elements";
 import { autoCalculatesText, ErrorMessages } from "../../../constants";
 import { ExportRateTable } from "components/export/ExportedReportTable";
+
+const FieldNames = {
+  numerator: "numerator",
+  denominator: "denominator",
+} as const;
+type FieldName = (typeof FieldNames)[keyof typeof FieldNames];
 
 export const NDR = (props: PageElementProps<NdrTemplate>) => {
   const { disabled, element, updateElement } = props;
@@ -33,7 +39,7 @@ export const NDR = (props: PageElementProps<NdrTemplate>) => {
   const [errors, setErrors] = useState(initialErrors);
 
   const updatedDisplayValue = (input: HTMLInputElement) => {
-    const fieldType = input.name as RateInputFieldName;
+    const fieldType = input.name as FieldName;
     const stringValue = input.value;
 
     const newDisplayValue = structuredClone(displayValue);
@@ -46,7 +52,7 @@ export const NDR = (props: PageElementProps<NdrTemplate>) => {
     input: HTMLInputElement,
     newDisplayValue: typeof displayValue
   ) => {
-    const fieldType = input.name as RateInputFieldName;
+    const fieldType = input.name as FieldName;
     const stringValue = input.value;
     const parsedValue = parseNumber(stringValue);
     let errorMessage;
@@ -61,18 +67,18 @@ export const NDR = (props: PageElementProps<NdrTemplate>) => {
     ) {
       return {
         ...errors,
-        [RateInputFieldNames.numerator]: ErrorMessages.denominatorZero(),
-        [RateInputFieldNames.denominator]: "",
+        [FieldNames.numerator]: ErrorMessages.denominatorZero(),
+        [FieldNames.denominator]: "",
       };
     } else if (
-      fieldType === RateInputFieldNames.denominator &&
+      fieldType === FieldNames.denominator &&
       parsedValue !== 0 &&
-      errors[RateInputFieldNames.numerator] === ErrorMessages.denominatorZero()
+      errors[FieldNames.numerator] === ErrorMessages.denominatorZero()
     ) {
       return {
         ...errors,
-        [RateInputFieldNames.numerator]: "",
-        [RateInputFieldNames.denominator]: "",
+        [FieldNames.numerator]: "",
+        [FieldNames.denominator]: "",
       };
     } else {
       errorMessage = "";
@@ -138,7 +144,7 @@ export const NDR = (props: PageElementProps<NdrTemplate>) => {
           <Heading variant="subHeader">Performance Rate: {label}</Heading>
           <CmsdsTextField
             label="Numerator"
-            name={RateInputFieldNames.numerator}
+            name={FieldNames.numerator}
             onChange={onChangeHandler}
             onBlur={onChangeHandler}
             value={displayValue.numerator}
@@ -147,7 +153,7 @@ export const NDR = (props: PageElementProps<NdrTemplate>) => {
           ></CmsdsTextField>
           <CmsdsTextField
             label="Denominator"
-            name={RateInputFieldNames.denominator}
+            name={FieldNames.denominator}
             onChange={onChangeHandler}
             onBlur={onChangeHandler}
             value={displayValue.denominator}

--- a/services/ui-src/src/components/rates/types/NDREnhanced.tsx
+++ b/services/ui-src/src/components/rates/types/NDREnhanced.tsx
@@ -1,11 +1,7 @@
 import React, { useState } from "react";
 import { Divider, Heading, Stack, Text } from "@chakra-ui/react";
 import { TextField as CmsdsTextField } from "@cmsgov/design-system";
-import {
-  NdrEnhancedTemplate,
-  RateInputFieldName,
-  RateInputFieldNames,
-} from "types";
+import { NdrEnhancedTemplate } from "types";
 import {
   parseNumber,
   removeNoise,
@@ -23,6 +19,12 @@ import {
   ExportRateTable,
 } from "components/export/ExportedReportTable";
 import { autoPopulatedText, ErrorMessages } from "../../../constants";
+
+const FieldNames = {
+  numerator: "numerator",
+  denominator: "denominator",
+} as const;
+type FieldName = (typeof FieldNames)[keyof typeof FieldNames];
 
 export const NDREnhanced = (props: PageElementProps<NdrEnhancedTemplate>) => {
   const { disabled, element, updateElement } = props;
@@ -48,18 +50,18 @@ export const NDREnhanced = (props: PageElementProps<NdrEnhancedTemplate>) => {
   const updatedDisplayValue = (input: HTMLInputElement) => {
     /*
      * The name will look like "denominator" or
-     * or "1.numerator". The last part is always a RateInputFieldName.
+     * or "1.numerator". The last part is always a FieldName.
      * If there are two parts, the first will be an index into answer.rates.
      */
     const parts = input.name.split(".");
-    const fieldType = parts.at(-1) as RateInputFieldName;
+    const fieldType = parts.at(-1) as FieldName;
     const assessIndex = parts.length > 1 ? Number(parts.at(0)) : undefined;
     const stringValue = input.value;
     const { errorMessage } = validateNumber(stringValue, true);
 
     const newDisplayValue = structuredClone(displayValue);
     const newErrorObject = structuredClone(errors);
-    if (fieldType === RateInputFieldNames.denominator) {
+    if (fieldType === FieldNames.denominator) {
       newDisplayValue.denominator = stringValue;
       newErrorObject.denominator = errorMessage;
     } else {
@@ -148,7 +150,7 @@ export const NDREnhanced = (props: PageElementProps<NdrEnhancedTemplate>) => {
       <Stack gap="2rem">
         <CmsdsTextField
           label={`${label ? `${label}s` : "Performance Rates"} Denominator`}
-          name={RateInputFieldNames.denominator}
+          name={FieldNames.denominator}
           onChange={onChangeHandler}
           onBlur={onChangeHandler}
           value={displayValue.denominator}
@@ -168,7 +170,7 @@ export const NDREnhanced = (props: PageElementProps<NdrEnhancedTemplate>) => {
               </Heading>
               <CmsdsTextField
                 label="Numerator"
-                name={`${index}.${RateInputFieldNames.numerator}`}
+                name={`${index}.${FieldNames.numerator}`}
                 onChange={onChangeHandler}
                 onBlur={onChangeHandler}
                 value={value.numerator}

--- a/services/ui-src/src/components/rates/types/NDRFields.tsx
+++ b/services/ui-src/src/components/rates/types/NDRFields.tsx
@@ -1,11 +1,7 @@
 import React, { useState } from "react";
 import { Box, Divider, Heading, Stack } from "@chakra-ui/react";
 import { TextField as CmsdsTextField } from "@cmsgov/design-system";
-import {
-  NdrFieldsTemplate,
-  RateInputFieldName,
-  RateInputFieldNames,
-} from "types";
+import { NdrFieldsTemplate } from "types";
 import {
   parseNumber,
   removeNoise,
@@ -23,6 +19,12 @@ import {
   ExportRateTable,
 } from "components/export/ExportedReportTable";
 import { ErrorMessages } from "../../../constants";
+
+const FieldNames = {
+  numerator: "numerator",
+  denominator: "denominator",
+} as const;
+type FieldName = (typeof FieldNames)[keyof typeof FieldNames];
 
 export const NDRFields = (props: PageElementProps<NdrFieldsTemplate>) => {
   const { disabled, element, updateElement } = props;
@@ -53,7 +55,7 @@ export const NDRFields = (props: PageElementProps<NdrFieldsTemplate>) => {
      * answer[i].rates array.
      */
     const parts = input.name.split(".");
-    const fieldType = parts.at(-1) as RateInputFieldName;
+    const fieldType = parts.at(-1) as FieldName;
     const assessIndex = Number(parts.at(0));
     const fieldIndex = parts.length > 2 ? Number(parts.at(2)) : undefined;
     const stringValue = input.value;
@@ -62,7 +64,7 @@ export const NDRFields = (props: PageElementProps<NdrFieldsTemplate>) => {
     // displayValue corresponds to the inputs on screen. Its values are strings.
     const newDisplayValue = structuredClone(displayValue);
     const newErrors = structuredClone(errors);
-    if (fieldType === RateInputFieldNames.denominator) {
+    if (fieldType === FieldNames.denominator) {
       newDisplayValue[assessIndex].denominator = stringValue;
       newErrors[assessIndex].denominator = errorMessage;
     } else {
@@ -169,7 +171,7 @@ export const NDRFields = (props: PageElementProps<NdrFieldsTemplate>) => {
 
               <CmsdsTextField
                 label={`Denominator (${assess.label})`}
-                name={`${assessIndex}.${RateInputFieldNames.denominator}`}
+                name={`${assessIndex}.${FieldNames.denominator}`}
                 onChange={onChangeHandler}
                 onBlur={onChangeHandler}
                 value={rateSet.denominator}
@@ -186,7 +188,7 @@ export const NDRFields = (props: PageElementProps<NdrFieldsTemplate>) => {
                     <Heading variant="nestedHeading">{field.label}</Heading>
                     <CmsdsTextField
                       label={`Numerator: ${field.label} (${assess.label})`}
-                      name={`${assessIndex}.rates.${fieldIndex}.${RateInputFieldNames.numerator}`}
+                      name={`${assessIndex}.rates.${fieldIndex}.${FieldNames.numerator}`}
                       onChange={onChangeHandler}
                       onBlur={onChangeHandler}
                       value={rateObject.numerator}

--- a/services/ui-src/src/components/rates/types/PerformanceNdr.test.tsx
+++ b/services/ui-src/src/components/rates/types/PerformanceNdr.test.tsx
@@ -1,14 +1,14 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { NDRBasic, NDRBasicExport } from "./NDRBasic";
-import { ElementType, NdrBasicTemplate } from "types";
+import { PerformanceNdr, PerformanceNdrExport } from "./PerformanceNdr";
+import { ElementType, PerformanceNdrTemplate } from "types";
 import { testA11y } from "utils/testing/commonTests";
 import { useState } from "react";
 import { ErrorMessages } from "../../../constants";
 
-const mockedElement: NdrBasicTemplate = {
+const mockedElement: PerformanceNdrTemplate = {
   id: "mock-perf-id",
-  type: ElementType.NdrBasic,
+  type: ElementType.PerformanceNdr,
   label: "test label",
   multiplier: 100,
   minPerformanceLevel: 90,
@@ -25,23 +25,27 @@ const mockedElement: NdrBasicTemplate = {
 };
 const updateSpy = jest.fn();
 
-const NdrBasicWrapper = ({ template }: { template: NdrBasicTemplate }) => {
+const PerformanceNdrWrapper = ({
+  template,
+}: {
+  template: PerformanceNdrTemplate;
+}) => {
   const [element, setElement] = useState(template);
   const onChange = (updatedElement: Partial<typeof element>) => {
     updateSpy(updatedElement);
     setElement({ ...element, ...updatedElement });
   };
-  return <NDRBasic element={element} updateElement={onChange} />;
+  return <PerformanceNdr element={element} updateElement={onChange} />;
 };
 
-describe("<NDRBasic />", () => {
-  describe("Test NDRBasic component", () => {
+describe("<PerformanceNdr />", () => {
+  describe("Test PerformanceNdr component", () => {
     beforeEach(() => {
       jest.clearAllMocks();
     });
 
-    test("NDRBasic is visible", () => {
-      render(<NdrBasicWrapper template={mockedElement} />);
+    test("PerformanceNdr is visible", () => {
+      render(<PerformanceNdrWrapper template={mockedElement} />);
       expect(
         screen.getByRole("textbox", { name: "Numerator" })
       ).toBeInTheDocument();
@@ -55,7 +59,7 @@ describe("<NDRBasic />", () => {
     });
 
     test("Rate should calculate", async () => {
-      render(<NdrBasicWrapper template={mockedElement} />);
+      render(<PerformanceNdrWrapper template={mockedElement} />);
 
       const numerator = screen.getByRole("textbox", { name: "Numerator" });
       await userEvent.type(numerator, "1");
@@ -70,7 +74,7 @@ describe("<NDRBasic />", () => {
     });
 
     test("Rate should not display a decimal point if it is not needed", async () => {
-      render(<NdrBasicWrapper template={mockedElement} />);
+      render(<PerformanceNdrWrapper template={mockedElement} />);
 
       const numerator = screen.getByRole("textbox", { name: "Numerator" });
       await userEvent.type(numerator, "27");
@@ -84,7 +88,7 @@ describe("<NDRBasic />", () => {
 
     test("Rate should not display as a percent normally", async () => {
       render(
-        <NdrBasicWrapper
+        <PerformanceNdrWrapper
           template={{ ...mockedElement, displayRateAsPercent: false }}
         />
       );
@@ -101,7 +105,7 @@ describe("<NDRBasic />", () => {
 
     test("Rate should display as a percent when appropriate", async () => {
       render(
-        <NdrBasicWrapper
+        <PerformanceNdrWrapper
           template={{ ...mockedElement, displayRateAsPercent: true }}
         />
       );
@@ -117,7 +121,7 @@ describe("<NDRBasic />", () => {
     });
 
     test("Rate should display trailing decimal places if the value is rounded to 0", async () => {
-      render(<NdrBasicWrapper template={mockedElement} />);
+      render(<PerformanceNdrWrapper template={mockedElement} />);
 
       const numerator = screen.getByRole("textbox", { name: "Numerator" });
       await userEvent.type(numerator, "4");
@@ -130,7 +134,7 @@ describe("<NDRBasic />", () => {
     });
 
     test("Proper error should show if a required field is empty", async () => {
-      render(<NdrBasicWrapper template={mockedElement} />);
+      render(<PerformanceNdrWrapper template={mockedElement} />);
 
       const denominator = screen.getByRole("textbox", { name: "Denominator" });
       await userEvent.type(denominator, "4");
@@ -140,7 +144,7 @@ describe("<NDRBasic />", () => {
     });
 
     test("Proper error should show if a field has invalid input", async () => {
-      render(<NdrBasicWrapper template={mockedElement} />);
+      render(<PerformanceNdrWrapper template={mockedElement} />);
 
       const denominator = screen.getByRole("textbox", { name: "Denominator" });
       await userEvent.type(denominator, "string");
@@ -149,7 +153,7 @@ describe("<NDRBasic />", () => {
     });
 
     test("Error should show if the denominator is 0 and the numerator is not 0, and also clear", async () => {
-      render(<NdrBasicWrapper template={mockedElement} />);
+      render(<PerformanceNdrWrapper template={mockedElement} />);
 
       const numerator = screen.getByRole("textbox", { name: "Numerator" });
       await userEvent.type(numerator, "4");
@@ -166,7 +170,7 @@ describe("<NDRBasic />", () => {
     });
 
     test("Rate should be 0 if both numerator and denominator are 0", async () => {
-      render(<NdrBasicWrapper template={mockedElement} />);
+      render(<PerformanceNdrWrapper template={mockedElement} />);
 
       const numerator = screen.getByRole("textbox", { name: "Numerator" });
       await userEvent.type(numerator, "0");
@@ -181,12 +185,12 @@ describe("<NDRBasic />", () => {
 
   describe("Miniminum Performance Rate Alerts", () => {
     test("Alert should be not visible if rate is empty", async () => {
-      render(<NdrBasicWrapper template={mockedElement} />);
+      render(<PerformanceNdrWrapper template={mockedElement} />);
       expect(screen.queryByRole("alert")).not.toBeInTheDocument();
     });
 
     test("Success Alert should be visible if minimum rate is met", async () => {
-      render(<NdrBasicWrapper template={mockedElement} />);
+      render(<PerformanceNdrWrapper template={mockedElement} />);
 
       const numerator = screen.getByRole("textbox", { name: "Numerator" });
       await userEvent.type(numerator, "9");
@@ -200,7 +204,7 @@ describe("<NDRBasic />", () => {
     });
 
     test("Warning Alert should be visible if minimum rate is met", async () => {
-      render(<NdrBasicWrapper template={mockedElement} />);
+      render(<PerformanceNdrWrapper template={mockedElement} />);
 
       const numerator = screen.getByRole("textbox", { name: "Numerator" });
       await userEvent.type(numerator, "1");
@@ -214,7 +218,7 @@ describe("<NDRBasic />", () => {
     });
 
     test("Conditional children should be visible if minimum rate is met", async () => {
-      render(<NdrBasicWrapper template={mockedElement} />);
+      render(<PerformanceNdrWrapper template={mockedElement} />);
 
       const numerator = screen.getByRole("textbox", { name: "Numerator" });
       await userEvent.type(numerator, "1");
@@ -226,10 +230,10 @@ describe("<NDRBasic />", () => {
     });
   });
 
-  describe("NDRBasicExport", () => {
+  describe("PerformanceNdr Export", () => {
     it("should render a normal rate", () => {
       render(
-        NDRBasicExport({
+        PerformanceNdrExport({
           ...mockedElement,
           displayRateAsPercent: false,
           answer: {
@@ -247,7 +251,7 @@ describe("<NDRBasic />", () => {
 
     it("should render a percentage", () => {
       render(
-        NDRBasicExport({
+        PerformanceNdrExport({
           ...mockedElement,
           displayRateAsPercent: true,
           answer: {
@@ -263,5 +267,5 @@ describe("<NDRBasic />", () => {
     });
   });
 
-  testA11y(<NdrBasicWrapper template={mockedElement} />);
+  testA11y(<PerformanceNdrWrapper template={mockedElement} />);
 });

--- a/services/ui-src/src/components/rates/types/PerformanceNdr.tsx
+++ b/services/ui-src/src/components/rates/types/PerformanceNdr.tsx
@@ -1,13 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { Heading, Stack } from "@chakra-ui/react";
 import { TextField as CmsdsTextField } from "@cmsgov/design-system";
-import {
-  NdrBasicTemplate,
-  RateInputFieldNameBasic,
-  RateInputFieldNamesBasic,
-  AlertTypes,
-  PageElement,
-} from "types";
+import { PerformanceNdrTemplate, AlertTypes, PageElement } from "types";
 import {
   parseNumber,
   removeNoise,
@@ -19,7 +13,15 @@ import { ErrorMessages, autoCalculatesText } from "../../../constants";
 import { Alert, Page } from "components";
 import { ExportRateTable } from "components/export/ExportedReportTable";
 
-export const NDRBasic = (props: PageElementProps<NdrBasicTemplate>) => {
+const FieldNames = {
+  numerator: "numerator",
+  denominator: "denominator",
+} as const;
+type FieldName = (typeof FieldNames)[keyof typeof FieldNames];
+
+export const PerformanceNdr = (
+  props: PageElementProps<PerformanceNdrTemplate>
+) => {
   const { updateElement, disabled, element } = props;
   const {
     label,
@@ -46,7 +48,7 @@ export const NDRBasic = (props: PageElementProps<NdrBasicTemplate>) => {
   const [errors, setErrors] = useState(initialErrors);
 
   const updatedDisplayValue = (input: HTMLInputElement) => {
-    const fieldType = input.name as RateInputFieldNameBasic;
+    const fieldType = input.name as FieldName;
     const stringValue = input.value;
 
     const newDisplayValue = structuredClone(displayValue);
@@ -59,7 +61,7 @@ export const NDRBasic = (props: PageElementProps<NdrBasicTemplate>) => {
     input: HTMLInputElement,
     newDisplayValue: typeof displayValue
   ) => {
-    const fieldType = input.name as RateInputFieldNameBasic;
+    const fieldType = input.name as FieldName;
     const stringValue = input.value;
     const parsedValue = parseNumber(stringValue);
     let errorMessage;
@@ -74,19 +76,18 @@ export const NDRBasic = (props: PageElementProps<NdrBasicTemplate>) => {
     ) {
       return {
         ...errors,
-        [RateInputFieldNamesBasic.numerator]: ErrorMessages.denominatorZero(),
-        [RateInputFieldNamesBasic.denominator]: "",
+        [FieldNames.numerator]: ErrorMessages.denominatorZero(),
+        [FieldNames.denominator]: "",
       };
     } else if (
-      fieldType === RateInputFieldNamesBasic.denominator &&
+      fieldType === FieldNames.denominator &&
       parsedValue !== 0 &&
-      errors[RateInputFieldNamesBasic.numerator] ===
-        ErrorMessages.denominatorZero()
+      errors[FieldNames.numerator] === ErrorMessages.denominatorZero()
     ) {
       return {
         ...errors,
-        [RateInputFieldNamesBasic.numerator]: "",
-        [RateInputFieldNamesBasic.denominator]: "",
+        [FieldNames.numerator]: "",
+        [FieldNames.denominator]: "",
       };
     } else {
       errorMessage = "";
@@ -216,7 +217,7 @@ export const NDRBasic = (props: PageElementProps<NdrBasicTemplate>) => {
           <CmsdsTextField
             label="Numerator"
             hint={hintText?.numHint}
-            name={RateInputFieldNamesBasic.numerator}
+            name={FieldNames.numerator}
             onChange={onChangeHandler}
             onBlur={onChangeHandler}
             value={displayValue.numerator}
@@ -226,7 +227,7 @@ export const NDRBasic = (props: PageElementProps<NdrBasicTemplate>) => {
           <CmsdsTextField
             label="Denominator"
             hint={hintText?.denomHint}
-            name={RateInputFieldNamesBasic.denominator}
+            name={FieldNames.denominator}
             onChange={onChangeHandler}
             onBlur={onChangeHandler}
             value={displayValue.denominator}
@@ -251,8 +252,11 @@ export const NDRBasic = (props: PageElementProps<NdrBasicTemplate>) => {
   );
 };
 
-//The pdf rendering of NDRBasic component
-export const NDRBasicExport = (element: NdrBasicTemplate, caption?: string) => {
+//The pdf rendering of PerformanceNdr component
+export const PerformanceNdrExport = (
+  element: PerformanceNdrTemplate,
+  caption?: string
+) => {
   const label = element.label ?? "";
 
   const minimum =

--- a/services/ui-src/src/components/report/Page.tsx
+++ b/services/ui-src/src/components/report/Page.tsx
@@ -28,7 +28,7 @@ import {
   TextAreaField,
   TextField,
   StatusAlert,
-  Fields,
+  LengthOfStay,
   ReadmissionRate,
   NDR,
   PerformanceNdr,
@@ -100,7 +100,7 @@ export const Page = ({ id, setElements, elements }: Props) => {
       case ElementType.MeasureFooter:
         return <MeasureFooterElement {...{ disabled, element }} />;
       case ElementType.LengthOfStayRate:
-        return <Fields {...{ updateElement, disabled, element }} />;
+        return <LengthOfStay {...{ updateElement, disabled, element }} />;
       case ElementType.ReadmissionRate:
         return <ReadmissionRate {...{ updateElement, disabled, element }} />;
       case ElementType.MultiCategoryNdr:

--- a/services/ui-src/src/components/report/Page.tsx
+++ b/services/ui-src/src/components/report/Page.tsx
@@ -32,7 +32,7 @@ import {
   ReadmissionRate,
   NDR,
   PerformanceNdr,
-  NDRFields,
+  MultiCategoryNdr,
   MultiRateNdr,
   CheckboxField,
   ListInput,
@@ -103,8 +103,8 @@ export const Page = ({ id, setElements, elements }: Props) => {
         return <Fields {...{ updateElement, disabled, element }} />;
       case ElementType.ReadmissionRate:
         return <ReadmissionRate {...{ updateElement, disabled, element }} />;
-      case ElementType.NdrFields:
-        return <NDRFields {...{ updateElement, disabled, element }} />;
+      case ElementType.MultiCategoryNdr:
+        return <MultiCategoryNdr {...{ updateElement, disabled, element }} />;
       case ElementType.MultiRateNdr:
         return <MultiRateNdr {...{ updateElement, disabled, element }} />;
       case ElementType.Ndr:

--- a/services/ui-src/src/components/report/Page.tsx
+++ b/services/ui-src/src/components/report/Page.tsx
@@ -33,7 +33,7 @@ import {
   NDR,
   PerformanceNdr,
   NDRFields,
-  NDREnhanced,
+  MultiRateNdr,
   CheckboxField,
   ListInput,
   EligibilityTableElement,
@@ -105,8 +105,8 @@ export const Page = ({ id, setElements, elements }: Props) => {
         return <ReadmissionRate {...{ updateElement, disabled, element }} />;
       case ElementType.NdrFields:
         return <NDRFields {...{ updateElement, disabled, element }} />;
-      case ElementType.NdrEnhanced:
-        return <NDREnhanced {...{ updateElement, disabled, element }} />;
+      case ElementType.MultiRateNdr:
+        return <MultiRateNdr {...{ updateElement, disabled, element }} />;
       case ElementType.Ndr:
         return <NDR {...{ updateElement, disabled, element }} />;
       case ElementType.PerformanceNdr:

--- a/services/ui-src/src/components/report/Page.tsx
+++ b/services/ui-src/src/components/report/Page.tsx
@@ -31,7 +31,7 @@ import {
   Fields,
   ReadmissionRate,
   NDR,
-  NDRBasic,
+  PerformanceNdr,
   NDRFields,
   NDREnhanced,
   CheckboxField,
@@ -109,8 +109,8 @@ export const Page = ({ id, setElements, elements }: Props) => {
         return <NDREnhanced {...{ updateElement, disabled, element }} />;
       case ElementType.Ndr:
         return <NDR {...{ updateElement, disabled, element }} />;
-      case ElementType.NdrBasic:
-        return <NDRBasic {...{ updateElement, disabled, element }} />;
+      case ElementType.PerformanceNdr:
+        return <PerformanceNdr {...{ updateElement, disabled, element }} />;
       case ElementType.StatusAlert:
         return <StatusAlert {...{ element }} />;
       case ElementType.Divider:

--- a/services/ui-src/src/types/report.ts
+++ b/services/ui-src/src/types/report.ts
@@ -191,7 +191,7 @@ export enum ElementType {
   NdrFields = "ndrFields",
   NdrEnhanced = "ndrEnhanced",
   Ndr = "ndr",
-  NdrBasic = "ndrBasic",
+  PerformanceNdr = "performanceNdr",
   StatusAlert = "statusAlert",
   Divider = "divider",
   SubmissionParagraph = "submissionParagraph",
@@ -224,7 +224,7 @@ export type PageElement =
   | NdrFieldsTemplate
   | NdrEnhancedTemplate
   | NdrTemplate
-  | NdrBasicTemplate
+  | PerformanceNdrTemplate
   | StatusAlertTemplate
   | DividerTemplate
   | ListInputTemplate
@@ -496,21 +496,6 @@ export type ReadmissionRateTemplate = {
   errors?: Record<ReadmissionRateField, string>;
 };
 
-export const RateInputFieldNames = {
-  numerator: "numerator",
-  denominator: "denominator",
-} as const;
-export type RateInputFieldName =
-  (typeof RateInputFieldNames)[keyof typeof RateInputFieldNames];
-
-export const RateInputFieldNamesBasic = {
-  numerator: "numerator",
-  denominator: "denominator",
-} as const;
-
-export type RateInputFieldNameBasic =
-  (typeof RateInputFieldNamesBasic)[keyof typeof RateInputFieldNamesBasic];
-
 export type RateType = {
   id: string;
   numerator: number | undefined;
@@ -556,9 +541,9 @@ export type NdrTemplate = {
   required: boolean;
 };
 
-export type NdrBasicTemplate = {
+export type PerformanceNdrTemplate = {
   id: string;
-  type: ElementType.NdrBasic;
+  type: ElementType.PerformanceNdr;
   label?: string;
   answer?: RateData;
   hintText?: {

--- a/services/ui-src/src/types/report.ts
+++ b/services/ui-src/src/types/report.ts
@@ -188,7 +188,7 @@ export enum ElementType {
   MeasureFooter = "measureFooter",
   LengthOfStayRate = "lengthOfStay",
   ReadmissionRate = "readmissionRate",
-  NdrFields = "ndrFields",
+  MultiCategoryNdr = "multiCategoryNdr",
   MultiRateNdr = "multiRateNdr",
   Ndr = "ndr",
   PerformanceNdr = "performanceNdr",
@@ -221,7 +221,7 @@ export type PageElement =
   | MeasureFooterTemplate
   | LengthOfStayRateTemplate
   | ReadmissionRateTemplate
-  | NdrFieldsTemplate
+  | MultiCategoryNdrTemplate
   | MultiRateNdrTemplate
   | NdrTemplate
   | PerformanceNdrTemplate
@@ -513,11 +513,11 @@ export type RateSetData = {
   rates: RateType[];
 };
 
-export type NdrFieldsTemplate = {
+export type MultiCategoryNdrTemplate = {
   id: string;
-  type: ElementType.NdrFields;
+  type: ElementType.MultiCategoryNdr;
   assessments: { label: string; id: string }[];
-  fields: { label: string; id: string; autoCalc?: boolean }[];
+  categories: { label: string; id: string; autoCalc?: boolean }[];
   multiplier?: number;
   answer?: RateSetData[];
   required: boolean;

--- a/services/ui-src/src/types/report.ts
+++ b/services/ui-src/src/types/report.ts
@@ -189,7 +189,7 @@ export enum ElementType {
   LengthOfStayRate = "lengthOfStay",
   ReadmissionRate = "readmissionRate",
   NdrFields = "ndrFields",
-  NdrEnhanced = "ndrEnhanced",
+  MultiRateNdr = "multiRateNdr",
   Ndr = "ndr",
   PerformanceNdr = "performanceNdr",
   StatusAlert = "statusAlert",
@@ -222,7 +222,7 @@ export type PageElement =
   | LengthOfStayRateTemplate
   | ReadmissionRateTemplate
   | NdrFieldsTemplate
-  | NdrEnhancedTemplate
+  | MultiRateNdrTemplate
   | NdrTemplate
   | PerformanceNdrTemplate
   | StatusAlertTemplate
@@ -523,9 +523,9 @@ export type NdrFieldsTemplate = {
   required: boolean;
 };
 
-export type NdrEnhancedTemplate = {
+export type MultiRateNdrTemplate = {
   id: string;
-  type: ElementType.NdrEnhanced;
+  type: ElementType.MultiRateNdr;
   label?: string;
   helperText?: string;
   assessments: { label: string; id: string }[];

--- a/services/ui-src/src/utils/state/reportLogic/completeness.test.ts
+++ b/services/ui-src/src/utils/state/reportLogic/completeness.test.ts
@@ -5,7 +5,7 @@ import {
   ListInputTemplate,
   MeasurePageTemplate,
   PerformanceNdrTemplate,
-  NdrEnhancedTemplate,
+  MultiRateNdrTemplate,
   NdrFieldsTemplate,
   NdrTemplate,
   PageElement,
@@ -486,9 +486,9 @@ describe("elementSatisfiesRequired", () => {
     }
   );
 
-  test("accepts complete NDREnhanced rates", () => {
+  test("accepts complete MultiRateNdr elements", () => {
     const element = {
-      type: ElementType.NdrEnhanced,
+      type: ElementType.MultiRateNdr,
       answer: {
         denominator: 5,
         rates: [
@@ -499,7 +499,7 @@ describe("elementSatisfiesRequired", () => {
         ],
       },
       required: true,
-    } as NdrEnhancedTemplate;
+    } as MultiRateNdrTemplate;
     expect(elementSatisfiesRequired(element, [element])).toBeTruthy();
   });
 
@@ -510,12 +510,12 @@ describe("elementSatisfiesRequired", () => {
     { denominator: 5, rates: [{ numerator: 7, rate: 1.4 }] },
     { denominator: 5, rates: [{ rate: 1.4 }] },
     { denominator: 5, rates: [{ numerator: 7 }] },
-  ])("accepts incomplete NDREnhanced rates", (answer) => {
+  ])("accepts incomplete MultiRateNdr elements", (answer) => {
     const element = {
-      type: ElementType.NdrEnhanced,
+      type: ElementType.MultiRateNdr,
       answer,
       required: false,
-    } as NdrEnhancedTemplate;
+    } as MultiRateNdrTemplate;
     expect(elementSatisfiesRequired(element, [element])).toBeTruthy();
   });
 

--- a/services/ui-src/src/utils/state/reportLogic/completeness.test.ts
+++ b/services/ui-src/src/utils/state/reportLogic/completeness.test.ts
@@ -6,7 +6,7 @@ import {
   MeasurePageTemplate,
   PerformanceNdrTemplate,
   MultiRateNdrTemplate,
-  NdrFieldsTemplate,
+  MultiCategoryNdrTemplate,
   NdrTemplate,
   PageElement,
   PageStatus,
@@ -519,9 +519,9 @@ describe("elementSatisfiesRequired", () => {
     expect(elementSatisfiesRequired(element, [element])).toBeTruthy();
   });
 
-  test("accepts complete NDRFields rates", () => {
+  test("accepts complete multiCategoryNdr elements", () => {
     const element = {
-      type: ElementType.NdrFields,
+      type: ElementType.MultiCategoryNdr,
       answer: [
         {
           denominator: 5,
@@ -534,7 +534,7 @@ describe("elementSatisfiesRequired", () => {
         },
       ],
       required: true,
-    } as NdrFieldsTemplate;
+    } as MultiCategoryNdrTemplate;
     expect(elementSatisfiesRequired(element, [element])).toBeTruthy();
   });
   test("rejects incomplete PerformanceNdr rates", () => {
@@ -586,12 +586,12 @@ describe("elementSatisfiesRequired", () => {
     [{ denominator: 5, rates: [{ numerator: 7, rate: 1.4 }] }],
     [{ denominator: 5, rates: [{ rate: 1.4 }] }],
     [{ denominator: 5, rates: [{ numerator: 7 }] }],
-  ])("accepts incomplete NDRFields when not required", (answer) => {
+  ])("accepts incomplete MultiCategoryNdr elements when optional", (answer) => {
     const element = {
-      type: ElementType.NdrFields,
+      type: ElementType.MultiCategoryNdr,
       answer,
       required: false, // ← It's not required
-    } as unknown as NdrFieldsTemplate;
+    } as unknown as MultiCategoryNdrTemplate;
     expect(elementSatisfiesRequired(element, [element])).toBeTruthy();
   });
   test("reject incomplete ListInput", () => {

--- a/services/ui-src/src/utils/state/reportLogic/completeness.test.ts
+++ b/services/ui-src/src/utils/state/reportLogic/completeness.test.ts
@@ -4,7 +4,7 @@ import {
   LengthOfStayRateTemplate,
   ListInputTemplate,
   MeasurePageTemplate,
-  NdrBasicTemplate,
+  PerformanceNdrTemplate,
   NdrEnhancedTemplate,
   NdrFieldsTemplate,
   NdrTemplate,
@@ -537,10 +537,10 @@ describe("elementSatisfiesRequired", () => {
     } as NdrFieldsTemplate;
     expect(elementSatisfiesRequired(element, [element])).toBeTruthy();
   });
-  test("rejects incomplete  NDRBasic rates", () => {
+  test("rejects incomplete PerformanceNdr rates", () => {
     const element = {
       id: "mock-id",
-      type: ElementType.NdrBasic,
+      type: ElementType.PerformanceNdr,
       answer: {
         numerator: 1,
         denominator: 2,
@@ -554,13 +554,13 @@ describe("elementSatisfiesRequired", () => {
         },
       ],
       required: true,
-    } as NdrBasicTemplate;
+    } as PerformanceNdrTemplate;
     expect(elementSatisfiesRequired(element, [element])).toBeFalsy();
   });
-  test("accepts complete NDRBasic rates", () => {
+  test("accepts complete PerformanceNdr rates", () => {
     const element = {
       id: "mock-id",
-      type: ElementType.NdrBasic,
+      type: ElementType.PerformanceNdr,
       answer: {
         numerator: 2,
         denominator: 2,
@@ -575,7 +575,7 @@ describe("elementSatisfiesRequired", () => {
         },
       ],
       required: true,
-    } as NdrBasicTemplate;
+    } as PerformanceNdrTemplate;
     expect(elementSatisfiesRequired(element, [element])).toBeTruthy();
   });
 

--- a/services/ui-src/src/utils/state/reportLogic/completeness.ts
+++ b/services/ui-src/src/utils/state/reportLogic/completeness.ts
@@ -250,7 +250,7 @@ export const elementSatisfiesRequired = (
     if (element.answer.rate === undefined) return false;
   }
 
-  if (element.type === ElementType.NdrBasic) {
+  if (element.type === ElementType.PerformanceNdr) {
     if (element.answer.numerator === undefined) return false;
     if (element.answer.denominator === undefined) return false;
     if (element.answer.rate === undefined) return false;

--- a/services/ui-src/src/utils/state/reportLogic/completeness.ts
+++ b/services/ui-src/src/utils/state/reportLogic/completeness.ts
@@ -236,7 +236,7 @@ export const elementSatisfiesRequired = (
       });
     });
   }
-  if (element.type === ElementType.NdrEnhanced) {
+  if (element.type === ElementType.MultiRateNdr) {
     if (element.answer.denominator === undefined) return false;
     return element.answer.rates.every((rateObj) => {
       if (rateObj.numerator === undefined) return false;

--- a/services/ui-src/src/utils/state/reportLogic/completeness.ts
+++ b/services/ui-src/src/utils/state/reportLogic/completeness.ts
@@ -226,7 +226,7 @@ export const elementSatisfiesRequired = (
       (fieldId) => element.answer?.[fieldId] !== undefined
     );
   }
-  if (element.type === ElementType.NdrFields) {
+  if (element.type === ElementType.MultiCategoryNdr) {
     return element.answer.every((assessObj) => {
       if (assessObj.denominator === undefined) return false;
       return assessObj.rates.every((rateObj) => {

--- a/services/ui-src/src/utils/state/reportLogic/reportActions.ts
+++ b/services/ui-src/src/utils/state/reportLogic/reportActions.ts
@@ -265,7 +265,7 @@ export const displayDivider = (page: ParentPageTemplate | FormPageTemplate) => {
     "measureResultsNavigationTable",
     "multiRateNdr",
     "ndr",
-    "ndrFields",
+    "multiCategoryNdr",
     "performanceNdr",
     "lengthOfStay",
     "readmissionRate",

--- a/services/ui-src/src/utils/state/reportLogic/reportActions.ts
+++ b/services/ui-src/src/utils/state/reportLogic/reportActions.ts
@@ -263,7 +263,7 @@ export const displayDivider = (page: ParentPageTemplate | FormPageTemplate) => {
   const hideFromElements = [
     "measureTable",
     "measureResultsNavigationTable",
-    "ndrEnhanced",
+    "multiRateNdr",
     "ndr",
     "ndrFields",
     "performanceNdr",

--- a/services/ui-src/src/utils/state/reportLogic/reportActions.ts
+++ b/services/ui-src/src/utils/state/reportLogic/reportActions.ts
@@ -266,7 +266,7 @@ export const displayDivider = (page: ParentPageTemplate | FormPageTemplate) => {
     "ndrEnhanced",
     "ndr",
     "ndrFields",
-    "ndrBasic",
+    "performanceNdr",
     "lengthOfStay",
     "readmissionRate",
   ];

--- a/services/ui-src/src/utils/state/reportLogic/reportActions.ts
+++ b/services/ui-src/src/utils/state/reportLogic/reportActions.ts
@@ -4,11 +4,13 @@
  */
 import { HcbsReportState } from "types";
 import {
+  ElementType,
   FormPageTemplate,
   isMeasurePageTemplate,
   isMeasureTemplate,
   MeasurePageTemplate,
   PageStatus,
+  PageType,
   ParentPageTemplate,
   Report,
 } from "types/report";
@@ -261,19 +263,19 @@ export const displayDivider = (page: ParentPageTemplate | FormPageTemplate) => {
 
   //add elements that already have bottom borders to prevent double diviers on the page
   const hideFromElements = [
-    "measureTable",
-    "measureResultsNavigationTable",
-    "multiRateNdr",
-    "ndr",
-    "multiCategoryNdr",
-    "performanceNdr",
-    "lengthOfStay",
-    "readmissionRate",
+    ElementType.MeasureTable,
+    ElementType.MeasureResultsNavigationTable,
+    ElementType.MultiRateNdr,
+    ElementType.Ndr,
+    ElementType.MultiCategoryNdr,
+    ElementType.PerformanceNdr,
+    ElementType.LengthOfStayRate,
+    ElementType.ReadmissionRate,
   ];
   //find the measureFooter index if the page type is measure & measureResults page, else use the last element's index
   const footerIndex =
-    page.type == "measure" || page.type == "measureResults"
-      ? page.elements.findIndex((ele) => ele.type == "measureFooter")
+    page.type == PageType.Measure || page.type == PageType.MeasureResults
+      ? page.elements.findIndex((ele) => ele.type == ElementType.MeasureFooter)
       : page.elements?.length;
 
   return !(

--- a/services/ui-src/src/utils/testing/mockRates.tsx
+++ b/services/ui-src/src/utils/testing/mockRates.tsx
@@ -2,7 +2,7 @@ import {
   NdrTemplate,
   ElementType,
   MultiRateNdrTemplate,
-  NdrFieldsTemplate,
+  MultiCategoryNdrTemplate,
   PerformanceNdrTemplate,
   LengthOfStayRateTemplate,
   ReadmissionRateTemplate,
@@ -39,9 +39,9 @@ export const mockedMultiRateNdr: MultiRateNdrTemplate = {
   },
 };
 
-export const mockNDRFields: NdrFieldsTemplate = {
-  id: "mock-ndr-fields",
-  type: ElementType.NdrFields,
+export const mockMultiCategoryNdr: MultiCategoryNdrTemplate = {
+  id: "mock-multi-category-ndr",
+  type: ElementType.MultiCategoryNdr,
   required: true,
   assessments: [
     {
@@ -49,10 +49,10 @@ export const mockNDRFields: NdrFieldsTemplate = {
       id: "mock-assess-1",
     },
   ],
-  fields: [
+  categories: [
     {
-      label: "Field 1",
-      id: "mock-field-1",
+      label: "Category 1",
+      id: "mock-category-1",
     },
   ],
   answer: [
@@ -60,7 +60,7 @@ export const mockNDRFields: NdrFieldsTemplate = {
       denominator: 2,
       rates: [
         {
-          id: "mock-assess-1.mock-field-1",
+          id: "mock-assess-1.mock-category-1",
           numerator: undefined,
           rate: undefined,
         },

--- a/services/ui-src/src/utils/testing/mockRates.tsx
+++ b/services/ui-src/src/utils/testing/mockRates.tsx
@@ -1,7 +1,7 @@
 import {
   NdrTemplate,
   ElementType,
-  NdrEnhancedTemplate,
+  MultiRateNdrTemplate,
   NdrFieldsTemplate,
   PerformanceNdrTemplate,
   LengthOfStayRateTemplate,
@@ -20,9 +20,9 @@ export const mockNDR: NdrTemplate = {
   required: true,
 };
 
-export const mockedNDREnhanced: NdrEnhancedTemplate = {
-  id: "mock-ndr-enhanced",
-  type: ElementType.NdrEnhanced,
+export const mockedMultiRateNdr: MultiRateNdrTemplate = {
+  id: "mock-multi-rate-ndr",
+  type: ElementType.MultiRateNdr,
   label: "test label",
   helperText: "helper text",
   required: true,

--- a/services/ui-src/src/utils/testing/mockRates.tsx
+++ b/services/ui-src/src/utils/testing/mockRates.tsx
@@ -3,7 +3,7 @@ import {
   ElementType,
   NdrEnhancedTemplate,
   NdrFieldsTemplate,
-  NdrBasicTemplate,
+  PerformanceNdrTemplate,
   LengthOfStayRateTemplate,
   ReadmissionRateTemplate,
 } from "types";
@@ -69,9 +69,9 @@ export const mockNDRFields: NdrFieldsTemplate = {
   ],
 };
 
-export const mockNDRBasics: NdrBasicTemplate = {
-  id: "mock-ndr-basic",
-  type: ElementType.NdrBasic,
+export const mockPerformanceNdr: PerformanceNdrTemplate = {
+  id: "mock-performance-ndr",
+  type: ElementType.PerformanceNdr,
   required: true,
 };
 


### PR DESCRIPTION
### Description
Some of the HCBS components (especially those containing multiple inputs) grew organically, and we had to name them before we really knew the scope of what they would be used for. This led to a set of names that didn't always make it clear what the named thing does.

This PR establishes a set of names that will hopefully make the behaviors (and differences in behavior) clearer at a glance. Here's the table, copy-pasted from the migration script in this PR:

| Before          | After            | What is it                          |
|-----------------|------------------|-------------------------------------|
| NDR             | [no rename]      | A Numerator, Denominator, and Rate  |
| NDRBasic        | PerformanceNdr   | NDR + a performance target          |
| NDREnhanced     | MultiRateNdr     | One D, with many NR pairs           |
| NDRFields       | MultiCategoryNdr | Many Ds, each with many NR pairs    |
| LengthOfStay    | [no rename]      | Actual vs Expected counts and rates |
| ReadmissionRate | [no rename]      | Observed vs Expected readmissions   |

NDRFieldsTemplate.fields is also renamed, to MultiCategoryNdr.categories.

Also, the original name of "LengthOfStay" was "Fields". We have already renamed the element type, but "Fields" was still hanging around in some places, like the file name. This PR finishes the job.

And, I apologize, but this PR _also_ changes some element IDs. I noticed that we had some pages with more than one element with the same ID, and that's a bad idea. We don't _need_ elements to have different IDs, but calling them "IDs" implies uniqueness, and we should keep that promise. 

### Out of scope
Is it possible for us to retire the MultiCategoryNdr element, replacing each one with a series of MultiRateNdr elements? Maybe, but not today.

We have some MultiRateNdr elements with only a single assessment. Should we replace these with plain-old NDR elements? Maybe, but not today.

### Related ticket(s)
CMDCT-5738

---
### How to test
https://d1e4k7iupixxeo.cloudfront.net/

There shouldn't be any behavioral changes; all of the elements should work exactly as before. So track down an instance of each renamed element, create a report containing that element, and fill it out.

---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist

#### Review
- ~[ ] Design: This work has been reviewed and approved by design, if necessary~
- ~[ ] Product: This work has been reviewed and approved by product owner, if necessary~

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- ~[ ] These changes are significant enough to require an update to the SIA.~
- ~[ ] These changes are significant enough to require a penetration test.~
