### PR TITLE
Dashboard table has extra empty column header

### DIFF
--- a/services/ui-src/src/components/pages/Dashboard/DashboardTable.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardTable.tsx
@@ -267,16 +267,17 @@ export const DashboardTable = ({
   const showAdminControlsColumn = userIsAdmin;
 
   // Build header columns based on defined behaviors per role
-  const headers = [
+  const baseHeaders = [
     "Submission name",
     "Reporting year",
     "Last edited",
     "Edited by",
     "Status",
-    "Actions",
   ];
+  const headers = [...baseHeaders];
   if (showReportSubmissionsColumn) headers.push("#");
-  headers.push("");
+  headers.push("Actions");
+  if (showAdminControlsColumn) headers.push("", "");
   const { reportType } = useParams();
   const tableContent = {
     caption: `${getReportName(reportType)}s`,

--- a/services/ui-src/src/components/pages/Dashboard/DashboardTable.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardTable.tsx
@@ -267,14 +267,14 @@ export const DashboardTable = ({
   const showAdminControlsColumn = userIsAdmin;
 
   // Build header columns based on defined behaviors per role
-  const baseHeaders = [
+  const headers = [
     "Submission name",
     "Reporting year",
     "Last edited",
     "Edited by",
     "Status",
   ];
-  const headers = [...baseHeaders];
+
   if (showReportSubmissionsColumn) headers.push("#");
   headers.push("Actions");
   if (showAdminControlsColumn) headers.push("", "");


### PR DESCRIPTION
<!-- This file is managed by macpro-mdct-core so if you'd like to change it let's do it there -->
### Description
<!-- Detailed description of changes and related context -->
* When expecting headers on dashboard (for example, Submission name), there's an extra empty <th> at the end.
* Removed Actions from the header and push it at the end, so it doesn't push an empty <th>

### Related ticket(s)
<!-- Link to related ticket(s) or issue(s) -->
<!-- Hint: Type CMDCT-<ticket-number> for autolinking -->
CMDCT-5984

---
### How to test
<!-- Step-by-step instructions on how to test, if necessary -->
https://d3gl5jaimgoyuj.cloudfront.net/
* Navigate to any report
* Expect dashboard header and see there's no <th> with empty string

### Notes
<!-- Changed dependencies, .env files, configs, etc. -->
<!-- Instructions for local dev, e.g. requires new installs in directories -->


---
### Pre-review checklist
<!-- Complete the following steps before opening for review -->
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist
<!-- Complete the following steps before merging -->

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
