### PR TITLE
[HCBS] Admin view of dashboard table has two extra empty column headers

### DIFF
--- a/services/ui-src/src/components/pages/Dashboard/DashboardTable.test.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardTable.test.tsx
@@ -76,7 +76,7 @@ const mockTableProps = {
   reports: reports,
   showEditNameColumn: true,
   showReportSubmissionsColumn: false,
-  showAdminControlsColumn: false,
+  showAdminControls: false,
   openAddEditReportModal: mockOpenAddEditReportModal,
   navigate: jest.fn(),
   userIsEndUser: true,
@@ -90,7 +90,7 @@ const mockAdminTableProps = {
   ...mockTableProps,
   showEditNameColumn: false,
   showReportSubmissionsColumn: true,
-  showAdminControlsColumn: true,
+  showAdminControls: true,
   userIsEndUser: false,
 };
 

--- a/services/ui-src/src/components/pages/Dashboard/DashboardTable.test.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardTable.test.tsx
@@ -13,7 +13,7 @@ import { VerticalTable } from "./DashboardTable";
 jest.mock("utils/state/useStore", () => ({
   useStore: jest.fn().mockReturnValue({}),
 }));
-const mockedUseStore = useStore as jest.MockedFunction<typeof useStore>;
+const mockedUseStore = jest.mocked(useStore);
 mockedUseStore.mockReturnValue(mockUseStore);
 
 const mockArchive = jest.fn();

--- a/services/ui-src/src/components/pages/Dashboard/DashboardTable.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardTable.tsx
@@ -106,42 +106,38 @@ export const HorizontalTable = (props: TableProps) => {
                   ? "Edit"
                   : "View"}
               </Button>
+              {props.showAdminControlsColumn && (
+                <>
+                  <Button
+                    variant="link"
+                    fontSize="body_sm"
+                    onClick={async () => await props.toggleRelease(idx)}
+                    disabled={
+                      report.status !== ReportStatus.SUBMITTED ||
+                      report.archived ||
+                      props.unlocking === idx
+                    }
+                  >
+                    {props.unlocking === idx && (
+                      <Spinner size="sm" marginRight="spacer_half" />
+                    )}
+                    Unlock
+                  </Button>
+                  <Button
+                    variant="link"
+                    fontSize="body_sm"
+                    onClick={async () => await props.toggleArchived(idx)}
+                    disabled={props.archiving === idx}
+                  >
+                    {props.archiving === idx && (
+                      <Spinner size="sm" marginRight="spacer_half" />
+                    )}
+                    {report.archived ? "Unarchive" : "Archive"}
+                  </Button>
+                </>
+              )}
             </Flex>
           </Td>
-          {props.showAdminControlsColumn && (
-            <>
-              <td>
-                <Button
-                  variant="link"
-                  fontSize="body_sm"
-                  onClick={async () => await props.toggleRelease(idx)}
-                  disabled={
-                    report.status !== ReportStatus.SUBMITTED ||
-                    report.archived ||
-                    props.unlocking === idx
-                  }
-                >
-                  {props.unlocking === idx && (
-                    <Spinner size="sm" marginRight="spacer_half" />
-                  )}
-                  Unlock
-                </Button>
-              </td>
-              <td>
-                <Button
-                  variant="link"
-                  fontSize="body_sm"
-                  onClick={async () => await props.toggleArchived(idx)}
-                  disabled={props.archiving === idx}
-                >
-                  {props.archiving === idx && (
-                    <Spinner size="sm" marginRight="spacer_half" />
-                  )}
-                  {report.archived ? "Unarchive" : "Archive"}
-                </Button>
-              </td>
-            </>
-          )}
         </Tr>
       ))}
     </Table>
