### PR TITLE
[HCBS] QMS - POM Measures Language Update

### DIFF
--- a/services/app-api/forms/2026/qms/measureTemplates.ts
+++ b/services/app-api/forms/2026/qms/measureTemplates.ts
@@ -1217,7 +1217,7 @@ export const measureTemplates: Record<
       feeForServiceMeasureResultsSubheader,
       ...whichProgramsWaivers,
       waiverListInputField,
-      performanceRatePOM,
+      performanceRatePOM("People Live in Integrated Environments (FFS LTSS)"),
       {
         type: ElementType.MeasureFooter,
         id: "measure-footer",
@@ -1249,7 +1249,7 @@ export const measureTemplates: Record<
       managedCareMeasureResultsSubheader,
       ...whichProgramsWaivers,
       waiverListInputField,
-      performanceRatePOM,
+      performanceRatePOM("People Live in Integrated Environments (MLTSS)"),
       {
         type: ElementType.MeasureFooter,
         id: "measure-footer",
@@ -1306,7 +1306,9 @@ export const measureTemplates: Record<
       feeForServiceMeasureResultsSubheader,
       ...whichProgramsWaivers,
       waiverListInputField,
-      performanceRatePOM,
+      performanceRatePOM(
+        "People Participate in the Life of the Community (FFS LTSS)"
+      ),
       {
         type: ElementType.MeasureFooter,
         id: "measure-footer",
@@ -1338,7 +1340,9 @@ export const measureTemplates: Record<
       managedCareMeasureResultsSubheader,
       ...whichProgramsWaivers,
       waiverListInputField,
-      performanceRatePOM,
+      performanceRatePOM(
+        "People Participate in the Life of the Community (MLTSS)"
+      ),
       {
         type: ElementType.MeasureFooter,
         id: "measure-footer",
@@ -1395,7 +1399,7 @@ export const measureTemplates: Record<
       feeForServiceMeasureResultsSubheader,
       ...whichProgramsWaivers,
       waiverListInputField,
-      performanceRatePOM,
+      performanceRatePOM("People Choose Services (FFS LTSS)"),
       {
         type: ElementType.MeasureFooter,
         id: "measure-footer",
@@ -1427,7 +1431,7 @@ export const measureTemplates: Record<
       managedCareMeasureResultsSubheader,
       ...whichProgramsWaivers,
       waiverListInputField,
-      performanceRatePOM,
+      performanceRatePOM("People Choose Services (MLTSS)"),
       {
         type: ElementType.MeasureFooter,
         id: "measure-footer",
@@ -1484,7 +1488,7 @@ export const measureTemplates: Record<
       feeForServiceMeasureResultsSubheader,
       ...whichProgramsWaivers,
       waiverListInputField,
-      performanceRatePOM,
+      performanceRatePOM("People Realize Personal Goals (FFS LTSS)"),
       {
         type: ElementType.MeasureFooter,
         id: "measure-footer",
@@ -1516,7 +1520,7 @@ export const measureTemplates: Record<
       managedCareMeasureResultsSubheader,
       ...whichProgramsWaivers,
       waiverListInputField,
-      performanceRatePOM,
+      performanceRatePOM("People Realize Personal Goals (MLTSS)"),
       {
         type: ElementType.MeasureFooter,
         id: "measure-footer",
@@ -1573,7 +1577,7 @@ export const measureTemplates: Record<
       feeForServiceMeasureResultsSubheader,
       ...whichProgramsWaivers,
       waiverListInputField,
-      performanceRatePOM,
+      performanceRatePOM("People are Free from Abuse and Neglect (FFS LTSS)"),
       {
         type: ElementType.MeasureFooter,
         id: "measure-footer",
@@ -1605,7 +1609,7 @@ export const measureTemplates: Record<
       managedCareMeasureResultsSubheader,
       ...whichProgramsWaivers,
       waiverListInputField,
-      performanceRatePOM,
+      performanceRatePOM("People are Free from Abuse and Neglect (MLTSS)"),
       {
         type: ElementType.MeasureFooter,
         id: "measure-footer",
@@ -1662,7 +1666,7 @@ export const measureTemplates: Record<
       feeForServiceMeasureResultsSubheader,
       ...whichProgramsWaivers,
       waiverListInputField,
-      performanceRatePOM,
+      performanceRatePOM("People Have the Best Possible Health (FFS LTSS)"),
       {
         type: ElementType.MeasureFooter,
         id: "measure-footer",
@@ -1694,7 +1698,7 @@ export const measureTemplates: Record<
       managedCareMeasureResultsSubheader,
       ...whichProgramsWaivers,
       waiverListInputField,
-      performanceRatePOM,
+      performanceRatePOM("People Have the Best Possible Health (MLTSS)"),
       {
         type: ElementType.MeasureFooter,
         id: "measure-footer",
@@ -1751,7 +1755,9 @@ export const measureTemplates: Record<
       feeForServiceMeasureResultsSubheader,
       ...whichProgramsWaivers,
       waiverListInputField,
-      performanceRatePOM,
+      performanceRatePOM(
+        "People Interact with Other Members of the Community (FFS LTSS)"
+      ),
       {
         type: ElementType.MeasureFooter,
         id: "measure-footer",
@@ -1783,7 +1789,9 @@ export const measureTemplates: Record<
       managedCareMeasureResultsSubheader,
       ...whichProgramsWaivers,
       waiverListInputField,
-      performanceRatePOM,
+      performanceRatePOM(
+        "People Interact with Other Members of the Community (MLTSS)"
+      ),
       {
         type: ElementType.MeasureFooter,
         id: "measure-footer",

--- a/services/app-api/forms/2026/qms/measureTemplates.ts
+++ b/services/app-api/forms/2026/qms/measureTemplates.ts
@@ -1217,7 +1217,10 @@ export const measureTemplates: Record<
       feeForServiceMeasureResultsSubheader,
       ...whichProgramsWaivers,
       waiverListInputField,
-      performanceRatePOM("People Live in Integrated Environments (FFS LTSS)"),
+      {
+        ...performanceRatePOM,
+        label: "People Live in Integrated Environments (FFS LTSS)",
+      },
       {
         type: ElementType.MeasureFooter,
         id: "measure-footer",
@@ -1249,7 +1252,10 @@ export const measureTemplates: Record<
       managedCareMeasureResultsSubheader,
       ...whichProgramsWaivers,
       waiverListInputField,
-      performanceRatePOM("People Live in Integrated Environments (MLTSS)"),
+      {
+        ...performanceRatePOM,
+        label: "People Live in Integrated Environments (MLTSS)",
+      },
       {
         type: ElementType.MeasureFooter,
         id: "measure-footer",
@@ -1306,9 +1312,10 @@ export const measureTemplates: Record<
       feeForServiceMeasureResultsSubheader,
       ...whichProgramsWaivers,
       waiverListInputField,
-      performanceRatePOM(
-        "People Participate in the Life of the Community (FFS LTSS)"
-      ),
+      {
+        ...performanceRatePOM,
+        label: "People Participate in the Life of the Community (FFS LTSS)",
+      },
       {
         type: ElementType.MeasureFooter,
         id: "measure-footer",
@@ -1340,9 +1347,10 @@ export const measureTemplates: Record<
       managedCareMeasureResultsSubheader,
       ...whichProgramsWaivers,
       waiverListInputField,
-      performanceRatePOM(
-        "People Participate in the Life of the Community (MLTSS)"
-      ),
+      {
+        ...performanceRatePOM,
+        label: "People Participate in the Life of the Community (MLTSS)",
+      },
       {
         type: ElementType.MeasureFooter,
         id: "measure-footer",
@@ -1399,7 +1407,10 @@ export const measureTemplates: Record<
       feeForServiceMeasureResultsSubheader,
       ...whichProgramsWaivers,
       waiverListInputField,
-      performanceRatePOM("People Choose Services (FFS LTSS)"),
+      {
+        ...performanceRatePOM,
+        label: "People Choose Services (FFS LTSS)",
+      },
       {
         type: ElementType.MeasureFooter,
         id: "measure-footer",
@@ -1431,7 +1442,10 @@ export const measureTemplates: Record<
       managedCareMeasureResultsSubheader,
       ...whichProgramsWaivers,
       waiverListInputField,
-      performanceRatePOM("People Choose Services (MLTSS)"),
+      {
+        ...performanceRatePOM,
+        label: "People Choose Services (MLTSS)",
+      },
       {
         type: ElementType.MeasureFooter,
         id: "measure-footer",
@@ -1488,7 +1502,10 @@ export const measureTemplates: Record<
       feeForServiceMeasureResultsSubheader,
       ...whichProgramsWaivers,
       waiverListInputField,
-      performanceRatePOM("People Realize Personal Goals (FFS LTSS)"),
+      {
+        ...performanceRatePOM,
+        label: "People Realize Personal Goals (FFS LTSS)",
+      },
       {
         type: ElementType.MeasureFooter,
         id: "measure-footer",
@@ -1520,7 +1537,10 @@ export const measureTemplates: Record<
       managedCareMeasureResultsSubheader,
       ...whichProgramsWaivers,
       waiverListInputField,
-      performanceRatePOM("People Realize Personal Goals (MLTSS)"),
+      {
+        ...performanceRatePOM,
+        label: "People Realize Personal Goals (MLTSS)",
+      },
       {
         type: ElementType.MeasureFooter,
         id: "measure-footer",
@@ -1577,7 +1597,10 @@ export const measureTemplates: Record<
       feeForServiceMeasureResultsSubheader,
       ...whichProgramsWaivers,
       waiverListInputField,
-      performanceRatePOM("People are Free from Abuse and Neglect (FFS LTSS)"),
+      {
+        ...performanceRatePOM,
+        label: "People are Free from Abuse and Neglect (FFS LTSS)",
+      },
       {
         type: ElementType.MeasureFooter,
         id: "measure-footer",
@@ -1609,7 +1632,10 @@ export const measureTemplates: Record<
       managedCareMeasureResultsSubheader,
       ...whichProgramsWaivers,
       waiverListInputField,
-      performanceRatePOM("People are Free from Abuse and Neglect (MLTSS)"),
+      {
+        ...performanceRatePOM,
+        label: "People are Free from Abuse and Neglect (MLTSS)",
+      },
       {
         type: ElementType.MeasureFooter,
         id: "measure-footer",
@@ -1666,7 +1692,10 @@ export const measureTemplates: Record<
       feeForServiceMeasureResultsSubheader,
       ...whichProgramsWaivers,
       waiverListInputField,
-      performanceRatePOM("People Have the Best Possible Health (FFS LTSS)"),
+      {
+        ...performanceRatePOM,
+        label: "People Have the Best Possible Health (FFS LTSS)",
+      },
       {
         type: ElementType.MeasureFooter,
         id: "measure-footer",
@@ -1698,7 +1727,10 @@ export const measureTemplates: Record<
       managedCareMeasureResultsSubheader,
       ...whichProgramsWaivers,
       waiverListInputField,
-      performanceRatePOM("People Have the Best Possible Health (MLTSS)"),
+      {
+        ...performanceRatePOM,
+        label: "People Have the Best Possible Health (MLTSS)",
+      },
       {
         type: ElementType.MeasureFooter,
         id: "measure-footer",
@@ -1755,9 +1787,10 @@ export const measureTemplates: Record<
       feeForServiceMeasureResultsSubheader,
       ...whichProgramsWaivers,
       waiverListInputField,
-      performanceRatePOM(
-        "People Interact with Other Members of the Community (FFS LTSS)"
-      ),
+      {
+        ...performanceRatePOM,
+        label: "People Interact with Other Members of the Community (FFS LTSS)",
+      },
       {
         type: ElementType.MeasureFooter,
         id: "measure-footer",
@@ -1789,9 +1822,10 @@ export const measureTemplates: Record<
       managedCareMeasureResultsSubheader,
       ...whichProgramsWaivers,
       waiverListInputField,
-      performanceRatePOM(
-        "People Interact with Other Members of the Community (MLTSS)"
-      ),
+      {
+        ...performanceRatePOM,
+        label: "People Interact with Other Members of the Community (MLTSS)",
+      },
       {
         type: ElementType.MeasureFooter,
         id: "measure-footer",

--- a/services/app-api/forms/2026/qms/qmsElements.ts
+++ b/services/app-api/forms/2026/qms/qmsElements.ts
@@ -378,12 +378,11 @@ export const exclusionRatesPatientPlanElements: MultiRateNdrTemplate = {
 };
 
 //Rates for POM
-export const performanceRatePOM = (label: string): NdrTemplate => ({
+export const performanceRatePOM: Omit<NdrTemplate, "label"> = {
   type: ElementType.Ndr,
   id: "measure-rates",
   required: true,
-  label,
-});
+};
 
 // Rates for LTSS-6
 export const performanceRateTermStay: MultiCategoryNdrTemplate = {

--- a/services/app-api/forms/2026/qms/qmsElements.ts
+++ b/services/app-api/forms/2026/qms/qmsElements.ts
@@ -378,12 +378,12 @@ export const exclusionRatesPatientPlanElements: MultiRateNdrTemplate = {
 };
 
 //Rates for POM
-export const performanceRatePOM: NdrTemplate = {
+export const performanceRatePOM = (label: string): NdrTemplate => ({
   type: ElementType.Ndr,
   id: "measure-rates",
   required: true,
-  label: "Person uses the same environments as people without disabilities",
-};
+  label,
+});
 
 // Rates for LTSS-6
 export const performanceRateTermStay: MultiCategoryNdrTemplate = {


### PR DESCRIPTION
### Description
The performance rate should be the wording that comes after "POM" in the measure section title.  
Therefore, if the measure section is: "POM: People Choose Services (MLTSS)" then the Rate should be: "Performance Rate: People Choose Services (MLTSS)"

Changed performanceRatePOM from a fixed value to a function that takes a label argument.

### Related ticket(s)
CMDCT-6111

---
### How to test
Deploy Link: https://d2575b6f1zte29.cloudfront.net/

1. Login as any state user
2. Create QMS report
3. Be sure to select "Yes" for "Is your state reporting on the POM Survey?"
4. Select "Both FFS and MLTSS (separate)" for "Which delivery methods will be reported on for this measure?"
5. Confirm the performance rates match the POM measure titles in MLTSS and FSS delivery methods.

### Example
<img width="412" height="677" alt="POM delivery method page showing rates match title" src="https://github.com/user-attachments/assets/27c78f93-683c-400c-a3cd-23fdc040ac9b" />

---
### Pre-review checklist
- [x] I have added [thorough](https://shorturl.at/aejkF) tests, if necessary
- [x] I have updated relevant documentation, if necessary
- [x] I have performed a self-review of my code
- [x] I have manually tested this PR in the deployed cloud environment

---
### Pre-merge checklist

#### Review
- [ ] Design: This work has been reviewed and approved by design, if necessary
- [ ] Product: This work has been reviewed and approved by product owner, if necessary