### PR TITLE
Collapsed sidebar still allows focus

### DIFF
--- a/services/ui-src/src/components/report/Sidebar.tsx
+++ b/services/ui-src/src/components/report/Sidebar.tsx
@@ -114,7 +114,7 @@ export const Sidebar = () => {
           className={sidebarOpen ? "left" : "right"}
         />
       </Button>
-      <Flex sx={sx.sidebarNav}>
+      <Flex sx={sx.sidebarNav} inert={sidebarOpen ? undefined : true}>
         <Flex sx={sx.sidebarList}>
           <Heading variant="sidebar">{title}</Heading>
           {report.pages[root].childPageIds?.map((child) =>


### PR DESCRIPTION
<!-- This file is managed by macpro-mdct-core so if you'd like to change it let's do it there -->
### Description
<!-- Detailed description of changes and related context -->
* Currently sidebar gets focused when sidebar is collapsed, so added inert to disable it

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-5944

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
https://d27jcbv5j2a39a.cloudfront.net/
* Create a form
* Use keyboard to see sidebar menu items no longer gets focused when sidebar is collapsed

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