@@ -211,34 +207,30 @@ export const VerticalTable = (props: TableProps) => {
             </Button>
             {props.showAdminControlsColumn && (
               <>
-                <td>
-                  <Button
-                    variant="link"
-                    onClick={async () => await props.toggleRelease(idx)}
-                    disabled={
-                      report.status !== ReportStatus.SUBMITTED ||
-                      report.archived ||
-                      props.unlocking === idx
-                    }
-                  >
-                    {props.unlocking === idx && (
-                      <Spinner size="sm" marginRight="spacer_half" />
-                    )}
-                    Unlock
-                  </Button>
-                </td>
-                <td>
-                  <Button
-                    variant="link"
-                    onClick={async () => await props.toggleArchived(idx)}
-                    disabled={props.archiving === idx}
-                  >
-                    {props.archiving === idx && (
-                      <Spinner size="sm" marginRight="spacer_half" />
-                    )}
-                    {report.archived ? "Unarchive" : "Archive"}
-                  </Button>
-                </td>
+                <Button
+                  variant="link"
+                  onClick={async () => await props.toggleRelease(idx)}
+                  disabled={
+                    report.status !== ReportStatus.SUBMITTED ||
+                    report.archived ||
+                    props.unlocking === idx
+                  }
+                >
+                  {props.unlocking === idx && (
+                    <Spinner size="sm" marginRight="spacer_half" />
+                  )}
+                  Unlock
+                </Button>
+                <Button
+                  variant="link"
+                  onClick={async () => await props.toggleArchived(idx)}
+                  disabled={props.archiving === idx}
+                >
+                  {props.archiving === idx && (
+                    <Spinner size="sm" marginRight="spacer_half" />
+                  )}
+                  {report.archived ? "Unarchive" : "Archive"}
+                </Button>
               </>
             )}
           </HStack>
@@ -277,7 +269,6 @@ export const DashboardTable = ({
 
   if (showReportSubmissionsColumn) headers.push("#");
   headers.push("Actions");
-  if (showAdminControlsColumn) headers.push("", "");
   const { reportType } = useParams();
   const tableContent = {
     caption: `${getReportName(reportType)}s`,

--- a/services/ui-src/src/components/pages/Dashboard/DashboardTable.tsx
+++ b/services/ui-src/src/components/pages/Dashboard/DashboardTable.tsx
@@ -38,7 +38,7 @@ interface TableProps extends Omit<
   tableContent: { caption: string; headRow: string[] };
   showEditNameColumn: boolean | undefined;
   showReportSubmissionsColumn: boolean;
-  showAdminControlsColumn: boolean | undefined;
+  showAdminControls: boolean | undefined;
   navigate: NavigateFunction;
   userIsEndUser: boolean | undefined;
   toggleArchived: (rowIndex: number) => void;
@@ -106,7 +106,7 @@ export const HorizontalTable = (props: TableProps) => {
                   ? "Edit"
                   : "View"}
               </Button>
-              {props.showAdminControlsColumn && (
+              {props.showAdminControls && (
                 <>
                   <Button
                     variant="link"
@@ -205,7 +205,7 @@ export const VerticalTable = (props: TableProps) => {
                 ? "Edit"
                 : "View"}
             </Button>
-            {props.showAdminControlsColumn && (
+            {props.showAdminControls && (
               <>
                 <Button
                   variant="link"
@@ -256,7 +256,7 @@ export const DashboardTable = ({
   // Translate role to defined behaviors
   const showEditNameColumn = userIsEndUser;
   const showReportSubmissionsColumn = !userIsEndUser;
-  const showAdminControlsColumn = userIsAdmin;
+  const showAdminControls = userIsAdmin;
 
   // Build header columns based on defined behaviors per role
   const headers = [
@@ -310,7 +310,7 @@ export const DashboardTable = ({
           reports,
           showEditNameColumn,
           showReportSubmissionsColumn,
-          showAdminControlsColumn,
+          showAdminControls,
           openAddEditReportModal,
           navigate,
           userIsEndUser,
@@ -326,7 +326,7 @@ export const DashboardTable = ({
           reports,
           showEditNameColumn,
           showReportSubmissionsColumn,
-          showAdminControlsColumn,
+          showAdminControls,
           openAddEditReportModal,
           navigate,
           userIsEndUser,


### PR DESCRIPTION
### Description
**Problem**
On any page that has an admin view of a DashboardTable, there are two extra column headers (<th>) that are empty which appear to the right of the "Actions" column, containing the admin functionality for unlocking and archiving.  These columns should be represented by column headers so that Assistive Technology can properly read the table.

**Solution**
Adjust the table generation to render the Unlock and Archive options beneath the existing "Actions" header, rather than in new columns.  Remove the empty table headers.  The number of columns should match the number of headers, and no headers should be empty.

### Related ticket(s)
CMDCT-6008

---
### How to test
**Deploy Link:** https://d21b6e4t5nz4rd.cloudfront.net/
1. Login as a state user, start a report (any)
2. Login as admin user and look at dashboard of report started
3. Inspect and verify the number of columns match the number of headers, and no headers are empty.

### Notes
1. Remove the empty "", "" headers from DashboardTable
2. Move Unlock/Archive buttons into the existing Actions <Td> in HorizontalTable
4. Remove the invalid <td> wrappers in VerticalTable

---
### Pre-review checklist
- [ ] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [ ] I have updated relevant documentation, if necessary
- [ ] I have performed a self-review of my code
- [ ] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist


#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary

#### Security
_If either of the following are true, notify the team's ISSO (Information System Security Officer)._

- [ ] These changes are significant enough to require an update to the SIA.
- [ ] These changes are significant enough to require a penetration test.
